### PR TITLE
blockchain: replace Signature with Signer trait

### DIFF
--- a/common/blockchain/src/epoch.rs
+++ b/common/blockchain/src/epoch.rs
@@ -108,7 +108,8 @@ impl Epoch<crate::validators::MockPubKey> {
             .copied()
             .map(|(pk, stake)| {
                 total += stake;
-                Validator::new(pk.into(), NonZeroU128::new(stake).unwrap())
+                let pk = crate::validators::MockPubKey(pk);
+                Validator::new(pk, NonZeroU128::new(stake).unwrap())
             })
             .collect();
         Self::new_with(validators, |total| {

--- a/common/blockchain/src/manager.rs
+++ b/common/blockchain/src/manager.rs
@@ -9,7 +9,7 @@ use lib::hash::CryptoHash;
 use crate::candidates::Candidates;
 pub use crate::candidates::UpdateCandidateError;
 use crate::height::HostHeight;
-use crate::validators::{PubKey, Signature};
+use crate::validators::PubKey;
 use crate::{block, chain, epoch};
 
 pub struct ChainManager<PK> {
@@ -196,7 +196,7 @@ impl<PK: PubKey> ChainManager<PK> {
         if pending.signers.contains(&pubkey) {
             return Ok(false);
         }
-        if !signature.verify(&pending.hash, &pubkey) {
+        if !pubkey.verify(pending.hash.as_slice(), signature) {
             return Err(AddSignatureError::BadSignature);
         }
 

--- a/common/blockchain/src/validators.rs
+++ b/common/blockchain/src/validators.rs
@@ -11,22 +11,18 @@ pub trait PubKey:
     + borsh::BorshDeserialize
 {
     /// Signature corresponding to this public key type.
-    type Signature: Signature<PubKey = Self>;
+    type Signature: Clone + borsh::BorshSerialize + borsh::BorshDeserialize;
+
+    /// Verifies the signature for given message.
+    fn verify(&self, message: &[u8], signature: &Self::Signature) -> bool;
 }
 
-/// A cryptographic signature.
-pub trait Signature:
-    Clone + borsh::BorshSerialize + borsh::BorshDeserialize
-{
-    /// Public key type which can verify the signature.
-    type PubKey: PubKey<Signature = Self>;
+pub trait Signer {
+    /// Signature created by this signer.
+    type Signature: Clone + borsh::BorshSerialize + borsh::BorshDeserialize;
 
-    /// Verifies that the signature of a given hash is correct.
-    fn verify(
-        &self,
-        message: &lib::hash::CryptoHash,
-        pk: &Self::PubKey,
-    ) -> bool;
+    /// Signs given message.
+    fn sign(&self, message: &[u8]) -> Self::Signature;
 }
 
 /// A validator
@@ -57,9 +53,6 @@ impl<PK> Validator<PK> {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-
-    use super::*;
-
     /// A mock implementation of a PubKey.  Offers no security; intended for
     /// tests only.
     #[derive(
@@ -72,11 +65,15 @@ pub(crate) mod test_utils {
         Hash,
         borsh::BorshSerialize,
         borsh::BorshDeserialize,
-        derive_more::From,
     )]
     pub struct MockPubKey(pub u32);
 
-    /// A mock implementation of a Signature.  Offers no security; intended for
+    /// A mock implementation of a Signer.  Offers no security; intended for
+    /// tests only.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub struct MockSigner(pub MockPubKey);
+
+    /// A mock implementation of a signature.  Offers no security; intended for
     /// tests only.
     #[derive(
         Clone,
@@ -92,49 +89,48 @@ pub(crate) mod test_utils {
     pub struct MockSignature(pub u32, pub MockPubKey);
 
     impl core::fmt::Debug for MockPubKey {
+        #[inline]
         fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(fmt, "⚷{}", self.0)
         }
     }
 
-    impl core::fmt::Debug for MockSignature {
+    impl core::fmt::Debug for MockSigner {
+        #[inline]
         fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            write!(fmt, "Sig({} by {:?})", self.0, self.1)
+            self.0.fmt(fmt)
+        }
+    }
+
+    impl core::fmt::Debug for MockSignature {
+        #[inline]
+        fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(fmt, "Sig({:x} by {:?})", self.0, self.1)
         }
     }
 
     impl super::PubKey for MockPubKey {
         type Signature = MockSignature;
-    }
 
-    impl MockSignature {
-        pub fn new(message: &[u8], pk: MockPubKey) -> Self {
-            Self(Self::hash_message(message), pk)
-        }
-
-        fn hash_message(message: &[u8]) -> u32 {
-            Self::cut_hash(&lib::hash::CryptoHash::digest(message))
-        }
-
-        fn cut_hash(hash: &lib::hash::CryptoHash) -> u32 {
-            let hash = hash.into();
-            let (head, _) = stdx::split_array_ref::<4, 28, 32>(&hash);
-            u32::from_be_bytes(*head)
+        fn verify(&self, message: &[u8], signature: &Self::Signature) -> bool {
+            signature.0 == short_hash(message) && &signature.1 == self
         }
     }
 
-    impl Signature for MockSignature {
-        type PubKey = MockPubKey;
+    impl super::Signer for MockSigner {
+        type Signature = MockSignature;
 
-        fn verify(
-            &self,
-            message: &lib::hash::CryptoHash,
-            pk: &Self::PubKey,
-        ) -> bool {
-            self.0 == Self::cut_hash(message) && &self.1 == pk
+        fn sign(&self, message: &[u8]) -> Self::Signature {
+            MockSignature(short_hash(message), self.0)
         }
+    }
+
+    fn short_hash(message: &[u8]) -> u32 {
+        let hash = <&[u8; 32]>::try_from(message).unwrap();
+        let (hash, _) = stdx::split_array_ref::<4, 28, 32>(&hash);
+        u32::from_be_bytes(*hash)
     }
 }
 
 #[cfg(test)]
-pub(crate) use test_utils::{MockPubKey, MockSignature};
+pub(crate) use test_utils::{MockPubKey, MockSignature, MockSigner};


### PR DESCRIPTION
Having a Signer type gives better place for a sign method.
Furthermore, it matches better interface used in signature crate which
will make integrating with it simpler.
