### PR TITLE
github: fix cargo-deny build failure in CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        run: cargo install --locked cargo-deny
 
       - name: Check bans
         run: cargo-deny --all-features check bans


### PR DESCRIPTION
Use --locked when installing cargo-deny to fix build failure caused by duplicate dependency:

    error[E0308]: `?` operator has incompatible types
       --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.54.1/src/repository/config/transport.rs:272:47
    272 |                       opts.proxy_authenticate = opts
        |  _______________________________________________^
    ...   |
    288 | |                         .transpose()?;
        | |_____________________________________^ expected `gix_credentials::helper::Action`, found a different `gix_credentials::helper::Action`
        |
        = note: `?` operator cannot convert from `Option<(gix_credentials::helper::Action, Arc<_>)>` to `Option<(gix_credentials::helper::Action, Arc<_>)>`
        = note: `gix_credentials::helper::Action` and `gix_credentials::helper::Action` have similar names, but are actually distinct types
        = note: perhaps two different versions of crate `gix_credentials` are being used?