### PR TITLE
solana-ibc: introduce Serialised wrapper in storage

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -544,11 +544,8 @@ impl IbcStorage<'_, '_> {
         let store = self.borrow();
         let mut range = store.private.consensus_states.range(range);
         if dir == Direction::Next { range.next() } else { range.next_back() }
-            .map(|(_, data)| borsh::BorshDeserialize::try_from_slice(data))
+            .map(|(_, data)| data.get())
             .transpose()
-            .map_err(|err| err.to_string())
-            .map_err(|description| {
-                ContextError::from(ClientError::ClientSpecific { description })
-            })
+            .map_err(|err| err.into())
     }
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -386,7 +386,7 @@ impl storage::IbcStorageInner<'_, '_> {
         self.provable
             .set(trie_key, &serialised.digest())
             .map_err(|e| ClientError::Other { description: e.to_string() })?;
-        get_map(&mut self.private).insert(key, serialised);
+        get_map(self.private).insert(key, serialised);
         Ok(())
     }
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -19,8 +19,6 @@ const TRIE_SEED: &[u8] = b"trie";
 const CONNECTION_ID_PREFIX: &str = "connection-";
 const CHANNEL_ID_PREFIX: &str = "channel-";
 
-use crate::storage::IBCPackets;
-
 declare_id!("EnfDJsAK7BGgetnmKzBx86CsgC5kfSPcsktFCQ4YLC81");
 
 mod chain;
