### PR TITLE
Move memory and stdx to separate crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ rust-version = "1.71.0"
 
 [workspace]
 members = [
+    "memory",
     "sealable-trie",
+    "stdx",
 ]
 resolver = "2"
 
@@ -17,3 +19,7 @@ pretty_assertions = "1.4.0"
 rand = { version = "0.8.5" }
 sha2 = { version = "0.10.7", default-features = false }
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
+
+memory = { path = "memory" }
+sealable-trie = { path = "sealable-trie" }
+stdx = { path = "stdx" }

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "memory"
+authors = ["Michal Nazarewicz <mina86@mina86.com>"]
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+derive_more.workspace = true
+stdx = { workspace = true, optional = true }
+
+[dev-dependencies]
+stdx.workspace = true
+
+[features]
+test_utils = ["stdx"]

--- a/sealable-trie/Cargo.toml
+++ b/sealable-trie/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "sealable-trie"
+authors = ["Michal Nazarewicz <mina86@mina86.com>"]
 version = "0.0.0"
 edition = "2021"
 
@@ -9,6 +10,11 @@ derive_more.workspace = true
 sha2.workspace = true
 strum.workspace = true
 
+memory.workspace = true
+stdx.workspace = true
+
 [dev-dependencies]
 pretty_assertions.workspace = true
 rand.workspace = true
+
+memory = { workspace = true, features = ["test_utils"] }

--- a/sealable-trie/src/bits.rs
+++ b/sealable-trie/src/bits.rs
@@ -3,7 +3,7 @@ use core::fmt;
 #[cfg(test)]
 use pretty_assertions::assert_eq;
 
-use crate::{nodes, stdx};
+use crate::nodes;
 
 /// Representation of a slice of bits.
 ///

--- a/sealable-trie/src/lib.rs
+++ b/sealable-trie/src/lib.rs
@@ -5,10 +5,8 @@ extern crate std;
 
 pub mod bits;
 pub mod hash;
-pub mod memory;
 pub mod nodes;
 pub mod proof;
-pub(crate) mod stdx;
 pub mod trie;
 
 #[cfg(test)]

--- a/sealable-trie/src/nodes/stress_tests.rs
+++ b/sealable-trie/src/nodes/stress_tests.rs
@@ -5,18 +5,18 @@
 //! it performs can be controlled by STRESS_TEST_ITERATIONS environment
 //! variable.
 
+use memory::Ptr;
 use pretty_assertions::assert_eq;
 
-use crate::memory::Ptr;
+use crate::bits;
 use crate::nodes::{self, Node, NodeRef, RawNode, Reference, ValueRef};
 use crate::test_utils::get_iteration_count;
