### PR TITLE
solana-ibc: update for_client_state documentation

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -44,9 +44,10 @@ impl ClientExecutionContext for IbcStorage<'_, '_> {
         let mut store = self.borrow_mut();
         let mut client = store.private.client_mut(&path.0, true)?;
         let serialised = client.client_state.set(&state)?;
+        let client_id = path.0.as_bytes();
         let hash = CryptoHash::digestv(&[
-            path.0.as_bytes(),
-            &[0],
+            &(client_id.len() as u32).to_le_bytes()[..],
+            client_id,
             serialised.as_bytes(),
         ]);
         let key = TrieKey::for_client_state(client.index);

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
@@ -58,8 +58,8 @@ impl TrieKey {
     /// Constructs a new key for a client state path for client with given
     /// counter.
     ///
-    /// The hash stored under the key is `hash(borsh(client_id.as_str()) ||
-    /// borsh(client_state))`.
+    /// The hash stored under the key is `hash(borsh((client_id.as_str(),
+    /// client_state)))`.
     pub fn for_client_state(client: ids::ClientIdx) -> Self {
         new_key_impl!(Tag::ClientState, client)
     }


### PR DESCRIPTION
Documentation of the for_client_state method disagreed with the
code. Update it to reflect reality.  While at it update what’s hashed
to match borsh serialisation.
