### PR TITLE
solana-ibc: prefer borsh encoding for emitted events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ codegen-units = 1
 [workspace.dependencies]
 anchor-lang = {version = "0.28.0", features = ["init-if-needed"]}
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
-bincode = "1.3.3"
 borsh = { version = "0.10.3", default-features = false }
 derive_more = "0.99.17"
 ibc = { version = "0.45.0", default-features = false, features = ["serde", "borsh"] }

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -17,7 +17,6 @@ mocks = ["ibc/mocks", "ibc/std"]
 
 [dependencies]
 anchor-lang.workspace = true
-bincode.workspace = true
 ibc.workspace = true
 ibc-proto.workspace = true
 serde.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -434,7 +434,7 @@ impl ExecutionContext for IbcStorage<'_, '_> {
             ibc::Height::new(store.private.height.0, store.private.height.1)
                 .map_err(ContextError::ClientError)
                 .unwrap();
-        let event_in_bytes: Vec<u8> = bincode::serialize(&event).unwrap();
+        let ibc_event = borsh::to_vec(&event).unwrap();
         let inner_host_height =
             (host_height.revision_height(), host_height.revision_number());
         store
@@ -442,8 +442,8 @@ impl ExecutionContext for IbcStorage<'_, '_> {
             .ibc_events_history
             .entry(inner_host_height)
             .or_default()
-            .push(event_in_bytes.clone());
-        emit!(EmitIBCEvent { ibc_event: event_in_bytes });
+            .push(ibc_event.clone());
+        emit!(EmitIBCEvent { ibc_event });
         Ok(())
     }
 


### PR DESCRIPTION
This eliminates bincode dependency.