### PR TITLE
Move CryptoHash to a new lib crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.71.0"
 
 [workspace]
 members = [
+    "lib",
     "memory",
     "sealable-trie",
     "solana/trie-example",
@@ -24,6 +25,7 @@ solana-program = "1.16.7"
 solana-sdk = "1.16.7"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 
+lib = { path = "lib" }
 memory = { path = "memory" }
 sealable-trie = { path = "sealable-trie" }
 stdx = { path = "stdx" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lib"
+authors = ["Michal Nazarewicz <mina86@mina86.com>"]
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+base64.workspace = true
+derive_more.workspace = true
+sha2.workspace = true
+
+[features]
+test_utils = []

--- a/lib/src/hash.rs
+++ b/lib/src/hash.rs
@@ -54,8 +54,8 @@ impl CryptoHash {
     /// Creates a new hash with given number encoded in its first bytes.
     ///
     /// This is meant for tests which need to use arbitrary hash values.
-    #[cfg(test)]
-    pub(crate) const fn test(num: usize) -> CryptoHash {
+    #[cfg(feature = "test_utils")]
+    pub const fn test(num: usize) -> CryptoHash {
         let mut buf = [0; Self::LENGTH];
         let num = (num as u32).to_be_bytes();
         let mut idx = 0;
@@ -65,11 +65,6 @@ impl CryptoHash {
         }
         Self(buf)
     }
-
-    /// Returns whether the hash is all zero bits.  Equivalent to comparing to
-    /// the default `CryptoHash` object.
-    #[inline]
-    pub fn is_zero(&self) -> bool { self.0.iter().all(|&byte| byte == 0) }
 
     /// Returns reference to the hash as slice of bytes.
     #[inline]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,0 +1,6 @@
+#![no_std]
+extern crate alloc;
+#[cfg(test)]
+extern crate std;
+
+pub mod hash;

--- a/sealable-trie/Cargo.toml
+++ b/sealable-trie/Cargo.toml
@@ -10,6 +10,7 @@ derive_more.workspace = true
 sha2.workspace = true
 strum.workspace = true
 
+lib.workspace = true
 memory.workspace = true
 stdx.workspace = true
 
@@ -17,4 +18,5 @@ stdx.workspace = true
 pretty_assertions.workspace = true
 rand.workspace = true
 
+lib = { workspace = true, features = ["test_utils"] }
 memory = { workspace = true, features = ["test_utils"] }

--- a/sealable-trie/src/lib.rs
+++ b/sealable-trie/src/lib.rs
@@ -4,7 +4,6 @@ extern crate alloc;
 extern crate std;
 
 pub mod bits;
-pub mod hash;
 pub mod nodes;
 pub mod proof;
 pub mod trie;

--- a/sealable-trie/src/nodes.rs
+++ b/sealable-trie/src/nodes.rs
@@ -1,8 +1,8 @@
+use lib::hash::CryptoHash;
 use memory::Ptr;
 
 use crate::bits;
 use crate::bits::Slice;
-use crate::hash::CryptoHash;
 
 #[cfg(test)]
 mod stress_tests;

--- a/sealable-trie/src/nodes/tests.rs
+++ b/sealable-trie/src/nodes/tests.rs
@@ -1,10 +1,10 @@
 use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 use base64::Engine;
+use lib::hash::CryptoHash;
 use memory::Ptr;
 use pretty_assertions::assert_eq;
 
 use crate::bits;
-use crate::hash::CryptoHash;
 use crate::nodes::{Node, NodeRef, RawNode, Reference, ValueRef};
 
 const DEAD: Ptr = match Ptr::new(0xDEAD) {

--- a/sealable-trie/src/proof.rs
+++ b/sealable-trie/src/proof.rs
@@ -2,8 +2,9 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::num::NonZeroU16;
 
+use lib::hash::CryptoHash;
+
 use crate::bits;
-use crate::hash::CryptoHash;
 use crate::nodes::{Node, NodeRef, Reference, ValueRef};
 
 /// A proof of a membership or non-membership of a key.

--- a/sealable-trie/src/trie.rs
+++ b/sealable-trie/src/trie.rs
@@ -1,8 +1,8 @@
 use core::num::NonZeroU16;
 
+use lib::hash::CryptoHash;
 use memory::Ptr;
 
-use crate::hash::CryptoHash;
 use crate::nodes::{Node, NodeRef, RawNode, Reference};
 use crate::{bits, proof};
 

--- a/sealable-trie/src/trie/set.rs
+++ b/sealable-trie/src/trie/set.rs
@@ -1,8 +1,8 @@
+use lib::hash::CryptoHash;
 use memory::Ptr;
 
 use super::{Error, Result};
 use crate::bits;
-use crate::hash::CryptoHash;
 use crate::nodes::{Node, NodeRef, RawNode, Reference, ValueRef};
 
 /// Context for [`Trie::set`] operation.

--- a/sealable-trie/src/trie/tests.rs
+++ b/sealable-trie/src/trie/tests.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 use std::println;
 
+use lib::hash::CryptoHash;
 use memory::test_utils::TestAllocator;
 use rand::Rng;
-
-use crate::hash::CryptoHash;
 
 fn do_test_inserts<'a>(
     keys: impl IntoIterator<Item = &'a [u8]>,

--- a/solana/trie-example/Cargo.toml
+++ b/solana/trie-example/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "lib"]
 derive_more.workspace = true
 solana-program.workspace = true
 
+lib.workspace = true
 memory.workspace = true
 sealable-trie.workspace = true
 stdx.workspace = true

--- a/solana/trie-example/src/lib.rs
+++ b/solana/trie-example/src/lib.rs
@@ -1,4 +1,4 @@
-use sealable_trie::hash::CryptoHash;
+use lib::hash::CryptoHash;
 use solana_program::account_info::AccountInfo;
 use solana_program::msg;
 use solana_program::program::set_return_data;

--- a/solana/trie-example/src/trie.rs
+++ b/solana/trie-example/src/trie.rs
@@ -1,8 +1,8 @@
 use core::cell::RefMut;
 use core::mem::ManuallyDrop;
 
+use lib::hash::CryptoHash;
 use memory::Ptr;
-use sealable_trie::hash::CryptoHash;
 
 use crate::magic;
 


### PR DESCRIPTION
With CryptoHash in a separate crate, other crates can be written to
use it without having to rely on sealable-trie.  This should help with
isolation of interfaces, preservation of abstractions and testability
of all the components.

lib crate is also going to be a place for other code which is used
across crates without clear ownership in any of them.
