### PR TITLE
blockchain: add Verifier trait

### DIFF
--- a/common/blockchain/src/lib.rs
+++ b/common/blockchain/src/lib.rs
@@ -19,4 +19,4 @@ pub use config::Config;
 pub use epoch::Epoch;
 pub use height::{BlockDelta, BlockHeight, HostDelta, HostHeight};
 pub use manager::ChainManager;
-pub use validators::{PubKey, Signer, Validator};
+pub use validators::{PubKey, Signer, Validator, Verifier};


### PR DESCRIPTION
Add an Verifier trait rather than a verify method on a Signature.  The
purpose is to allow additional context to be provided when checking
signatures.  This is needed in Solana where signature checking
requires access to per-request data (specifically instructions native
program which is passed with the rest of accounts).
