### PR TITLE
solana-ibc: introduce TryFrom conversion into Vec for Slice and Owned

### DIFF
--- a/common/sealable-trie/src/trie/del.rs
+++ b/common/sealable-trie/src/trie/del.rs
@@ -140,8 +140,8 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
                 Action::Ext(bits::Slice::from(key).into(), child)
             }
             Action::Ext(suffix, child) => {
-                let key = bits::Owned::concat(key.into(), suffix).unwrap();
-                Action::Ext(key, child)
+                let key = bits::Owned::concat(key.into(), suffix.as_slice());
+                Action::Ext(key.unwrap(), child)
             }
         })
     }


### PR DESCRIPTION
In addition to providing fallible conversion from bit slice to a Vec,
reword Owned::concat method so it works on slices.  All of those
changes as well as Default implementation for both types will be
needed in upcoming change for subtrie iteration.
