### PR TITLE
solana-ibc: introduce ConnectionIdx type for connection identification

### DIFF
--- a/common/sealable-trie/src/trie/tests.rs
+++ b/common/sealable-trie/src/trie/tests.rs
@@ -13,7 +13,7 @@ fn make_trie_impl<'a>(
     want: Option<(&str, usize)>,
 ) -> TestTrie {
     let keys = keys.into_iter();
-    let count = keys.size_hint().1.unwrap_or(1000).saturating_mul(4);
+    let count = keys.size_hint().1.unwrap_or(1000).saturating_mul(4).max(100);
     let mut trie = TestTrie::new(count);
     for key in keys {
         set(&mut trie, key)

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -6,6 +6,7 @@ use ibc::core::events::IbcEvent;
 use ibc::core::ics02_client::error::ClientError;
 use ibc::core::ics02_client::ClientExecutionContext;
 use ibc::core::ics03_connection::connection::ConnectionEnd;
+use ibc::core::ics03_connection::error::ConnectionError;
 use ibc::core::ics04_channel::channel::ChannelEnd;
 use ibc::core::ics04_channel::commitment::{
     AcknowledgementCommitment, PacketCommitment,
@@ -25,7 +26,7 @@ use lib::hash::CryptoHash;
 use crate::client_state::AnyClientState;
 use crate::consensus_state::AnyConsensusState;
 use crate::storage::trie_key::TrieKey;
-use crate::storage::{self, IbcStorage};
+use crate::storage::{self, ids, IbcStorage};
 
 type Result<T = (), E = ibc::core::ContextError> = core::result::Result<T, E>;
 
@@ -150,13 +151,34 @@ impl ExecutionContext for IbcStorage<'_, '_> {
         path: &ConnectionPath,
         connection_end: ConnectionEnd,
     ) -> Result {
+        use core::cmp::Ordering;
+
         msg!("store_connection({}, {:?})", path, connection_end);
-        self.borrow_mut().store_serialised_proof(
-            |private| &mut private.connections,
-            path.0.to_string(),
-            &TrieKey::from(path),
-            &connection_end,
-        )
+        let connection = ids::ConnectionIdx::try_from(&path.0)?;
+        let serialised = storage::Serialised::new(&connection_end)?;
+        let hash = serialised.digest();
+
+        let mut store = self.borrow_mut();
+
+        let connections = &mut store.private.connections;
+        let index = usize::from(connection);
+        match index.cmp(&connections.len()) {
+            Ordering::Less => connections[index] = serialised,
+            Ordering::Equal => connections.push(serialised),
+            Ordering::Greater => {
+                return Err(ConnectionError::ConnectionNotFound {
+                    connection_id: path.0.clone(),
+                }
+                .into())
+            }
+        }
+
+        store
+            .provable
+            .set(&TrieKey::for_connection(connection), &hash)
+            .map_err(error)?;
+
+        Ok(())
     }
 
     fn store_connection_to_client(
@@ -170,16 +192,7 @@ impl ExecutionContext for IbcStorage<'_, '_> {
         Ok(())
     }
 
-    fn increase_connection_counter(&mut self) -> Result {
-        let mut store = self.borrow_mut();
-        store.private.connection_counter =
-            store.private.connection_counter.checked_add(1).unwrap();
-        msg!(
-            "connection_counter has increased to: {}",
-            store.private.connection_counter
-        );
-        Ok(())
-    }
+    fn increase_connection_counter(&mut self) -> Result { Ok(()) }
 
     fn store_packet_commitment(
         &mut self,

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -187,6 +187,7 @@ impl ExecutionContext for IbcStorage<'_, '_> {
         conn_id: ConnectionId,
     ) -> Result {
         msg!("store_connection_to_client({}, {:?})", path, conn_id);
+        let conn_id = ids::ConnectionIdx::try_from(&conn_id)?;
         self.borrow_mut().private.client_mut(&path.0, false)?.1.connection_id =
             Some(conn_id);
         Ok(())

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -14,6 +14,7 @@ use crate::consensus_state::AnyConsensusState;
 mod ibc {
     pub use ibc::core::ics02_client::error::ClientError;
     pub use ibc::core::ics03_connection::connection::ConnectionEnd;
+    pub use ibc::core::ics03_connection::error::ConnectionError;
     pub use ibc::core::ics04_channel::channel::ChannelEnd;
     pub use ibc::core::ics04_channel::msgs::PacketMsg;
     pub use ibc::core::ics04_channel::packet::Sequence;
@@ -25,7 +26,6 @@ pub(crate) mod ids;
 pub(crate) mod trie_key;
 
 pub(crate) type SolanaTimestamp = u64;
-pub(crate) type InnerConnectionId = String;
 pub(crate) type InnerPortId = String;
 pub(crate) type InnerChannelId = String;
 
@@ -118,9 +118,8 @@ pub struct IbcPackets(pub Vec<ibc::PacketMsg>);
 pub(crate) struct PrivateStorage {
     clients: Vec<ClientStore>,
 
-    pub connection_counter: u64,
-    pub connections:
-        BTreeMap<InnerConnectionId, Serialised<ibc::ConnectionEnd>>,
+    pub connections: Vec<Serialised<ibc::ConnectionEnd>>,
+
     pub channel_ends:
         BTreeMap<(InnerPortId, InnerChannelId), Serialised<ibc::ChannelEnd>>,
     pub channel_counter: u64,

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -113,11 +113,18 @@ pub struct IbcPackets(pub Vec<ibc::PacketMsg>);
 
 #[account]
 #[derive(Debug)]
-/// All the structs from IBC are stored as String since they dont implement
-/// AnchorSerialize and AnchorDeserialize
+/// The private IBC storage, i.e. data which doesn’t require proofs.
 pub(crate) struct PrivateStorage {
+    /// Per-client information.
+    ///
+    /// Entry at index `N` corresponds to the client with IBC identifier
+    /// `client-<N>`.
     clients: Vec<ClientStore>,
 
+    /// Information about the counterparty on given connection.
+    ///
+    /// Entry at index `N` corresponds to the connection with IBC identifier
+    /// `connection-<N>`.
     pub connections: Vec<Serialised<ibc::ConnectionEnd>>,
 
     pub channel_ends:

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -86,7 +86,7 @@ impl SequenceTriple {
 #[derive(Clone, Debug, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub(crate) struct ClientStore {
     pub client_id: ibc::ClientId,
-    pub connection_id: Option<ibc::ConnectionId>,
+    pub connection_id: Option<ids::ConnectionIdx>,
 
     pub client_state: Serialised<AnyClientState>,
     pub consensus_states: BTreeMap<ibc::Height, Serialised<AnyConsensusState>>,

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
@@ -1,3 +1,5 @@
+use anchor_lang::prelude::borsh;
+
 use super::ibc;
 
 type Result<T, E = ibc::ClientError> = core::result::Result<T, E>;
@@ -57,7 +59,17 @@ impl PartialEq<usize> for ClientIdx {
 /// The identifier is build from IBC identifiers which are of the form
 /// `connection-<number>`.  Rather than treating the identifier as a string,
 /// we’re parsing the number out and keep only that.
-#[derive(Clone, Copy, PartialEq, Eq, derive_more::From, derive_more::Into)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+    derive_more::From,
+    derive_more::Into,
+)]
 pub struct ConnectionIdx(u32);
 
 impl ConnectionIdx {


### PR DESCRIPTION
IBC connections identifiers are in the form `connection-<number>` and
use sequential numbering.  Take advantage of that by introducing
ConnectionIdx type which only holds the number and storing connection
information in a vector rather than a map.  This is analogous to
change already made for clients.

Issue: https://github.com/ComposableFi/emulated-light-client/issues/35