### PR TITLE
solana-ibc: store proof of client id together with client state

### DIFF
--- a/common/lib/src/hash.rs
+++ b/common/lib/src/hash.rs
@@ -45,7 +45,7 @@ impl CryptoHash {
     #[inline]
     pub fn digest(bytes: &[u8]) -> Self { Self::digestv(&[bytes]) }
 
-    /// Returns hash of consternation of given byte slices.
+    /// Returns hash of concatenation of given byte slices.
     ///
     /// This is morally equivalent to feeding all the slices into the builder
     /// one-by-one or concatenating them into a single buffer and hashing it in

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -43,7 +43,12 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
         msg!("store_client_state({}, {:?})", path, state);
         let mut store = self.borrow_mut();
         let mut client = store.private.client_mut(&path.0, true)?;
-        let hash = client.client_state.set(&state)?.digest();
+        let serialised = client.client_state.set(&state)?;
+        let hash = CryptoHash::digestv(&[
+            path.0.as_bytes(),
+            &[0],
+            serialised.as_bytes(),
+        ]);
         let key = TrieKey::for_client_state(client.index);
         store.provable.set(&key, &hash).map_err(error)
     }

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -350,6 +350,8 @@ pub(crate) struct Serialised<T>(Vec<u8>, core::marker::PhantomData<T>);
 impl<T> Serialised<T> {
     pub fn empty() -> Self { Self(Vec::new(), core::marker::PhantomData) }
 
+    pub fn as_bytes(&self) -> &[u8] { self.0.as_slice() }
+
     pub fn digest(&self) -> CryptoHash { CryptoHash::digest(self.0.as_slice()) }
 
     fn make_err(err: io::Error) -> ibc::ClientError {

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
@@ -70,7 +70,7 @@ impl TrieKey {
     /// Constructs a new key for a consensus state path for client with given
     /// counter and specified height.
     ///
-    /// The hsah stored under the key is `hash(borsh(consensus_state))`.
+    /// The hash stored under the key is `hash(borsh(consensus_state))`.
     pub fn for_consensus_state(
         client: ids::ClientIdx,
         height: ibc::Height,

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
@@ -80,7 +80,7 @@ impl TrieKey {
 
     /// Constructs a new key for a connection end path.
     ///
-    /// The hsah stored under the key is `hash(borsh(connection_end))`.
+    /// The hash stored under the key is `hash(borsh(connection_end))`.
     pub fn for_connection(connection: ids::ConnectionIdx) -> Self {
         new_key_impl!(Tag::Connection, connection)
     }

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
@@ -60,12 +60,17 @@ macro_rules! new_key_impl {
 impl TrieKey {
     /// Constructs a new key for a client state path for client with given
     /// counter.
+    ///
+    /// The hash stored under the key is `hash(borsh(client_id.as_str()) ||
+    /// borsh(client_state))`.
     pub fn for_client_state(client: ids::ClientIdx) -> Self {
         new_key_impl!(Tag::ClientState, client)
     }
 
     /// Constructs a new key for a consensus state path for client with given
     /// counter and specified height.
+    ///
+    /// The hsah stored under the key is `hash(borsh(consensus_state))`.
     pub fn for_consensus_state(
         client: ids::ClientIdx,
         height: ibc::Height,
@@ -74,6 +79,8 @@ impl TrieKey {
     }
 
     /// Constructs a new key for a connection end path.
+    ///
+    /// The hsah stored under the key is `hash(borsh(connection_end))`.
     pub fn for_connection(connection: ids::ConnectionIdx) -> Self {
         new_key_impl!(Tag::Connection, connection)
     }


### PR DESCRIPTION
As we parse client ids we strip out the client type.  This means
that ‘foo-42’ and ‘bar-42’ are internally represented as 42.  To
avoid confusion, we keep the client ids in private storage and
whenever we index client data by the number we check that the
full client id matches.

However, that information isn’t currently available in provable
storage (i.e. it’s not verifiable by light clients).

Change hash we’re storing under client state path to include the
client id.  This way, light clients will be able to verify that
indexes they’re extracting from the client id match the client id
they are given.

Issue: https://github.com/ComposableFi/emulated-light-client/issues/35
