### PR TITLE
solana-ibc: remember sequence numbers of commitments in private storage

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -107,6 +107,13 @@ pub(crate) struct PrivateStorage {
     pub port_channel_id_set: Vec<(InnerPortId, InnerChannelId)>,
     pub channel_counter: u64,
 
+    /// The sequence numbers of the packet commitments.
+    pub packet_commitment_sequence_sets:
+        BTreeMap<(InnerPortId, InnerChannelId), Vec<Sequence>>,
+    /// The sequence numbers of the packet acknowledgements.
+    pub packet_acknowledgement_sequence_sets:
+        BTreeMap<(InnerPortId, InnerChannelId), Vec<Sequence>>,
+
     /// Next send, receive and ack sequence for given (port, channel).
     ///
     /// We’re storing all three sequences in a single object to reduce amount of


### PR DESCRIPTION
For the sake of relayer, remember sequence numbers of packet and
acknowledgement commitments in the private storage.

This isn’t strictly necessary since the data can be read from the
trie, but that requires iterator interface which isn’t yet
implemented.  For the time being, use sets in the private storage.
