### PR TITLE
sealable-trie: propagate decode error rather than panicking

### DIFF
--- a/common/sealable-trie/src/nodes/stress_tests.rs
+++ b/common/sealable-trie/src/nodes/stress_tests.rs
@@ -19,7 +19,7 @@ fn stress_test_raw_encoding_round_trip() {
     let mut raw = RawNode([0; RawNode::SIZE]);
     for _ in 0..get_iteration_count(1) {
         gen_random_raw_node(&mut rng, &mut raw.0);
-        let node = raw.decode();
+        let node = raw.decode().unwrap();
         // Test RawNode→Node→RawNode round trip conversion.
         assert_eq!(Ok(raw), node.encode(), "node: {node:?}");
     }
@@ -91,7 +91,7 @@ fn stress_test_node_encoding_round_trip() {
         let node = gen_random_node(&mut rng, &mut buf);
 
         let raw = super::tests::raw_from_node(&node);
-        assert_eq!(node, raw.decode(), "Failed decoding Raw: {raw:?}");
+        assert_eq!(Ok(node), raw.decode(), "Failed decoding Raw: {raw:?}");
     }
 }
 

--- a/common/sealable-trie/src/nodes/tests.rs
+++ b/common/sealable-trie/src/nodes/tests.rs
@@ -25,7 +25,7 @@ const TWO: CryptoHash = CryptoHash([2; 32]);
 pub(super) fn raw_from_node(node: &Node) -> RawNode {
     let raw = node.encode().unwrap_or_else(|err| panic!("{err:?}: {node:?}"));
     assert_eq!(
-        *node,
+        Ok(*node),
         raw.decode(),
         "Node → RawNode → Node gave different result:\n Raw: {raw:?}"
     );
@@ -44,7 +44,7 @@ pub(super) fn raw_from_node(node: &Node) -> RawNode {
 fn check_node_encoding(node: Node, want: [u8; RawNode::SIZE], want_hash: &str) {
     let raw = raw_from_node(&node);
     assert_eq!(want, raw.0, "Unexpected raw representation");
-    assert_eq!(node, RawNode(want).decode(), "Bad Raw→Node conversion");
+    assert_eq!(Ok(node), RawNode(want).decode(), "Bad Raw→Node conversion");
 
     let want_hash = b64decode(want_hash);
     assert_eq!(want_hash, node.hash(), "Unexpected hash of {node:?}");

--- a/common/sealable-trie/src/trie.rs
+++ b/common/sealable-trie/src/trie.rs
@@ -86,10 +86,18 @@ pub enum Error {
     NotFound,
     #[display(fmt = "Not enough space")]
     OutOfMemory,
+    #[display(fmt = "Error decoding node: {}", "_0")]
+    BadRawNode(crate::nodes::DecodeError),
 }
 
 impl From<memory::OutOfMemory> for Error {
+    #[inline]
     fn from(_: memory::OutOfMemory) -> Self { Self::OutOfMemory }
+}
+
+impl From<crate::nodes::DecodeError> for Error {
+    #[inline]
+    fn from(err: crate::nodes::DecodeError) -> Self { Self::BadRawNode(err) }
 }
 
 type Result<T, E = Error> = ::core::result::Result<T, E>;
@@ -175,7 +183,7 @@ impl<A: memory::Allocator<Value = Value>> Trie<A> {
         let mut node_hash = self.root_hash.clone();
         loop {
             let node = self.alloc.get(node_ptr.ok_or(Error::Sealed)?);
-            let node = <&RawNode>::from(node).decode();
+            let node = <&RawNode>::from(node).decode()?;
             debug_assert_eq!(node_hash, node.hash());
 
             let child = match node {
@@ -324,19 +332,23 @@ impl<A: memory::Allocator<Value = Value>> Trie<A> {
             println!(" (sealed)");
             return;
         };
-        match <&RawNode>::from(self.alloc.get(ptr)).decode() {
-            Node::Branch { children } => {
+        let node = <&RawNode>::from(self.alloc.get(ptr));
+        match node.decode() {
+            Ok(Node::Branch { children }) => {
                 println!(" Branch");
                 print_ref(children[0], depth + 2);
                 print_ref(children[1], depth + 2);
             }
-            Node::Extension { key, child } => {
+            Ok(Node::Extension { key, child }) => {
                 println!(" Extension {key}");
                 print_ref(child, depth + 2);
             }
-            Node::Value { value, child } => {
+            Ok(Node::Value { value, child }) => {
                 println!(" Value {}", value.hash);
                 print_ref(Reference::from(child), depth + 2);
+            }
+            Err(err) => {
+                println!(" BadRawNode: {err}: {node:?}");
             }
         }
     }


### PR DESCRIPTION
Reduce amount of potential panics by propagating errors from decoding
invalid raw nodes.  Those errors should never happen since we write
the raw nodes and thus guarantee valid representation but in case the
code is ever used on data that needs validation it’s safer to detect
and propagate errors.

The crux of the change is in RawNode::decode and Reference::from_raw
methods in nodes.rs file.  The rest of the changes is just adapting to
RawNode::decode’s return type change.
