### PR TITLE
solana-ibc: fix lack of client id checking and add client references

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -462,7 +462,6 @@ impl ibc::clients::ics07_tendermint::CommonContext for IbcStorage<'_, '_> {
             .borrow()
             .private
             .client(client_id)?
-            .1
             .consensus_states
             .keys()
             .copied()
@@ -540,7 +539,7 @@ impl IbcStorage<'_, '_> {
         };
 
         let store = self.borrow();
-        let (_index, client) = store.private.client(client_id)?;
+        let client = store.private.client(client_id)?;
         let mut range = client.consensus_states.range(range);
         if dir == Direction::Next { range.next() } else { range.next_back() }
             .map(|(_, data)| data.get())

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -41,9 +41,9 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
     ) -> Result {
         msg!("store_client_state({}, {:?})", path, state);
         let mut store = self.borrow_mut();
-        let (client_idx, client) = store.private.client_mut(&path.0, true)?;
+        let mut client = store.private.client_mut(&path.0, true)?;
         let hash = client.client_state.set(&state)?.digest();
-        let key = TrieKey::for_client_state(client_idx);
+        let key = TrieKey::for_client_state(client.index);
         store.provable.set(&key, &hash).map_err(error)
     }
 
@@ -55,12 +55,11 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
         msg!("store_consensus_state({}, {:?})", path, state);
         let height = Height::new(path.epoch, path.height)?;
         let mut store = self.borrow_mut();
-        let (client_idx, client) =
-            store.private.client_mut(&path.client_id, false)?;
+        let mut client = store.private.client_mut(&path.client_id, false)?;
         let serialised = storage::Serialised::new(&state)?;
         let hash = serialised.digest();
         client.consensus_states.insert(height, serialised);
-        let trie_key = TrieKey::for_consensus_state(client_idx, height);
+        let trie_key = TrieKey::for_consensus_state(client.index, height);
         store.provable.set(&trie_key, &hash).map_err(error)?;
         Ok(())
     }
@@ -72,10 +71,9 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
         msg!("delete_consensus_state({})", path);
         let height = Height::new(path.epoch, path.height)?;
         let mut store = self.borrow_mut();
-        let (client_idx, client) =
-            store.private.client_mut(&path.client_id, false)?;
+        let mut client = store.private.client_mut(&path.client_id, false)?;
         client.consensus_states.remove(&height);
-        let key = TrieKey::for_consensus_state(client_idx, height);
+        let key = TrieKey::for_consensus_state(client.index, height);
         store.provable.del(&key).map_err(error)?;
         Ok(())
     }
@@ -89,7 +87,6 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
         self.borrow_mut()
             .private
             .client_mut(&client_id, false)?
-            .1
             .processed_heights
             .remove(&height);
         Ok(())
@@ -103,7 +100,6 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
         self.borrow_mut()
             .private
             .client_mut(&client_id, false)?
-            .1
             .processed_times
             .remove(&height);
         Ok(())
@@ -119,7 +115,6 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
         self.borrow_mut()
             .private
             .client_mut(&client_id, false)?
-            .1
             .processed_times
             .insert(height, timestamp.nanoseconds());
         Ok(())
@@ -135,7 +130,6 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
         self.borrow_mut()
             .private
             .client_mut(&client_id, false)?
-            .1
             .processed_heights
             .insert(height, host_height);
         Ok(())
@@ -165,7 +159,7 @@ impl ExecutionContext for IbcStorage<'_, '_> {
         conn_id: ConnectionId,
     ) -> Result {
         msg!("store_connection_to_client({}, {:?})", path, conn_id);
-        self.borrow_mut().private.client_mut(&path.0, false)?.1.connection_id =
+        self.borrow_mut().private.client_mut(&path.0, false)?.connection_id =
             Some(conn_id);
         Ok(())
     }

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -107,6 +107,34 @@ impl ClientStore {
     }
 }
 
+/// A shared reference to a [`ClientStore`] together with its index.
+pub(crate) struct ClientRef<'a> {
+    #[allow(dead_code)]
+    pub index: ids::ClientIdx,
+    pub store: &'a ClientStore,
+}
+
+impl<'a> core::ops::Deref for ClientRef<'a> {
+    type Target = ClientStore;
+    fn deref(&self) -> &ClientStore { self.store }
+}
+
+/// An exclusive reference to a [`ClientStore`] together with its index.
+pub(crate) struct ClientMut<'a> {
+    pub index: ids::ClientIdx,
+    pub store: &'a mut ClientStore,
+}
+
+impl<'a> core::ops::Deref for ClientMut<'a> {
+    type Target = ClientStore;
+    fn deref(&self) -> &ClientStore { self.store }
+}
+
+impl<'a> core::ops::DerefMut for ClientMut<'a> {
+    fn deref_mut(&mut self) -> &mut ClientStore { self.store }
+}
+
+
 #[account]
 #[derive(Debug)]
 pub struct IbcPackets(pub Vec<ibc::PacketMsg>);
