### PR TITLE
common: use bytemuck to remove unsafe

### DIFF
--- a/common/lib/Cargo.toml
+++ b/common/lib/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 base64.workspace = true
 borsh = { workspace = true, optional = true }
+bytemuck.workspace = true
 derive_more.workspace = true
 
 stdx.workspace = true

--- a/common/lib/src/hash.rs
+++ b/common/lib/src/hash.rs
@@ -2,6 +2,7 @@ use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 use base64::Engine;
 #[cfg(feature = "borsh")]
 use borsh::maybestd::io;
+use bytemuck::TransparentWrapper;
 
 /// A cryptographic hash.
 #[derive(
@@ -13,6 +14,7 @@ use borsh::maybestd::io;
     derive_more::AsMut,
     derive_more::From,
     derive_more::Into,
+    bytemuck::TransparentWrapper,
 )]
 #[cfg_attr(
     feature = "borsh",
@@ -120,21 +122,14 @@ impl From<&'_ CryptoHash> for [u8; CryptoHash::LENGTH] {
 impl<'a> From<&'a [u8; CryptoHash::LENGTH]> for &'a CryptoHash {
     #[inline]
     fn from(hash: &'a [u8; CryptoHash::LENGTH]) -> Self {
-        let hash =
-            (hash as *const [u8; CryptoHash::LENGTH]).cast::<CryptoHash>();
-        // SAFETY: CryptoHash is repr(transparent) over [u8; CryptoHash::LENGTH]
-        // thus transmuting is safe.
-        unsafe { &*hash }
+        CryptoHash::wrap_ref(hash)
     }
 }
 
 impl<'a> From<&'a mut [u8; CryptoHash::LENGTH]> for &'a mut CryptoHash {
     #[inline]
     fn from(hash: &'a mut [u8; CryptoHash::LENGTH]) -> Self {
-        let hash = (hash as *mut [u8; CryptoHash::LENGTH]).cast::<CryptoHash>();
-        // SAFETY: CryptoHash is repr(transparent) over [u8; CryptoHash::LENGTH]
-        // thus transmuting is safe.
-        unsafe { &mut *hash }
+        CryptoHash::wrap_mut(hash)
     }
 }
 

--- a/common/sealable-trie/Cargo.toml
+++ b/common/sealable-trie/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 ascii.workspace = true
 base64.workspace = true
 borsh = { workspace = true, optional = true }
+bytemuck.workspace = true
 derive_more.workspace = true
 sha2.workspace = true
 strum.workspace = true

--- a/common/sealable-trie/src/nodes.rs
+++ b/common/sealable-trie/src/nodes.rs
@@ -1,3 +1,4 @@
+use bytemuck::TransparentWrapper;
 use lib::hash::CryptoHash;
 use memory::Ptr;
 
@@ -107,7 +108,9 @@ pub enum Node<'a, P = Option<Ptr>, S = bool> {
 // ```
 //
 // The actual pointer value is therefore 30-bit long.
-#[derive(Clone, Copy, PartialEq, derive_more::Deref)]
+#[derive(
+    Clone, Copy, PartialEq, derive_more::Deref, bytemuck::TransparentWrapper,
+)]
 #[repr(transparent)]
 pub struct RawNode(pub(crate) [u8; RawNode::SIZE]);
 
@@ -494,8 +497,7 @@ impl<'a> ValueRef<'a, bool> {
 
 impl<'a> From<&'a [u8; RawNode::SIZE]> for &'a RawNode {
     fn from(bytes: &'a [u8; RawNode::SIZE]) -> &'a RawNode {
-        // SAFETY: RawNode is repr(transparent).
-        unsafe { &*bytes.as_ptr().cast() }
+        RawNode::wrap_ref(bytes)
     }
 }
 


### PR DESCRIPTION
The unsafe is of course still there but now hidden in bytemuck
crate. The advantage is that bytemuck checks all the necessary
conditions when deriving TransparentWrapper rather than them only
being described in a comment.
