### PR TITLE
Reduce amount of unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ codegen-units = 1
 
 [workspace.dependencies]
 anchor-lang = {version = "0.28.0", features = ["init-if-needed"]}
+ascii = "1.1.0"
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 borsh = { version = "0.10.3", default-features = false }
 derive_more = "0.99.17"

--- a/common/blockchain/src/manager.rs
+++ b/common/blockchain/src/manager.rs
@@ -183,10 +183,7 @@ impl<PK: crate::PubKey> ChainManager<PK> {
             return None;
         }
         crate::Epoch::new_with(self.candidates.maybe_get_head()?, |total| {
-            // SAFETY: 1. ‘total / 2 ≥ 0’ thus ‘total / 2 + 1 > 0’.
-            // 2. ‘total / 2 <= u128::MAX / 2’ thus ‘total / 2 + 1 < u128::MAX’.
-            let quorum =
-                unsafe { NonZeroU128::new_unchecked(total.get() / 2 + 1) };
+            let quorum = NonZeroU128::new(total.get() / 2 + 1).unwrap();
             // min_quorum_stake may be greater than total_stake so we’re not
             // using .clamp to make sure we never return value higher than
             // total_stake.

--- a/common/sealable-trie/Cargo.toml
+++ b/common/sealable-trie/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+ascii.workspace = true
 base64.workspace = true
 borsh = { workspace = true, optional = true }
 derive_more.workspace = true

--- a/common/stdx/src/lib.rs
+++ b/common/stdx/src/lib.rs
@@ -47,28 +47,8 @@ pub fn rsplit_at<const R: usize>(xs: &[u8]) -> Option<(&[u8], &[u8; R])> {
     Some((head, tail.try_into().unwrap()))
 }
 
-/// Splits the slice into a slice of `N`-element arrays and a remainder slice
-/// with length strictly less than `N`.
-///
-/// This is simplified copy of Rust unstable `[T]::as_chunks_mut` method.
-pub fn as_chunks_mut<const N: usize, T>(slice: &mut [T]) -> &mut [[T; N]] {
-    let () = AssertNonZero::<N>::OK;
-
-    let ptr = slice.as_mut_ptr().cast();
-    let len = slice.len() / N;
-    // SAFETY: We already panicked for zero, and ensured by construction
-    // that the length of the subslice is a multiple of N.
-    unsafe { core::slice::from_raw_parts_mut(ptr, len) }
-}
-
 /// Asserts, at compile time, that `A + B == S`.
 struct AssertEqSum<const A: usize, const B: usize, const S: usize>;
 impl<const A: usize, const B: usize, const S: usize> AssertEqSum<A, B, S> {
     const OK: () = assert!(S == A + B);
-}
-
-/// Asserts, at compile time, that `N` is non-zero.
-struct AssertNonZero<const N: usize>;
-impl<const N: usize> AssertNonZero<N> {
-    const OK: () = assert!(N != 0);
 }


### PR DESCRIPTION
1. Compiler is actually smart enough to figure out that unsigned
   number + 1 is non-zero and optimises NonZeroU128::new(n + 1)
   correctly.  Get rid of the unsafe block and new_unchecked call.

2. Use ascii crate’s AsciiChar when formatting the bits slice.  This
   removes the need from converting slice of bytes into a str slice.
   Instead, we get AsciiStr for free which can be converted to str.

3. Remove unused as_chunks_mut method from the stdx crate.
