### PR TITLE
solana-ibc: introduce ChannelIdx type for channel identification

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -16,9 +16,13 @@ mod ibc {
     pub use ibc::core::ics03_connection::connection::ConnectionEnd;
     pub use ibc::core::ics03_connection::error::ConnectionError;
     pub use ibc::core::ics04_channel::channel::ChannelEnd;
+    pub use ibc::core::ics04_channel::error::ChannelError;
     pub use ibc::core::ics04_channel::msgs::PacketMsg;
     pub use ibc::core::ics04_channel::packet::Sequence;
-    pub use ibc::core::ics24_host::identifier::{ClientId, ConnectionId};
+    pub use ibc::core::ics24_host::identifier::{
+        ChannelId, ClientId, ConnectionId, PortId,
+    };
+    pub use ibc::core::ics24_host::path;
     pub use ibc::Height;
 }
 
@@ -26,8 +30,6 @@ pub(crate) mod ids;
 pub(crate) mod trie_key;
 
 pub(crate) type SolanaTimestamp = u64;
-pub(crate) type InnerPortId = String;
-pub(crate) type InnerChannelId = String;
 
 /// A triple of send, receive and acknowledge sequences.
 #[derive(
@@ -155,23 +157,15 @@ pub(crate) struct PrivateStorage {
     /// `connection-<N>`.
     pub connections: Vec<Serialised<ibc::ConnectionEnd>>,
 
-    pub channel_ends:
-        BTreeMap<(InnerPortId, InnerChannelId), Serialised<ibc::ChannelEnd>>,
-    pub channel_counter: u64,
-
-    /// The sequence numbers of the packet commitments.
-    pub packet_commitment_sequence_sets:
-        BTreeMap<(InnerPortId, InnerChannelId), Vec<ibc::Sequence>>,
-    /// The sequence numbers of the packet acknowledgements.
-    pub packet_acknowledgement_sequence_sets:
-        BTreeMap<(InnerPortId, InnerChannelId), Vec<ibc::Sequence>>,
+    pub channel_ends: BTreeMap<ids::PortChannelPK, Serialised<ibc::ChannelEnd>>,
+    pub channel_counter: u32,
 
     /// Next send, receive and ack sequence for given (port, channel).
     ///
     /// We’re storing all three sequences in a single object to reduce amount of
     /// different maps we need to maintain.  This saves us on the amount of
     /// trie nodes we need to maintain.
-    pub next_sequence: BTreeMap<(InnerPortId, InnerChannelId), SequenceTriple>,
+    pub next_sequence: BTreeMap<ids::PortChannelPK, SequenceTriple>,
 }
 
 impl PrivateStorage {

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
@@ -5,14 +5,6 @@ use super::ibc;
 type Result<T, E = ibc::ClientError> = core::result::Result<T, E>;
 
 
-/// Prefix of IBC channel ids.
-///
-/// Note: We’re not using ChannelId::prefix() because it returns the prefix
-/// without trailing `-` which we want included to simplify stripping of the
-/// prefix.
-pub(super) const CHANNEL_ID_PREFIX: &str = "channel-";
-
-
 /// An index used as unique identifier for a client.
 ///
 /// IBC client id uses `<client-type>-<counter>` format.  This index is
@@ -110,6 +102,71 @@ impl TryFrom<&ibc::ConnectionId> for ConnectionIdx {
             }),
         }
     }