@@ -122,7 +120,7 @@ pub mod solana_ibc {
         let private: &mut storage::PrivateStorage = &mut ctx.accounts.storage;
         msg!("This is private: {:?}", private);
         let provable = storage::get_provable_from(&ctx.accounts.trie, "trie")?;
-        let packets: &mut IBCPackets = &mut ctx.accounts.packets;
+        let packets = &mut ctx.accounts.packets;
         let host_head = host::Head::get()?;
 
         // Before anything else, try generating a new guest block.  However, if
@@ -227,7 +225,7 @@ pub struct Deliver<'info> {
 
     /// The account holding packets.
     #[account(init_if_needed, payer = sender, seeds = [PACKET_SEED], bump, space = 1000)]
-    packets: Account<'info, IBCPackets>,
+    packets: Account<'info, storage::IbcPackets>,
 
     /// The guest blockchain data.
     #[account(init_if_needed, payer = sender, seeds = [CHAIN_SEED], bump, space = 10000)]

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -1,24 +1,31 @@
 use alloc::collections::BTreeMap;
 use alloc::rc::Rc;
-use core::cell::RefCell;
+use core::cell::{RefCell, RefMut};
 
 use anchor_lang::prelude::*;
-use ibc::core::ics02_client::height::Height;
-use ibc::core::ics04_channel::msgs::PacketMsg;
-use ibc::core::ics04_channel::packet::Sequence;
+use borsh::maybestd::io;
+use lib::hash::CryptoHash;
 
-pub(crate) type HostHeight = Height;
+use crate::client_state::AnyClientState;
+use crate::consensus_state::AnyConsensusState;
+
+mod ibc {
+    pub use ibc::core::ics02_client::error::ClientError;
+    pub use ibc::core::ics02_client::height::Height;
+    pub use ibc::core::ics03_connection::connection::ConnectionEnd;
+    pub use ibc::core::ics04_channel::channel::ChannelEnd;
+    pub use ibc::core::ics04_channel::msgs::PacketMsg;
+    pub use ibc::core::ics04_channel::packet::Sequence;
+}
+
 type Result<T, E = anchor_lang::error::Error> = core::result::Result<T, E>;
 
+pub(crate) type HostHeight = ibc::Height;
 pub(crate) type SolanaTimestamp = u64;
 pub(crate) type InnerClientId = String;
 pub(crate) type InnerConnectionId = String;
 pub(crate) type InnerPortId = String;
 pub(crate) type InnerChannelId = String;
-pub(crate) type InnerClient = Vec<u8>; // Serialized
-pub(crate) type InnerConnectionEnd = Vec<u8>; // Serialized
-pub(crate) type InnerChannelEnd = Vec<u8>; // Serialized
-pub(crate) type InnerConsensusState = Vec<u8>; // Serialized
 
 /// A triple of send, receive and acknowledge sequences.
 #[derive(
@@ -44,24 +51,24 @@ pub(crate) enum SequenceTripleIdx {
 
 impl SequenceTriple {
     /// Returns sequence at given index or `None` if it wasn’t set yet.
-    pub(crate) fn get(&self, idx: SequenceTripleIdx) -> Option<Sequence> {
+    pub(crate) fn get(&self, idx: SequenceTripleIdx) -> Option<ibc::Sequence> {
         if self.mask & (1 << (idx as u32)) == 1 {
-            Some(Sequence::from(self.sequences[idx as usize]))
+            Some(ibc::Sequence::from(self.sequences[idx as usize]))
         } else {
             None
         }
     }
 
     /// Sets sequence at given index.
-    pub(crate) fn set(&mut self, idx: SequenceTripleIdx, seq: Sequence) {
+    pub(crate) fn set(&mut self, idx: SequenceTripleIdx, seq: ibc::Sequence) {
         self.sequences[idx as usize] = u64::from(seq);
         self.mask |= 1 << (idx as u32)
     }
 
     /// Encodes the object as a `CryptoHash` so it can be stored in the trie
     /// directly.
-    pub(crate) fn to_hash(&self) -> lib::hash::CryptoHash {
-        let mut hash = lib::hash::CryptoHash::default();
+    pub(crate) fn to_hash(&self) -> CryptoHash {
+        let mut hash = CryptoHash::default();
         let (first, tail) = stdx::split_array_mut::<8, 24, 32>(&mut hash.0);
         let (second, tail) = stdx::split_array_mut::<8, 16, 24>(tail);
         let (third, tail) = stdx::split_array_mut::<8, 8, 16>(tail);
@@ -75,34 +82,36 @@ impl SequenceTriple {
 
 #[account]
 #[derive(Debug)]
-pub struct IBCPackets(pub Vec<PacketMsg>);
+pub struct IbcPackets(pub Vec<ibc::PacketMsg>);
 
 #[account]
 #[derive(Debug)]
 /// All the structs from IBC are stored as String since they dont implement
 /// AnchorSerialize and AnchorDeserialize
 pub(crate) struct PrivateStorage {
-    pub clients: BTreeMap<InnerClientId, InnerClient>,
+    pub clients: BTreeMap<InnerClientId, Serialised<AnyClientState>>,
     pub client_counter: u64,
     pub client_processed_times:
-        BTreeMap<InnerClientId, BTreeMap<Height, SolanaTimestamp>>,
+        BTreeMap<InnerClientId, BTreeMap<ibc::Height, SolanaTimestamp>>,
     pub client_processed_heights:
-        BTreeMap<InnerClientId, BTreeMap<Height, HostHeight>>,
+        BTreeMap<InnerClientId, BTreeMap<ibc::Height, HostHeight>>,
     pub consensus_states:
-        BTreeMap<(InnerClientId, Height), InnerConsensusState>,
+        BTreeMap<(InnerClientId, ibc::Height), Serialised<AnyConsensusState>>,
     pub connection_counter: u64,
-    pub connections: BTreeMap<InnerConnectionId, InnerConnectionEnd>,
-    pub channel_ends: BTreeMap<(InnerPortId, InnerChannelId), InnerChannelEnd>,
+    pub connections:
+        BTreeMap<InnerConnectionId, Serialised<ibc::ConnectionEnd>>,
+    pub channel_ends:
+        BTreeMap<(InnerPortId, InnerChannelId), Serialised<ibc::ChannelEnd>>,
     // Contains the client id corresponding to the connectionId
     pub client_to_connection: BTreeMap<InnerClientId, InnerConnectionId>,
     pub channel_counter: u64,
 
     /// The sequence numbers of the packet commitments.
     pub packet_commitment_sequence_sets:
-        BTreeMap<(InnerPortId, InnerChannelId), Vec<Sequence>>,
+        BTreeMap<(InnerPortId, InnerChannelId), Vec<ibc::Sequence>>,
     /// The sequence numbers of the packet acknowledgements.
     pub packet_acknowledgement_sequence_sets:
-        BTreeMap<(InnerPortId, InnerChannelId), Vec<Sequence>>,
+        BTreeMap<(InnerPortId, InnerChannelId), Vec<ibc::Sequence>>,
 
     /// Next send, receive and ack sequence for given (port, channel).
     ///
@@ -114,7 +123,7 @@ pub(crate) struct PrivateStorage {
 
 /// Provable storage, i.e. the trie, held in an account.
 pub type AccountTrie<'a, 'b> =
-    solana_trie::AccountTrie<core::cell::RefMut<'a, &'b mut [u8]>>;
+    solana_trie::AccountTrie<RefMut<'a, &'b mut [u8]>>;
 
 /// Checks contents of given unchecked account and returns a trie if it’s valid.
 ///
@@ -147,7 +156,7 @@ pub fn get_provable_from<'a, 'info>(
 pub(crate) struct IbcStorageInner<'a, 'b> {
     pub private: &'a mut PrivateStorage,
     pub provable: AccountTrie<'a, 'b>,
-    pub packets: &'a mut IBCPackets,
+    pub packets: &'a mut IbcPackets,
     pub host_head: crate::host::Head,
 }
 
@@ -190,9 +199,76 @@ impl<'a, 'b> IbcStorage<'a, 'b> {
     /// # Panics
     ///
     /// Panics if the value is currently borrowed.
-    pub fn borrow_mut<'c>(
-        &'c self,
-    ) -> core::cell::RefMut<'c, IbcStorageInner<'a, 'b>> {
+    pub fn borrow_mut<'c>(&'c self) -> RefMut<'c, IbcStorageInner<'a, 'b>> {
         self.0.borrow_mut()
+    }
+
+    /// Mutably borrows private and provable storage.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is currently borrowed.
+    pub fn split_borrow_mut<'s>(
+        &'s self,
+    ) -> (RefMut<'s, &'a mut PrivateStorage>, RefMut<'s, AccountTrie<'a, 'b>>)
+    {
+        RefMut::map_split(self.borrow_mut(), |this| {
+            (&mut this.private, &mut this.provable)
+        })
+    }
+}
+
+
+/// A wrapper type for a Borsh-serialised object.
+///
+/// It is kept as a slice of bytes and only deserialised on demand.  This way
+/// the value doesn’t need to be serialised/deserialised each time the account
+/// data is loaded.
+///
+/// Note that while Borsh allows dynamic arrays of up to over 4 billion
+/// elements, to further save space this object is serialised with 2-byte length
+/// prefix which means that the serialised representation of the held object
+/// must less than 64 KiB.  Solana’s heap is only half that so this limit isn’t
+/// an issue.
+#[derive(Clone, Default, Debug)]
+pub(crate) struct Serialised<T>(Vec<u8>, core::marker::PhantomData<T>);
+
+impl<T> Serialised<T> {
+    pub fn digest(&self) -> CryptoHash { CryptoHash::digest(self.0.as_slice()) }
+
+    fn make_err(err: io::Error) -> ibc::ClientError {
+        ibc::ClientError::ClientSpecific { description: err.to_string() }
+    }
+}
+
+impl<T: borsh::BorshSerialize> Serialised<T> {
+    pub fn new(value: &T) -> Result<Self, ibc::ClientError> {
+        borsh::to_vec(value)
+            .map(|data| Self(data, core::marker::PhantomData))
+            .map_err(Self::make_err)
+    }
+}
+
+impl<T: borsh::BorshDeserialize> Serialised<T> {
+    pub fn get(&self) -> Result<T, ibc::ClientError> {
+        T::try_from_slice(self.0.as_slice()).map_err(Self::make_err)
+    }
+}
+
+impl<T> borsh::BorshSerialize for Serialised<T> {
+    fn serialize<W: io::Write>(&self, wr: &mut W) -> io::Result<()> {
+        u16::try_from(self.0.len())
+            .map_err(|_| io::ErrorKind::InvalidData.into())
+            .and_then(|len| len.serialize(wr))?;
+        wr.write_all(self.0.as_slice())
+    }
+}
+
+impl<T> borsh::BorshDeserialize for Serialised<T> {
+    fn deserialize_reader<R: io::Read>(rd: &mut R) -> io::Result<Self> {
+        let len = u16::deserialize_reader(rd)?.into();
+        let mut data = vec![0; len];
+        rd.read_exact(data.as_mut_slice())?;
+        Ok(Self(data, core::marker::PhantomData))
     }
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -202,20 +202,6 @@ impl<'a, 'b> IbcStorage<'a, 'b> {
     pub fn borrow_mut<'c>(&'c self) -> RefMut<'c, IbcStorageInner<'a, 'b>> {
         self.0.borrow_mut()
     }
-
-    /// Mutably borrows private and provable storage.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is currently borrowed.
-    pub fn split_borrow_mut<'s>(
-        &'s self,
-    ) -> (RefMut<'s, &'a mut PrivateStorage>, RefMut<'s, AccountTrie<'a, 'b>>)
-    {
-        RefMut::map_split(self.borrow_mut(), |this| {
-            (&mut this.private, &mut this.provable)
-        })
-    }
 }
 
 


### PR DESCRIPTION
Rather than using untyped `Vec<u8>` for places where serialised
objects are kept in storage, introduce a `Serialised<T>` wrapper which
allows typing the stored object.
