### PR TITLE
solana-ibc: limit the maximum length of the TrieKey; use on-stack buffer

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
@@ -48,7 +48,7 @@ impl TrieKey {
     /// The hash stored under the key is `hash(borsh(client_id.as_str()) ||
     /// borsh(client_state))`.
     pub fn for_client_state(client: ids::ClientIdx) -> Self {
-        Self::new(Tag::ClientState, client)
+        Self::new(Tag::ClientState, u32::from(client))
     }
 
     /// Constructs a new key for a consensus state path for client with given
@@ -59,14 +59,14 @@ impl TrieKey {
         client: ids::ClientIdx,
         height: ibc::Height,
     ) -> Self {
-        Self::new(Tag::ConsensusState, (client, height))
+        Self::new(Tag::ConsensusState, (u32::from(client), height))
     }
 
     /// Constructs a new key for a connection end path.
     ///
     /// The hash stored under the key is `hash(borsh(connection_end))`.
     pub fn for_connection(connection: ids::ConnectionIdx) -> Self {
-        Self::new(Tag::Connection, connection)
+        Self::new(Tag::Connection, u32::from(connection))
     }
 
     /// Constructs a new key for a channel end path.
@@ -105,7 +105,7 @@ impl TrieKey {
         sequence: ibc::Sequence,
     ) -> Result<Self, ibc::ChannelError> {
         let port_channel = ids::PortChannelPK::try_from(port_id, channel_id)?;
-        Ok(Self::new(tag, (port_channel, sequence)))
+        Ok(Self::new(tag, (port_channel, u64::from(sequence))))
     }
 
     /// Constructs a new key with given tag and key component.
@@ -222,18 +222,6 @@ trait AsComponent {
     fn append_into(&self, dest: &mut TrieKey);
 }
 
-impl AsComponent for ids::ClientIdx {
-    fn append_into(&self, dest: &mut TrieKey) {
-        u32::from(*self).append_into(dest);
-    }
-}
-
-impl AsComponent for ids::ConnectionIdx {
-    fn append_into(&self, dest: &mut TrieKey) {
-        u32::from(*self).append_into(dest);
-    }
-}
-
 impl AsComponent for ids::PortChannelPK {
     fn append_into(&self, dest: &mut TrieKey) {
         self.port_key.as_bytes().append_into(dest);
@@ -243,14 +231,7 @@ impl AsComponent for ids::PortChannelPK {
 
 impl AsComponent for ibc::Height {
     fn append_into(&self, dest: &mut TrieKey) {
-        self.revision_number().append_into(dest);
-        self.revision_height().append_into(dest);
-    }
-}
-
-impl AsComponent for ibc::Sequence {
-    fn append_into(&self, dest: &mut TrieKey) {
-        u64::from(*self).append_into(dest);
+        (self.revision_number(), self.revision_height()).append_into(dest);
     }
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/trie_key.rs
@@ -29,29 +29,16 @@ use crate::storage::{ibc, ids};
 /// consecutive keys (i.e. sequence 10 is immediately followed by 11 which would
 /// not be the case in little-endian encoding).  This is also one reason why we
 /// don’t just use Borsh encoding.
-// TODO(mina86): Look into using lib::varint::Buffer or some kind of small vec
-// to avoid heap allocations.
-pub struct TrieKey(Vec<u8>);
+pub struct TrieKey {
+    // tag (1) + port_id (9) + channel_id (4) + sequence (8) = max 22 bytes
+    bytes: [u8; 22],
+    len: u8,
+}
 
 /// A path for next send, receive and ack sequence paths.
 pub struct SequencePath<'a> {
     pub port_id: &'a ibc::PortId,
     pub channel_id: &'a ibc::ChannelId,
-}
-
-/// Constructs a new [`TrieKey`] by concatenating key components.
-///
-/// The first argument to the macro is a [`Tag`] object.  Remaining must
-/// implement [`AsComponent`].
-macro_rules! new_key_impl {
-    ($tag:expr $(, $component:expr)*) => {{
-        let len = 1 $(+ $component.key_len())*;
-        let mut key = Vec::with_capacity(len);
-        key.push(Tag::from($tag) as u8);
-        $($component.append_into(&mut key);)*
-        debug_assert_eq!(len, key.len());
-        TrieKey(key)
-    }}
 }
 
 impl TrieKey {
@@ -61,7 +48,7 @@ impl TrieKey {
     /// The hash stored under the key is `hash(borsh(client_id.as_str()) ||
     /// borsh(client_state))`.
     pub fn for_client_state(client: ids::ClientIdx) -> Self {
-        new_key_impl!(Tag::ClientState, client)
+        Self::new(Tag::ClientState, client)
     }
 
     /// Constructs a new key for a consensus state path for client with given
@@ -72,14 +59,14 @@ impl TrieKey {
         client: ids::ClientIdx,
         height: ibc::Height,
     ) -> Self {
-        new_key_impl!(Tag::ConsensusState, client, height)
+        Self::new(Tag::ConsensusState, (client, height))
     }
 
     /// Constructs a new key for a connection end path.
     ///
     /// The hash stored under the key is `hash(borsh(connection_end))`.
     pub fn for_connection(connection: ids::ConnectionIdx) -> Self {
-        new_key_impl!(Tag::Connection, connection)
+        Self::new(Tag::Connection, connection)
     }
 
     /// Constructs a new key for a channel end path.
@@ -102,7 +89,7 @@ impl TrieKey {
     /// This is internal method used by other public-facing methods which use
     /// only (port, channel) tuple as the key component.
     fn for_channel_path(tag: Tag, port_channel: &ids::PortChannelPK) -> Self {
-        new_key_impl!(tag, port_channel)
+        Self::new(tag, port_channel)
     }
 
     /// Constructs a new key for a `(port_id, channel_id, sequence)` path.
@@ -118,13 +105,32 @@ impl TrieKey {
         sequence: ibc::Sequence,
     ) -> Result<Self, ibc::ChannelError> {
         let port_channel = ids::PortChannelPK::try_from(port_id, channel_id)?;
-        Ok(new_key_impl!(tag, port_channel, sequence))
+        Ok(Self::new(tag, (port_channel, sequence)))
+    }
+
+    /// Constructs a new key with given tag and key component.
+    ///
+    /// For keys consisting of a multiple components, a tuple component can be
+    /// used.
+    fn new(tag: Tag, component: impl AsComponent) -> Self {
+        let mut key = TrieKey { bytes: [0; 22], len: 1 };
+        key.bytes[0] = tag.into();
+        component.append_into(&mut key);
+        key
+    }
+
+    /// Internal function to append bytes into the internal buffer.
+    fn extend(&mut self, bytes: &[u8]) {
+        let start = usize::from(self.len);
+        let end = start + bytes.len();
+        self.bytes[start..end].copy_from_slice(bytes);
+        self.len = end as u8;
     }
 }
 
 impl core::ops::Deref for TrieKey {
     type Target = [u8];
-    fn deref(&self) -> &[u8] { self.0.as_slice() }
+    fn deref(&self) -> &[u8] { &self.bytes[..usize::from(self.len)] }
 }
 
 impl<'a> From<&'a SeqSendPath> for SequencePath<'a> {
@@ -204,67 +210,73 @@ enum Tag {
     Ack = 8,
 }
 
+impl From<Tag> for u8 {
+    fn from(tag: Tag) -> u8 { tag as u8 }
+}
+
 /// Component of a [`TrieKey`].
 ///
 /// A `TrieKey` is constructed by concatenating a sequence of components.
 trait AsComponent {
-    /// Returns length of the raw representation of the component.
-    fn key_len(&self) -> usize;
-
-    /// Appends the component into a vector.
-    fn append_into(&self, dest: &mut Vec<u8>);
+    /// Appends the component into the trie key.
+    fn append_into(&self, dest: &mut TrieKey);
 }
 
-/// Implements [`AsComponent`] for types which are `Copy` and `Into<T>` for type
-/// `T` which implements `AsComponent`.
-macro_rules! cast_component {
-    ($component:ty as $ty:ty) => {
-        impl AsComponent for $component {
-            fn key_len(&self) -> usize { <$ty>::from(*self).key_len() }
-            fn append_into(&self, dest: &mut Vec<u8>) {
-                <$ty>::from(*self).append_into(dest)
-            }
-        }
-    };
+impl AsComponent for ids::ClientIdx {
+    fn append_into(&self, dest: &mut TrieKey) {
+        u32::from(*self).append_into(dest);
+    }
 }
 
-cast_component!(ids::ClientIdx as u32);
-cast_component!(ids::ConnectionIdx as u32);
-cast_component!(ibc::Sequence as u64);
+impl AsComponent for ids::ConnectionIdx {
+    fn append_into(&self, dest: &mut TrieKey) {
+        u32::from(*self).append_into(dest);
+    }
+}
 
 impl AsComponent for ids::PortChannelPK {
-    fn key_len(&self) -> usize {
-        self.port_key.as_bytes().len() + self.channel_idx.key_len()
-    }
-    fn append_into(&self, dest: &mut Vec<u8>) {
+    fn append_into(&self, dest: &mut TrieKey) {
         self.port_key.as_bytes().append_into(dest);
         self.channel_idx.append_into(dest);
     }
 }
 
 impl AsComponent for ibc::Height {
-    fn key_len(&self) -> usize { 2 * 0_u64.key_len() }
-    fn append_into(&self, dest: &mut Vec<u8>) {
+    fn append_into(&self, dest: &mut TrieKey) {
         self.revision_number().append_into(dest);
         self.revision_height().append_into(dest);
     }
 }
 
+impl AsComponent for ibc::Sequence {
+    fn append_into(&self, dest: &mut TrieKey) {
+        u64::from(*self).append_into(dest);
+    }
+}
+
 impl AsComponent for u32 {
-    fn key_len(&self) -> usize { core::mem::size_of_val(self) }
-    fn append_into(&self, dest: &mut Vec<u8>) {
+    fn append_into(&self, dest: &mut TrieKey) {
         self.to_be_bytes().append_into(dest)
     }
 }
 
 impl AsComponent for u64 {
-    fn key_len(&self) -> usize { core::mem::size_of_val(self) }
-    fn append_into(&self, dest: &mut Vec<u8>) {
+    fn append_into(&self, dest: &mut TrieKey) {
         self.to_be_bytes().append_into(dest)
     }
 }
 
 impl<const N: usize> AsComponent for [u8; N] {
-    fn key_len(&self) -> usize { N }
-    fn append_into(&self, dest: &mut Vec<u8>) { dest.extend_from_slice(self) }
+    fn append_into(&self, dest: &mut TrieKey) { dest.extend(self); }
+}
+
+impl<T: AsComponent> AsComponent for &T {
+    fn append_into(&self, dest: &mut TrieKey) { (*self).append_into(dest) }
+}
+
+impl<T: AsComponent, U: AsComponent> AsComponent for (T, U) {
+    fn append_into(&self, dest: &mut TrieKey) {
+        self.0.append_into(dest);
+        self.1.append_into(dest);
+    }
 }


### PR DESCRIPTION
Instead of using a Vec to store the TrieKey, limit the maximum length
of the TrieKey and store the value within the structure itself.  Since
we know all possible keys and each key component is fixed-size, we can
easily deduce the longest possible key.  Turns out it’s 22.  That’s
a reasonable size of a buffer to keep within the TrieKey instead of
doing a heap allocation with a Vec.
