### PR TITLE
github: don’t run tests in nightly

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,7 +36,7 @@ jobs:
           args: --all-features -- -D warnings
 
   stable:
-    name: Rust stable
+    name: Rust tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
         run: cargo test --all-features
 
   nightly:
-    name: Rust nightly
+    name: Rust Miri tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -65,9 +65,6 @@ jobs:
         with:
           toolchain: nightly
           components: miri
-
-      - name: Run tests
-        run: cargo test
 
       - name: Run tests with Miri
         run: cargo miri test -- --skip ::stress_test


### PR DESCRIPTION
We’re already running tests via stable Rust.  Running them with nightly Rust doesn’t add that much value.  Only run Miri tests in nightly.