### PR TITLE
solana-ibc: map IBC client ids into u32 and refactor client state storage

### DIFF
--- a/common/lib/src/hash.rs
+++ b/common/lib/src/hash.rs
@@ -49,15 +49,6 @@ impl CryptoHash {
         builder.build()
     }
 
-    /// Returns hash of a Borsh-serialised object.
-    #[inline]
-    #[cfg(feature = "borsh")]
-    pub fn borsh(obj: &impl borsh::BorshSerialize) -> io::Result<Self> {
-        let mut builder = Self::builder();
-        obj.serialize(&mut builder)?;
-        Ok(builder.build())
-    }
-
     /// Decodes a base64 string representation of the hash.
     pub fn from_base64(base64: &str) -> Option<Self> {
         // base64 API is kind of garbage.  In certain situations the output
@@ -242,7 +233,9 @@ impl io::Write for Builder {
 }
 
 #[test]
-fn test_empty_digest() {
+fn test_new_hash() {
+    assert_eq!(CryptoHash::from([0; 32]), CryptoHash::default());
+
     // https://www.di-mgt.com.au/sha_testvectors.html
     let want = CryptoHash::from([
         0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8,
@@ -257,21 +250,14 @@ fn test_empty_digest() {
         builder.build()
     };
     assert_eq!(want, got);
+    assert_eq!(want, CryptoHash::builder().build());
 
-    #[cfg(feature = "borsh")]
-    assert_eq!(want, CryptoHash::borsh(&()).unwrap());
-}
-
-#[test]
-fn test_abc_digest() {
-    // https://www.di-mgt.com.au/sha_testvectors.html
     let want = CryptoHash::from([
         0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde,
         0x5d, 0xae, 0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
         0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
     ]);
     assert_eq!(want, CryptoHash::digest(b"abc"));
-
     let got = {
         let mut builder = CryptoHash::builder();
         builder.update(b"a");
@@ -279,9 +265,4 @@ fn test_abc_digest() {
         builder.build()
     };
     assert_eq!(want, got);
-
-    #[cfg(feature = "borsh")]
-    assert_eq!(want, CryptoHash::borsh(b"abc").unwrap());
-    #[cfg(feature = "borsh")]
-    assert_eq!(want, CryptoHash::borsh(&(b'a', 25442u16)).unwrap());
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -233,7 +233,7 @@ impl PrivateStorage {
     ) -> Option<(ClientIdx, &mut ClientStore)> {
         use core::cmp::Ordering;
 
-        let idx = self.client_index(&client_id)?;
+        let idx = self.client_index(client_id)?;
         let pos = usize::from(idx);
         match pos.cmp(&self.clients.len()) {
             Ordering::Less => Some((idx, &mut self.clients[pos])),

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -219,10 +219,11 @@ impl PrivateStorage {
         client_id: &ibc::ClientId,
         create: bool,
     ) -> Result<(ClientIdx, &mut ClientStore), ibc::ClientError> {
-        self.client_mut_impl(client_id, create)
-            .ok_or_else(|| ibc::ClientError::ClientStateNotFound {
+        self.client_mut_impl(client_id, create).ok_or_else(|| {
+            ibc::ClientError::ClientStateNotFound {
                 client_id: client_id.clone(),
-            })
+            }
+        })
     }
 
     fn client_mut_impl(
@@ -239,8 +240,8 @@ impl PrivateStorage {
             Ordering::Equal if create => {
                 self.clients.push(ClientStore::new(client_id.clone()));
                 self.clients.last_mut().map(|client| (idx, client))
-            },
-            _ => None
+            }
+            _ => None,
         }
     }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -85,19 +85,19 @@ impl SequenceTriple {
 ///
 /// To avoid confusing identifiers with the same counter but different client
 /// type (which may be crafted by an attacker), we always check that client type
-/// matches one we know.  Because of this check, to get `ClientIndex`
+/// matches one we know.  Because of this check, to get `ClientIdx`
 /// [`PrivateStorage::client`] needs to be used.
 ///
 /// The index is guaranteed to fit `u32` and `usize`.
 #[derive(Clone, Copy, PartialEq, Eq, derive_more::From, derive_more::Into)]
-pub struct ClientIndex(u32);
+pub struct ClientIdx(u32);
 
-impl From<ClientIndex> for usize {
+impl From<ClientIdx> for usize {
     #[inline]
-    fn from(index: ClientIndex) -> usize { index.0 as usize }
+    fn from(index: ClientIdx) -> usize { index.0 as usize }
 }
 
-impl core::str::FromStr for ClientIndex {
+impl core::str::FromStr for ClientIdx {
     type Err = core::num::ParseIntError;
 
     #[inline]
@@ -110,7 +110,7 @@ impl core::str::FromStr for ClientIndex {
     }
 }
 
-impl PartialEq<usize> for ClientIndex {
+impl PartialEq<usize> for ClientIdx {
     #[inline]
     fn eq(&self, rhs: &usize) -> bool {
         u32::try_from(*rhs).ok().filter(|rhs| self.0 == *rhs).is_some()
@@ -197,7 +197,7 @@ impl PrivateStorage {
     pub fn client(
         &self,
         client_id: &ibc::ClientId,
-    ) -> Result<(ClientIndex, &ClientStore), ibc::ClientError> {
+    ) -> Result<(ClientIdx, &ClientStore), ibc::ClientError> {
         self.client_index(client_id)
             .and_then(|idx| {
                 self.clients
@@ -218,7 +218,7 @@ impl PrivateStorage {
     pub fn client_mut(
         &mut self,
         client_id: &ibc::ClientId,
-    ) -> Result<(ClientIndex, &mut ClientStore), ibc::ClientError> {
+    ) -> Result<(ClientIdx, &mut ClientStore), ibc::ClientError> {
         self.client_index(client_id)
             .and_then(|idx| {
                 self.clients
@@ -240,7 +240,7 @@ impl PrivateStorage {
         &mut self,
         client_id: ibc::ClientId,
         client_state: crate::client_state::AnyClientState,
-    ) -> Result<(ClientIndex, &mut ClientStore), ibc::ClientError> {
+    ) -> Result<(ClientIdx, &mut ClientStore), ibc::ClientError> {
         if let Some(index) = self.client_index(&client_id) {
             if index == self.clients.len() {
                 let store = ClientStore::new(client_id, client_state);
@@ -257,7 +257,7 @@ impl PrivateStorage {
         Err(ibc::ClientError::ClientStateNotFound { client_id })
     }
 
-    fn client_index(&self, client_id: &ibc::ClientId) -> Option<ClientIndex> {
+    fn client_index(&self, client_id: &ibc::ClientId) -> Option<ClientIdx> {
         client_id
             .as_str()
             .rsplit_once('-')


### PR DESCRIPTION
IBC client ids have `<client-type>-<counter>` format where counter is
a global sequential number.  Take advantage of that by converting
client ids into u32 including just the counter.

Since we’re effectively ignoring the client-type part of the id, keep
counter → client id map in private storage and use it to verify that
id we were given is the one we know about.

Furthermore, rather than storing client information in a map keep it
in a vector which is more compact and faster to index.  At the same
time, keep just a single vector for all per-client data rather than
having separate maps for each piece of information.

Issue: https://github.com/ComposableFi/emulated-light-client/issues/35
