### PR TITLE
change client to connection from connection to client

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -253,8 +253,8 @@ impl ExecutionContext for IbcStorage<'_, '_> {
         let mut store = self.0.borrow_mut();
         store
             .private
-            .connection_to_client
-            .insert(conn_id.to_string(), client_connection_path.0.to_string());
+            .client_to_connection
+            .insert( client_connection_path.0.to_string(), conn_id.to_string(),);
         Ok(())
     }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -254,7 +254,7 @@ impl ExecutionContext for IbcStorage<'_, '_> {
         store
             .private
             .client_to_connection
-            .insert( client_connection_path.0.to_string(), conn_id.to_string(),);
+            .insert(client_connection_path.0.to_string(), conn_id.to_string());
         Ok(())
     }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -201,7 +201,7 @@ pub struct PrivateStorage {
     pub connections: BTreeMap<InnerConnectionId, InnerConnectionEnd>,
     pub channel_ends: BTreeMap<(InnerPortId, InnerChannelId), InnerChannelEnd>,
     // Contains the client id corresponding to the connectionId
-    pub connection_to_client: BTreeMap<InnerConnectionId, InnerClientId>,
+    pub client_to_connection: BTreeMap<InnerClientId, InnerConnectionId>,
     /// The port and channel id tuples of the channels.
     pub port_channel_id_set: Vec<(InnerPortId, InnerChannelId)>,
     pub channel_counter: u64,


### PR DESCRIPTION
We are having a mapping between connectionId to clientId ( connectionId is the key ) but it should be the other way round since we would query the connection using client. 