### PR TITLE
using try_unwrap instead of into_inner since solana program uses older rustc version

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -91,7 +91,7 @@ pub mod solana_ibc {
         // TODO(dhruvja): Since Solana-program uses rustc version 1.69
         // and Rc::into_inner() is supported only from 1.70 and above
         // so using the inner function instead.
-        let inner = Rc::try_unwrap(store.0).ok().unwrap().into_inner();
+        let inner = Rc::try_unwrap(store.0).unwrap().into_inner();
 
         msg!("These are errors {:?}", errors);
         msg!("This is final structure {:?}", inner.private);


### PR DESCRIPTION
Solana program 1.16.14 uses rustc version of 1.69 which doesnt support `Rc::into_inner()` since it requires `rustc >= 1.70` so using the `try_unwrap` method instead. Since the latest version 1.17.0 is not stable yet, its better for us to stay in version 1.16.

Once we upgrade the solana-program ( >= 1.17.0) , we can switch it back to `into_inner`