### PR TITLE
blockchain: change signing schema

### DIFF
--- a/common/blockchain/Cargo.toml
+++ b/common/blockchain/Cargo.toml
@@ -9,11 +9,11 @@ borsh.workspace = true
 derive_more.workspace = true
 
 lib = { workspace = true, features = ["borsh"] }
+stdx.workspace = true
 
 [dev-dependencies]
 lib = { workspace = true, features = ["borsh", "test_utils"] }
 rand.workspace = true
-stdx.workspace = true
 
 [features]
 std = []


### PR DESCRIPTION
Rather than signing the block, change the code so that validators sign
block_height + block_hash.  The advantage of this is that checking
malicious signatures doesn’t require having the whole block.  This
will reduce amount of data contract and fishermen need to store to
work.