@@ -154,13 +182,13 @@ impl PrivateStorage {
     pub fn client(
         &self,
         client_id: &ibc::ClientId,
-    ) -> Result<(ids::ClientIdx, &ClientStore), ibc::ClientError> {
+    ) -> Result<ClientRef<'_>, ibc::ClientError> {
         self.client_index(client_id)
-            .and_then(|idx| {
+            .and_then(|index| {
                 self.clients
-                    .get(usize::from(idx))
-                    .filter(|state| state.client_id == *client_id)
-                    .map(|state| (idx, state))
+                    .get(usize::from(index))
+                    .filter(|store| store.client_id == *client_id)
+                    .map(|store| ClientRef { index, store })
             })
             .ok_or_else(|| ibc::ClientError::ClientStateNotFound {
                 client_id: client_id.clone(),
@@ -180,31 +208,28 @@ impl PrivateStorage {
         &mut self,
         client_id: &ibc::ClientId,
         create: bool,
-    ) -> Result<(ids::ClientIdx, &mut ClientStore), ibc::ClientError> {
-        self.client_mut_impl(client_id, create).ok_or_else(|| {
-            ibc::ClientError::ClientStateNotFound {
-                client_id: client_id.clone(),
-            }
-        })
-    }
-
-    fn client_mut_impl(
-        &mut self,
-        client_id: &ibc::ClientId,
-        create: bool,
-    ) -> Option<(ids::ClientIdx, &mut ClientStore)> {
+    ) -> Result<ClientMut<'_>, ibc::ClientError> {
         use core::cmp::Ordering;
 
-        let idx = self.client_index(client_id)?;
-        let pos = usize::from(idx);
-        match pos.cmp(&self.clients.len()) {
-            Ordering::Less => Some((idx, &mut self.clients[pos])),
-            Ordering::Equal if create => {
-                self.clients.push(ClientStore::new(client_id.clone()));
-                self.clients.last_mut().map(|client| (idx, client))
-            }
-            _ => None,
-        }
+        self.client_index(client_id)
+            .and_then(|index| {
+                let pos = usize::from(index);
+                match pos.cmp(&self.clients.len()) {
+                    Ordering::Less => self
+                        .clients
+                        .get_mut(pos)
+                        .filter(|store| store.client_id == *client_id),
+                    Ordering::Equal if create => {
+                        self.clients.push(ClientStore::new(client_id.clone()));
+                        self.clients.last_mut()
+                    }
+                    _ => None,
+                }
+                .map(|store| ClientMut { index, store })
+            })
+            .ok_or_else(|| ibc::ClientError::ClientStateNotFound {
+                client_id: client_id.clone(),
+            })
     }
 
     fn client_index(

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -39,7 +39,7 @@ impl ValidationContext for IbcStorage<'_, '_> {
         &self,
         client_id: &ClientId,
     ) -> Result<Self::AnyClientState> {
-        Ok(self.borrow().private.client(client_id)?.1.client_state.get()?)
+        Ok(self.borrow().private.client(client_id)?.client_state.get()?)
     }
 
     fn decode_client_state(
@@ -57,7 +57,6 @@ impl ValidationContext for IbcStorage<'_, '_> {
         self.borrow()
             .private
             .client(&path.client_id)?
-            .1
             .consensus_states
             .get(&height)
             .cloned()
@@ -270,7 +269,6 @@ impl ibc::core::ics02_client::ClientValidationContext for IbcStorage<'_, '_> {
         store
             .private
             .client(client_id)?
-            .1
             .processed_times
             .get(height)
             .map(|ts| Timestamp::from_nanoseconds(*ts).unwrap())
@@ -293,7 +291,6 @@ impl ibc::core::ics02_client::ClientValidationContext for IbcStorage<'_, '_> {
         self.borrow()
             .private
             .client(client_id)?
-            .1
             .processed_heights
             .get(height)
             .copied()


### PR DESCRIPTION
Firstly, and most importantly, add a missing client_id check in
PrivateStorage::client_mut method.  When getting an existing client we
must check that the client id given as argument matches the one stored
in the ClientStore.  PrivateStorage::client performed that check alas,
PrivateStorage::client_mut lacked it.  Add it as required.

Secondly, introduce ClientRef and ClientMut reference types which
replace previously used pairs.  Those type clarify some of the code by
naming the index field and simplify other code by removing the need
for `.1` to get the reference.

Issue: https://github.com/ComposableFi/emulated-light-client/issues/35
