### PR TITLE
solana-ibc: avoid copy by referencing private store in inner storage

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -49,8 +49,6 @@ pub mod solana_ibc {
     ) -> Result<()> {
         msg!("Called deliver method");
         let _sender = ctx.accounts.sender.to_account_info();
-        let private_store: &mut PrivateStorage = &mut ctx.accounts.storage;
-        msg!("This is private_store {:?}", private_store);
 
         let all_messages = messages
             .into_iter()
@@ -62,16 +60,15 @@ pub mod solana_ibc {
 
         msg!("These are messages {:?}", all_messages);
 
+        let private: &mut PrivateStorage = &mut ctx.accounts.storage;
+        msg!("This is private_store {:?}", private);
+
         let account = &ctx.accounts.trie;
-        let trie = trie::AccountTrie::new(account.try_borrow_mut_data()?)
+        let provable = trie::AccountTrie::new(account.try_borrow_mut_data()?)
             .ok_or(ProgramError::InvalidAccountData)?;
 
-        let solana_real_storage =
-            IbcStorageInner { private: private_store.clone(), provable: trie };
-
-        let mut store = IbcStorage(Rc::<RefCell<IbcStorageInner>>::new(
-            solana_real_storage.into(),
-        ));
+        let inner = IbcStorageInner { private, provable };
+        let mut store = IbcStorage(Rc::new(RefCell::new(inner)));
         let mut router = store.clone();
 
         let errors =
@@ -89,38 +86,11 @@ pub mod solana_ibc {
                 errors
             });
 
-        let sol_store = &store.0.borrow_mut().private;
-        private_store.height = sol_store.height;
-        private_store.clients = sol_store.clients.clone();
-        private_store.client_id_set = sol_store.client_id_set.clone();
-        private_store.client_counter = sol_store.client_counter;
-        private_store.client_processed_times =
-            sol_store.client_processed_times.clone();
-        private_store.client_processed_heights =
-            sol_store.client_processed_heights.clone();
-        private_store.consensus_states = sol_store.consensus_states.clone();
-        private_store.client_consensus_state_height_sets =
-            sol_store.client_consensus_state_height_sets.clone();
-        private_store.connection_id_set = sol_store.connection_id_set.clone();
-        private_store.connection_counter = sol_store.connection_counter;
-        private_store.connections = sol_store.connections.clone();
-        private_store.channel_ends = sol_store.channel_ends.clone();
-        private_store.connection_to_client =
-            sol_store.connection_to_client.clone();
-        private_store.port_channel_id_set =
-            sol_store.port_channel_id_set.clone();
-        private_store.channel_counter = sol_store.channel_counter;
-        private_store.next_sequence = sol_store.next_sequence.clone();
-        private_store.packet_commitment_sequence_sets =
-            sol_store.packet_commitment_sequence_sets.clone();
-        private_store.packet_receipt_sequence_sets =
-            sol_store.packet_receipt_sequence_sets.clone();
-        private_store.packet_acknowledgement_sequence_sets =
-            sol_store.packet_acknowledgement_sequence_sets.clone();
-        private_store.ibc_events_history = sol_store.ibc_events_history.clone();
+        core::mem::drop(router);
+        let inner = Rc::into_inner(store.0).unwrap().into_inner();
 
         msg!("These are errors {:?}", errors);
-        msg!("This is final structure {:?}", private_store);
+        msg!("This is final structure {:?}", inner.private);
 
         // msg!("this is length {}", TrieKey::ClientState{ client_id: String::from("hello")}.into());
 
@@ -271,7 +241,7 @@ pub struct PrivateStorage {
 /// All the structs from IBC are stored as String since they dont implement AnchorSerialize and AnchorDeserialize
 #[derive(Debug)]
 pub struct IbcStorageInner<'a, 'b> {
-    pub private: PrivateStorage,
+    pub private: &'a mut PrivateStorage,
     pub provable: trie::AccountTrie<'a, 'b>,
 }
 


### PR DESCRIPTION
Rather than creating a copy of PrivateStorage and using that inside of
the IbcStorageInner, keep a reference to the existing object.  This
removes the need from making a copy.