### PR TITLE
solana-ibc: don’t enable std in ibc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,22 +22,22 @@ incremental = false
 codegen-units = 1
 
 [workspace.dependencies]
+anchor-lang = {version = "0.28.0", features = ["init-if-needed"]}
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
+bincode = "1.3.3"
 borsh = { version = "0.10.3", default-features = false }
 derive_more = "0.99.17"
+ibc = { git = "https://github.com/dhruvja/ibc-rs", default-features = false }
+ibc-proto = { git = "https://github.com/dhruvja/ibc-proto-rs", default-features = false }
 pretty_assertions = "1.4.0"
 rand = { version = "0.8.5" }
+serde = "1"
+serde_json = "1"
 sha2 = { version = "0.10.7", default-features = false }
 solana-client = "1.16.14"
 solana-program = "1.16.14"
 solana-sdk = "1.16.14"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
-anchor-lang = {version = "0.28.0", features = ["init-if-needed"]}
-bincode = "1.3.3"
-ibc = { git = "https://github.com/dhruvja/ibc-rs", features = ["serde", "borsh", "mocks"] }
-ibc-proto = { git = "https://github.com/dhruvja/ibc-proto-rs", default-features = false, features = ["serde", "borsh"] }
-serde = "1"
-serde_json = "1"
 
 lib = { path = "common/lib" }
 memory = { path = "common/memory" }

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -25,6 +25,4 @@ serde_json.workspace = true
 [dev-dependencies]
 anchor-client.workspace = true
 anyhow.workspace = true
-
-
-
+ibc = { workspace = true, features = ["mocks", "std"] }


### PR DESCRIPTION
Disable all features (including default ones) of ibc and ibc-proto
crates and only selectively enable mocks and std in dev
dependencies. This has the effect of removing std dependencies from
ibc code and also unused borsh and serde dependencies.
