### PR TITLE
sealable-trie: add slightly optimised `set_and_seal` method

### DIFF
--- a/common/sealable-trie/src/trie.rs
+++ b/common/sealable-trie/src/trie.rs
@@ -308,7 +308,7 @@ impl<A: memory::Allocator<Value = Value>> Trie<A> {
         value_hash: &CryptoHash,
     ) -> Result<()> {
         let key = bits::Slice::from_bytes(key).ok_or(Error::KeyTooLong)?;
-        self.set_impl(key.clone(), value_hash)?;
+        self.set_impl(key, value_hash)?;
         self.seal_impl(key)
     }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -322,8 +322,8 @@ impl ExecutionContext for IbcStorage<'_, '_> {
         let mut store = self.0.borrow_mut();
         let receipt_trie_key = TrieKey::from(receipt_path);
         let trie = &mut store.provable;
-        trie.set(&receipt_trie_key, &lib::hash::CryptoHash::DEFAULT).unwrap();
-        trie.seal(&receipt_trie_key).unwrap();
+        trie.set_and_seal(&receipt_trie_key, &lib::hash::CryptoHash::DEFAULT)
+            .unwrap();
         record_packet_sequence(
             &mut store.private.packet_receipt_sequence_sets,
             &receipt_path.port_id,


### PR DESCRIPTION
Fully optimised set and seal operation is still to be done.  For now
add the `set_and_seal` method to the Trie which removes just the most
trivial duplicate work but really serves more as a placeholder so that
clients can start using the method in anticipation of an optimised
version.