+}
+
+
+/// An internal port-channel identifier; that is, it combines IBC port and
+/// channel identifier into a single primary key type.
+///
+/// Currently port identifier is represented as a string.
+///
+/// Meanwhile, the channel identifier is build from IBC identifiers which are of
+/// the form `channel-<number>`.  Rather than treating the identifier as
+/// a string, we’re parsing the number out and keep only that.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+)]
+pub struct PortChannelPK {
+    pub(super) port_id: ibc::PortId,
+    pub(super) channel_idx: u32,
+}
+
+impl PortChannelPK {
+    /// Prefix of IBC channel ids.
+    ///
+    /// Note: We’re not using ChannelId::prefix() because it returns the
+    /// prefix without trailing `-` which we want included to simplify stripping
+    /// of the prefix.
+    const CHANNEL_IBC_PREFIX: &'static str = "channel-";
+
+    pub fn try_from(
+        port_id: impl MaybeOwned<ibc::PortId>,
+        channel_id: impl MaybeOwned<ibc::ChannelId>,
+    ) -> Result<Self, ibc::ChannelError> {
+        let channel_str = channel_id.as_ref().as_str();
+        match parse_sans_prefix(Self::CHANNEL_IBC_PREFIX, channel_str) {
+            Some(channel_idx) => {
+                Ok(Self { port_id: port_id.into_owned(), channel_idx })
+            }
+            None => Err(ibc::ChannelError::ChannelNotFound {
+                port_id: port_id.into_owned(),
+                channel_id: channel_id.into_owned(),
+            }),
+        }
+    }
+}
+
+pub trait MaybeOwned<T> {
+    fn as_ref(&self) -> &T;
+    fn into_owned(self) -> T;
+}
+
+impl<T: Clone> MaybeOwned<T> for &T {
+    fn as_ref(&self) -> &T { *self }
+    fn into_owned(self) -> T { (*self).clone() }
+}
+
+impl<T> MaybeOwned<T> for T {
+    fn as_ref(&self) -> &T { self }
+    fn into_owned(self) -> T { self }
 }
 
 

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
@@ -160,7 +160,7 @@ pub trait MaybeOwned<T> {
 }
 
 impl<T: Clone> MaybeOwned<T> for &T {
-    fn as_ref(&self) -> &T { *self }
+    fn as_ref(&self) -> &T { self }
     fn into_owned(self) -> T { (*self).clone() }
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
@@ -1,7 +1,6 @@
-use ibc::path::{
+use crate::storage::ibc::path::{
     AckPath, CommitmentPath, ReceiptPath, SeqAckPath, SeqRecvPath, SeqSendPath,
 };
-
 use crate::storage::{ibc, ids};
 
 
@@ -229,13 +228,13 @@ impl AsComponent for ids::PortChannelPK {
     fn key_len(&self) -> usize {
         let port_id_len = self.port_id.as_bytes().len();
         assert!(port_id_len <= usize::from(u8::MAX));
-        1 + port_id_len + u32::from(self.channel_idx).key_len()
+        1 + port_id_len + self.channel_idx.key_len()
     }
     fn append_into(&self, dest: &mut Vec<u8>) {
         let port_id = self.port_id.as_bytes();
         dest.push(port_id.len() as u8);
         dest.extend(port_id);
-        u32::from(self.channel_idx).append_into(dest);
+        self.channel_idx.append_into(dest);
     }
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -127,59 +127,58 @@ impl ValidationContext for IbcStorage<'_, '_> {
         })
     }
 
-    fn channel_end(
-        &self,
-        channel_end_path: &ChannelEndPath,
-    ) -> Result<ChannelEnd> {
-        let key =
-            (channel_end_path.0.to_string(), channel_end_path.1.to_string());
+    fn channel_end(&self, path: &ChannelEndPath) -> Result<ChannelEnd> {
+        let key = ids::PortChannelPK::try_from(&path.0, &path.1)?;
         self.borrow()
             .private
             .channel_ends
             .get(&key)
             .ok_or_else(|| ChannelError::ChannelNotFound {
-                port_id: channel_end_path.0.clone(),
-                channel_id: channel_end_path.1.clone(),
+                port_id: path.0.clone(),
+                channel_id: path.1.clone(),
             })?
             .get()
             .map_err(Into::into)
     }
 
     fn get_next_sequence_send(&self, path: &SeqSendPath) -> Result<Sequence> {
-        self.get_next_sequence(path.into(), storage::SequenceTripleIdx::Send)
-            .map_err(|(port_id, channel_id)| {
-                ContextError::PacketError(PacketError::MissingNextSendSeq {
-                    port_id,
-                    channel_id,
-                })
-            })
+        self.get_next_sequence(
+            path,
+            storage::SequenceTripleIdx::Send,
+            |port_id, channel_id| PacketError::MissingNextSendSeq {
+                port_id,
+                channel_id,
+            },
+        )
     }
 
     fn get_next_sequence_recv(&self, path: &SeqRecvPath) -> Result<Sequence> {
-        self.get_next_sequence(path.into(), storage::SequenceTripleIdx::Recv)
-            .map_err(|(port_id, channel_id)| {
-                ContextError::PacketError(PacketError::MissingNextRecvSeq {
-                    port_id,
-                    channel_id,
-                })
-            })
+        self.get_next_sequence(
+            path,
+            storage::SequenceTripleIdx::Recv,
+            |port_id, channel_id| PacketError::MissingNextRecvSeq {
+                port_id,
+                channel_id,
+            },
+        )
     }
 
     fn get_next_sequence_ack(&self, path: &SeqAckPath) -> Result<Sequence> {
-        self.get_next_sequence(path.into(), storage::SequenceTripleIdx::Ack)
-            .map_err(|(port_id, channel_id)| {
-                ContextError::PacketError(PacketError::MissingNextAckSeq {
-                    port_id,
-                    channel_id,
-                })
-            })
+        self.get_next_sequence(
+            path,
+            storage::SequenceTripleIdx::Ack,
+            |port_id, channel_id| PacketError::MissingNextAckSeq {
+                port_id,
+                channel_id,
+            },
+        )
     }
 
     fn get_packet_commitment(
         &self,
         path: &CommitmentPath,
     ) -> Result<PacketCommitment> {
-        let trie_key = TrieKey::from(path);
+        let trie_key = TrieKey::try_from(path)?;
         match self.borrow().provable.get(&trie_key).ok().flatten() {
             Some(hash) => Ok(hash.as_slice().to_vec().into()),
             None => Err(ContextError::PacketError(
@@ -189,7 +188,7 @@ impl ValidationContext for IbcStorage<'_, '_> {
     }
 
     fn get_packet_receipt(&self, path: &ReceiptPath) -> Result<Receipt> {
-        let trie_key = TrieKey::from(path);
+        let trie_key = TrieKey::try_from(path)?;
         match self.borrow().provable.get(&trie_key).ok().flatten() {
             Some(hash) if hash == CryptoHash::DEFAULT => Ok(Receipt::Ok),
             _ => Err(ContextError::PacketError(
@@ -202,7 +201,7 @@ impl ValidationContext for IbcStorage<'_, '_> {
         &self,
         path: &AckPath,
     ) -> Result<AcknowledgementCommitment> {
-        let trie_key = TrieKey::from(path);
+        let trie_key = TrieKey::try_from(path)?;
         match self.borrow().provable.get(&trie_key).ok().flatten() {
             Some(hash) => Ok(hash.as_slice().to_vec().into()),
             None => Err(ContextError::PacketError(
@@ -214,8 +213,7 @@ impl ValidationContext for IbcStorage<'_, '_> {
     }
 
     fn channel_counter(&self) -> Result<u64> {
-        let store = self.borrow();
-        Ok(store.private.channel_counter)
+        Ok(u64::from(self.borrow().private.channel_counter))
     }
 
     fn max_expected_time_per_block(&self) -> Duration {
@@ -309,24 +307,34 @@ impl ibc::core::ics02_client::ClientValidationContext for IbcStorage<'_, '_> {
 }
 
 impl IbcStorage<'_, '_> {
-    fn get_next_sequence(
+    fn get_next_sequence<'a>(
         &self,
-        path: crate::storage::trie_key::SequencePath<'_>,
+        path: impl Into<storage::trie_key::SequencePath<'a>>,
         index: storage::SequenceTripleIdx,
-    ) -> core::result::Result<
-        Sequence,
-        (
+        make_err: impl FnOnce(
             ibc::core::ics24_host::identifier::PortId,
             ibc::core::ics24_host::identifier::ChannelId,
-        ),
-    > {
-        let store = self.borrow();
-        store
-            .private
-            .next_sequence
-            .get(&(path.port_id.to_string(), path.channel_id.to_string()))
-            .and_then(|triple| triple.get(index))
-            .ok_or_else(|| (path.port_id.clone(), path.channel_id.clone()))
+        ) -> PacketError,
+    ) -> Result<Sequence> {
+        fn get(
+            this: &IbcStorage<'_, '_>,
+            port_channel: &ids::PortChannelPK,
+            index: storage::SequenceTripleIdx,
+        ) -> Option<Sequence> {
+            this.borrow()
+                .private
+                .next_sequence
+                .get(&port_channel)
+                .and_then(|triple| triple.get(index))
+        }
+
+        let path = path.into();
+        let key = ids::PortChannelPK::try_from(path.port_id, path.channel_id)?;
+        get(self, &key, index)
+            .ok_or_else(|| {
+                make_err(path.port_id.clone(), path.channel_id.clone())
+            })
+            .map_err(ContextError::from)
     }
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -324,7 +324,7 @@ impl IbcStorage<'_, '_> {
             this.borrow()
                 .private
                 .next_sequence
-                .get(&port_channel)
+                .get(port_channel)
                 .and_then(|triple| triple.get(index))
         }
 


### PR DESCRIPTION
Analogous to ConnectionIdx for connection identifiers, introduce
ChannelIdx type which represents a channel identifier.  It takes
advantage of our channels using `channel-<number>` format and
allows to store channel identifiers in more efficient way.

Issue: https://github.com/ComposableFi/emulated-light-client/issues/35
