### PR TITLE
anchor: configure ‘anchor test’ to actually run anchor tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,4 +67,4 @@ jobs:
           components: miri
 
       - name: Run tests with Miri
-        run: cargo miri test -- --skip ::stress_test
+        run: cargo miri test -- --skip ::stress_test --skip ::anchor

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -20,5 +20,4 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 # test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
-test = "cargo test -- --nocapture" 
-
+test = "cargo test --lib -- --nocapture --include-ignored ::anchor"

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -46,7 +46,7 @@ fn create_mock_client_and_cs_state() -> (MockClientState, MockConsensusState) {
 
 #[test]
 #[ignore = "Requires local validator to run"]
-fn test_deliver() -> Result<()> {
+fn anchor_test_deliver() -> Result<()> {
     let authority = Rc::new(Keypair::new());
     println!("This is pubkey {}", authority.pubkey().to_string());
     let lamports = 10_000_000_000;


### PR DESCRIPTION
Introduce a convention where Anchor test names start with ‘anchor_’
thus making it easy to select all of them.  Because they fail when run
via normal ‘cargo test’ invocation, they are set as ignored so ‘anchor
test’ command has to be configured to include ignored tests.