-use crate::{bits, stdx};
 
 /// Generates random raw representation and checks decode→encode round-trip.
 #[test]
 fn stress_test_raw_encoding_round_trip() {
     let mut rng = rand::thread_rng();
-    let mut raw = RawNode([0; 72]);
+    let mut raw = RawNode([0; RawNode::SIZE]);
     for _ in 0..get_iteration_count() {
         gen_random_raw_node(&mut rng, &mut raw.0);
         let node = raw.decode();
@@ -26,7 +26,10 @@ fn stress_test_raw_encoding_round_trip() {
 }
 
 /// Generates a random raw node representation in canonical representation.
-fn gen_random_raw_node(rng: &mut impl rand::Rng, bytes: &mut [u8; 72]) {
+fn gen_random_raw_node(
+    rng: &mut impl rand::Rng,
+    bytes: &mut [u8; RawNode::SIZE],
+) {
     fn make_ref_canonical(bytes: &mut [u8]) {
         if bytes[0] & 0x40 == 0 {
             // Node reference.  Pointer can be non-zero.

--- a/sealable-trie/src/nodes/tests.rs
+++ b/sealable-trie/src/nodes/tests.rs
@@ -1,10 +1,10 @@
 use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 use base64::Engine;
+use memory::Ptr;
 use pretty_assertions::assert_eq;
 
 use crate::bits;
 use crate::hash::CryptoHash;
-use crate::memory::Ptr;
 use crate::nodes::{Node, NodeRef, RawNode, Reference, ValueRef};
 
 const DEAD: Ptr = match Ptr::new(0xDEAD) {
@@ -45,7 +45,7 @@ pub(super) fn raw_from_node(node: &Node) -> RawNode {
 /// 4. If node is an Extension, checks if slow path hash calculation produces
 ///    the same hash.
 #[track_caller]
-fn check_node_encoding(node: Node, want: [u8; 72], want_hash: &str) {
+fn check_node_encoding(node: Node, want: [u8; RawNode::SIZE], want_hash: &str) {
     let raw = raw_from_node(&node);
     assert_eq!(want, raw.0, "Unexpected raw representation");
     assert_eq!(node, RawNode(want).decode(), "Bad Raw→Node conversion");

--- a/sealable-trie/src/trie/tests.rs
+++ b/sealable-trie/src/trie/tests.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::println;
 
+use memory::test_utils::TestAllocator;
 use rand::Rng;
 
 use crate::hash::CryptoHash;
-use crate::memory::test_utils::TestAllocator;
 
 fn do_test_inserts<'a>(
     keys: impl IntoIterator<Item = &'a [u8]>,
@@ -114,7 +114,7 @@ impl core::fmt::Debug for Key {
 }
 
 struct TestTrie {
-    trie: super::Trie<TestAllocator>,
+    trie: super::Trie<TestAllocator<super::Value>>,
     mapping: HashMap<Key, CryptoHash>,
     count: usize,
 }

--- a/stdx/Cargo.toml
+++ b/stdx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "stdx"
+version = "0.0.0"
+edition = "2021"

--- a/stdx/src/lib.rs
+++ b/stdx/src/lib.rs
@@ -1,9 +1,5 @@
 /// Splits `&[u8; L + R]` into `(&[u8; L], &[u8; R])`.
-pub(crate) fn split_array_ref<
-    const L: usize,
-    const R: usize,
-    const N: usize,
->(
+pub fn split_array_ref<const L: usize, const R: usize, const N: usize>(
     xs: &[u8; N],
 ) -> (&[u8; L], &[u8; R]) {
     let () = AssertEqSum::<L, R, N>::OK;
@@ -13,11 +9,7 @@ pub(crate) fn split_array_ref<
 }
 
 /// Splits `&mut [u8; L + R]` into `(&mut [u8; L], &mut [u8; R])`.
-pub(crate) fn split_array_mut<
-    const L: usize,
-    const R: usize,
-    const N: usize,
->(
+pub fn split_array_mut<const L: usize, const R: usize, const N: usize>(
     xs: &mut [u8; N],
 ) -> (&mut [u8; L], &mut [u8; R]) {
     let () = AssertEqSum::<L, R, N>::OK;
@@ -28,7 +20,7 @@ pub(crate) fn split_array_mut<
 
 /// Splits `&[u8]` into `(&[u8; L], &[u8])`.  Returns `None` if input is too
 /// shorter.
-pub(crate) fn split_at<const L: usize>(xs: &[u8]) -> Option<(&[u8; L], &[u8])> {
+pub fn split_at<const L: usize>(xs: &[u8]) -> Option<(&[u8; L], &[u8])> {
     if xs.len() < L {
         return None;
     }
@@ -39,9 +31,7 @@ pub(crate) fn split_at<const L: usize>(xs: &[u8]) -> Option<(&[u8; L], &[u8])> {
 /// Splits `&[u8]` into `(&[u8], &[u8; R])`.  Returns `None` if input is too
 /// shorter.
 #[allow(dead_code)]
-pub(crate) fn rsplit_at<const R: usize>(
-    xs: &[u8],
-) -> Option<(&[u8], &[u8; R])> {
+pub fn rsplit_at<const R: usize>(xs: &[u8]) -> Option<(&[u8], &[u8; R])> {
     let (head, tail) = xs.split_at(xs.len().checked_sub(R)?);
     Some((head, tail.try_into().unwrap()))
 }


### PR DESCRIPTION
stdx includes functions which are not dependent on any other part of
the code base and are useful in any code.  As such, it doesn’t make
sense to keep it inside of the sealable-trie crate.  Moving it to
separate crate makes it more reusable.

Separating memory into its own crate should make it easier to
implement pool allocators since they won’t need to link to the
sealable-trie crate and thus ‘know’ the details of RawNode structure.
