### PR TITLE
memory: reuse freed nodes in WriteLog

### DIFF
--- a/common/memory/src/lib.rs
+++ b/common/memory/src/lib.rs
@@ -195,9 +195,14 @@ impl<'a, A: Allocator> WriteLog<'a, A> {
     pub fn allocator(&self) -> &A { &*self.alloc }
 
     pub fn alloc(&mut self, value: A::Value) -> Result<Ptr, OutOfMemory> {
-        let ptr = self.alloc.alloc(value)?;
-        self.allocated.push(ptr);
-        Ok(ptr)
+        Ok(if let Some(ptr) = self.freed.pop() {
+            self.set(ptr, value);
+            ptr
+        } else {
+            let ptr = self.alloc.alloc(value)?;
+            self.allocated.push(ptr);
+            ptr
+        })
     }
 
     pub fn set(&mut self, ptr: Ptr, value: A::Value) {


### PR DESCRIPTION
Once a node is freed it can be used in next allocation.  Change
WriteLog such that it tries to pick freed nodes first before calling
out to the allocator when customer tries to allocate a new node.
