### PR TITLE
solana-ibc: refactor events handling

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -19,6 +19,7 @@ mocks = ["ibc/mocks", "ibc/std"]
 anchor-lang.workspace = true
 base64.workspace = true
 bytemuck.workspace = true
+derive_more.workspace = true
 ibc-proto.workspace = true
 ibc.workspace = true
 serde.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/events.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/events.rs
@@ -1,0 +1,29 @@
+use anchor_lang::prelude::borsh;
+use anchor_lang::solana_program;
+
+/// Possible events emitted by the smart contract.
+///
+/// The events are logged in their borsh-serialised form.
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+    derive_more::From,
+)]
+pub enum Event {
+    IBCEvent(ibc::core::events::IbcEvent),
+}
+
+impl Event {
+    pub fn emit(&self) -> Result<(), String> {
+        borsh::BorshSerialize::try_to_vec(self)
+            .map(|data| solana_program::log::sol_log_data(&[data.as_slice()]))
+            .map_err(|err| err.to_string())
+    }
+}
+
+pub fn emit(event: impl Into<Event>) -> Result<(), String> {
+    event.into().emit()
+}

--- a/solana/solana-ibc/programs/solana-ibc/src/events.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/events.rs
@@ -13,7 +13,7 @@ use anchor_lang::solana_program;
     derive_more::From,
 )]
 pub enum Event {
-    IBCEvent(ibc::core::events::IbcEvent),
+    IbcEvent(ibc::core::events::IbcEvent),
 }
 
 impl Event {

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -21,6 +21,7 @@ declare_id!("EnfDJsAK7BGgetnmKzBx86CsgC5kfSPcsktFCQ4YLC81");
 mod client_state;
 mod consensus_state;
 mod ed25519;
+mod events;
 mod execution_context;
 mod storage;
 #[cfg(test)]
@@ -130,11 +131,6 @@ impl From<Error<'_>> for u32 {
         let code = ErrorDiscriminants::from(err) as u32;
         anchor_lang::error::ERROR_CODE_OFFSET + code
     }
-}
-
-#[event]
-pub struct EmitIBCEvent {
-    pub ibc_event: Vec<u8>,
 }
 
 impl Router for storage::IbcStorage<'_, '_> {

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -22,8 +22,8 @@ declare_id!("EnfDJsAK7BGgetnmKzBx86CsgC5kfSPcsktFCQ4YLC81");
 mod client_state;
 mod consensus_state;
 mod ed25519;
-mod events;
 mod error;
+mod events;
 mod execution_context;
 mod storage;
 #[cfg(test)]

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -13,7 +13,6 @@ pub(crate) type InnerClientId = String;
 pub(crate) type InnerConnectionId = String;
 pub(crate) type InnerPortId = String;
 pub(crate) type InnerChannelId = String;
-pub(crate) type InnerIbcEvent = Vec<u8>;
 pub(crate) type InnerClient = Vec<u8>; // Serialized
 pub(crate) type InnerConnectionEnd = Vec<u8>; // Serialized
 pub(crate) type InnerChannelEnd = Vec<u8>; // Serialized
@@ -120,9 +119,6 @@ pub(crate) struct PrivateStorage {
     /// different maps we need to maintain.  This saves us on the amount of
     /// trie nodes we need to maintain.
     pub next_sequence: BTreeMap<(InnerPortId, InnerChannelId), SequenceTriple>,
-
-    /// The history of IBC events.
-    pub ibc_events_history: BTreeMap<InnerHeight, Vec<InnerIbcEvent>>,
 }
 
 /// Provable storage, i.e. the trie, held in an account.


### PR DESCRIPTION
Firstly, remove ibc_events_history from the storage.  The field only
ever grows which isn’t sustainable.  The contract has no use for the
field and off-chain customers should look at history of Solana logs
rather than looking at the field.

Secondly, encode the IBC event directly in an event struct rather than
first borsh serialising it and then emitting that.  Since emitting
causes another borsh serialisation this leads to somewhat awkward and
unnecessary double serialisation.

Lastly, use Solana logging directly rather than using Anchor’s logging
infrastructure.  Anchor really doesn’t give us much as far as I can
tell and having an enum with all possible events which is serialised
is just as if not more convenient.
