### PR TITLE
sealable-trie: remove dependency on CryptoHash being borsh-serialisable

### DIFF
--- a/common/lib/src/hash.rs
+++ b/common/lib/src/hash.rs
@@ -85,6 +85,10 @@ impl CryptoHash {
         Self(buf)
     }
 
+    /// Returns a shared reference to the underlying bytes array.
+    #[inline]
+    pub fn as_array(&self) -> &[u8; Self::LENGTH] { &self.0 }
+
     /// Returns a shared reference to the hash as slice of bytes.
     #[inline]
     pub fn as_slice(&self) -> &[u8] { &self.0[..] }

--- a/common/sealable-trie/Cargo.toml
+++ b/common/sealable-trie/Cargo.toml
@@ -22,6 +22,3 @@ rand.workspace = true
 
 lib = { workspace = true, features = ["test_utils"] }
 memory = { workspace = true, features = ["test_utils"] }
-
-[features]
-borsh = ["dep:borsh", "lib/borsh"]


### PR DESCRIPTION
We need to change sealable-trie to support multiple borsh crate
versions.  Since it’s borsh-serialising CryptoHash, this by extension
means that lib needs to support all the same versions of borsh.

To avoid the latter, rather than serialising and deserialising
CryptoHash, deal with the underlying arrays of bytes.  This makes
sealable-trie code slightly more verbose but removes the need for lib
to support multiple borsh versions.

(We’ll see whether the support will need to be eventually added. So
far this simplifies stuff a bit).
