### PR TITLE
solana-ibc: avoid string copy when calling msg  [trivial]

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -329,7 +329,7 @@ impl ExecutionContext for IbcStorage<'_, '_> {
     }
 
     fn log_message(&mut self, message: String) -> Result {
-        msg!("{}", message);
+        msg!(message.as_str());
         Ok(())
     }
 


### PR DESCRIPTION
`msg!("{}", message)` includes a `format!` call which needs to
allocate a new string which is then logged.  `message` is already
a string thus this formatting step is wasteful.  Use single-argument
invocation of `msg!` which avoids the formatting step and logs the
string argument directly.
