### PR TITLE
solana-ibc: add derive_more::TryInto to AnyClientState  [trivial]

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -27,7 +27,7 @@ use ibc_proto::protobuf::Protobuf;
 use crate::consensus_state::AnyConsensusState;
 use crate::storage::IbcStorage;
 
-#[derive(Clone, Debug, PartialEq, derive_more::From)]
+#[derive(Clone, Debug, PartialEq, derive_more::From, derive_more::TryInto)]
 pub enum AnyClientState {
     Tendermint(TmClientState),
     #[cfg(any(test, feature = "mocks"))]


### PR DESCRIPTION
AnyConsensusState already has derive_more::TryInto derive; add it to
AnyClientState as well.
