### PR TITLE
make attributes of portChanelPk struct public

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::borsh;
+use ::ibc::core::ics24_host::identifier::ChannelId;
 
 use super::ibc;
 
@@ -125,8 +126,8 @@ impl TryFrom<&ibc::ConnectionId> for ConnectionIdx {
     borsh::BorshDeserialize,
 )]
 pub struct PortChannelPK {
-    pub port_id: ibc::PortId,
-    pub channel_idx: u32,
+    pub(super) port_id: ibc::PortId,
+    pub(super) channel_idx: u32,
 }
 
 impl PortChannelPK {
@@ -151,6 +152,14 @@ impl PortChannelPK {
                 channel_id: channel_id.into_owned(),
             }),
         }
+    }
+
+    pub fn channel_id(&self) -> ibc::ChannelId {
+        ChannelId::new(self.channel_idx.into())
+    }
+
+    pub fn port_id(&self) -> ibc::PortId {
+        self.port_id.clone()
     }
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
@@ -1,5 +1,5 @@
-use anchor_lang::prelude::borsh;
 use ::ibc::core::ics24_host::identifier::ChannelId;
+use anchor_lang::prelude::borsh;
 
 use super::ibc;
 
@@ -158,9 +158,7 @@ impl PortChannelPK {
         ChannelId::new(self.channel_idx.into())
     }
 
-    pub fn port_id(&self) -> ibc::PortId {
-        self.port_id.clone()
-    }
+    pub fn port_id(&self) -> ibc::PortId { self.port_id.clone() }
 }
 
 pub trait MaybeOwned<T> {

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
@@ -125,8 +125,8 @@ impl TryFrom<&ibc::ConnectionId> for ConnectionIdx {
     borsh::BorshDeserialize,
 )]
 pub struct PortChannelPK {
-    pub(super) port_id: ibc::PortId,
-    pub(super) channel_idx: u32,
+    pub port_id: ibc::PortId,
+    pub channel_idx: u32,
 }
 
 impl PortChannelPK {

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/ids.rs
@@ -1,4 +1,3 @@
-use ::ibc::core::ics24_host::identifier::ChannelId;
 use anchor_lang::prelude::borsh;
 
 use super::ibc;
@@ -154,11 +153,11 @@ impl PortChannelPK {
         }
     }
 
-    pub fn channel_id(&self) -> ibc::ChannelId {
-        ChannelId::new(self.channel_idx.into())
-    }
-
     pub fn port_id(&self) -> ibc::PortId { self.port_id.clone() }
+
+    pub fn channel_id(&self) -> ibc::ChannelId {
+        ibc::ChannelId::new(self.channel_idx.into())
+    }
 }
 
 pub trait MaybeOwned<T> {


### PR DESCRIPTION
Making them public so that the `channel_id` and `port_id` can be accessed. 

Should we add getter method or making them public is fine?