### PR TITLE
Enable stress tests on Miri and shrink couple other tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,4 +67,4 @@ jobs:
           components: miri
 
       - name: Run tests with Miri
-        run: cargo miri test -- --skip ::stress_test --skip ::anchor
+        run: cargo miri test -- -Z unstable-options --report-time --skip ::anchor


### PR DESCRIPTION
Limit stress tests to just five iterations when running on Miri.  This
makes them actually quite fast (faster than some regular tests) so
they can be added back to CI.

Furthermore, disable the slowest trie tests on Miri introducing their
smaller variants which run on Miri in reasonable time.  Largest
example is test_del which on my machine takes 144 seconds while
test_del_small takes 18.  To be fair I’d argue it’s still considerable
for a unit test but definitely much more reasonable.
