### PR TITLE
solana-ibc: use ibc::Height for storing height in private storage

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -128,7 +128,7 @@ pub mod solana_ibc {
         // Before anything else, try generating a new guest block.  However, if
         // that fails it’s not an error condition.  We do this at the beginning
         // of any request.
-        // ctx.accounts.chain.maybe_generate_block(&provable, Some(host_head))?;
+        ctx.accounts.chain.maybe_generate_block(&provable, Some(host_head))?;
 
         let mut store = storage::IbcStorage::new(storage::IbcStorageInner {
             private,

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -3,11 +3,11 @@ use alloc::rc::Rc;
 use core::cell::RefCell;
 
 use anchor_lang::prelude::*;
+use ibc::core::ics02_client::height::Height;
 use ibc::core::ics04_channel::msgs::PacketMsg;
 use ibc::core::ics04_channel::packet::Sequence;
 
-pub(crate) type InnerHeight = (u64, u64);
-pub(crate) type HostHeight = InnerHeight;
+pub(crate) type HostHeight = Height;
 pub(crate) type SolanaTimestamp = u64;
 pub(crate) type InnerClientId = String;
 pub(crate) type InnerConnectionId = String;
@@ -80,21 +80,21 @@ pub struct IBCPackets(pub Vec<PacketMsg>);
 /// All the structs from IBC are stored as String since they dont implement
 /// AnchorSerialize and AnchorDeserialize
 pub(crate) struct PrivateStorage {
-    pub height: InnerHeight,
+    pub height: Height,
     pub clients: BTreeMap<InnerClientId, InnerClient>,
     /// The client ids of the clients.
     pub client_id_set: Vec<InnerClientId>,
     pub client_counter: u64,
     pub client_processed_times:
-        BTreeMap<InnerClientId, BTreeMap<InnerHeight, SolanaTimestamp>>,
+        BTreeMap<InnerClientId, BTreeMap<Height, SolanaTimestamp>>,
     pub client_processed_heights:
-        BTreeMap<InnerClientId, BTreeMap<InnerHeight, HostHeight>>,
+        BTreeMap<InnerClientId, BTreeMap<Height, HostHeight>>,
     pub consensus_states:
-        BTreeMap<(InnerClientId, InnerHeight), InnerConsensusState>,
+        BTreeMap<(InnerClientId, Height), InnerConsensusState>,
     /// This collection contains the heights corresponding to all consensus states of
     /// all clients stored in the contract.
     pub client_consensus_state_height_sets:
-        BTreeMap<InnerClientId, Vec<InnerHeight>>,
+        BTreeMap<InnerClientId, Vec<Height>>,
     /// The connection ids of the connections.
     pub connection_id_set: Vec<InnerConnectionId>,
     pub connection_counter: u64,

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -81,7 +81,7 @@ impl ValidationContext for IbcStorage<'_, '_> {
     }
 
     fn host_height(&self) -> Result<ibc::Height> {
-        Ok(self.borrow().private.height)
+        self.borrow().host_head.ibc_height().map_err(Into::into)
     }
 
     fn host_timestamp(&self) -> Result<Timestamp> {


### PR DESCRIPTION
Simplify code by removing conversion between ibc::Height and (u64,
u64) tuple when storing heights in private IBC storage.  The two types
are morally equivalent and using the tuple doesn’t offer us any
benefits.
