### PR TITLE
Enable stress tests on Miri

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,4 +67,4 @@ jobs:
           components: miri
 
       - name: Run tests with Miri
-        run: cargo miri test -- --skip ::stress_test --skip ::anchor
+        run: cargo miri test -- --skip ::anchor


### PR DESCRIPTION
Limit stress tests to just five iterations when running on Miri.  This
makes them actually quite fast (faster than some regular tests) so
they can be added back to CI.
