### PR TITLE
sealable-trie: introduce U3 type and use it for offset

### DIFF
--- a/common/blockchain/src/candidates.rs
+++ b/common/blockchain/src/candidates.rs
@@ -170,7 +170,7 @@ impl<PK: crate::PubKey> Candidates<PK> {
     ) -> Result<(), UpdateCandidateError> {
         let pos = self.candidates.iter().position(|el| &el.pubkey == pubkey);
         if let Some(pos) = pos {
-            if self.candidates.len() <= cfg.min_validators.get().into() {
+            if self.candidates.len() <= usize::from(cfg.min_validators.get()) {
                 return Err(UpdateCandidateError::NotEnoughValidators);
             }
             self.update_stake_for_remove(cfg, pos)?;

--- a/common/blockchain/src/candidates/tests.rs
+++ b/common/blockchain/src/candidates/tests.rs
@@ -240,7 +240,7 @@ impl TestCtx {
     fn check(&self) {
         assert!(
             self.candidates.candidates.len() >=
-                self.config.min_validators.get().into(),
+                usize::from(self.config.min_validators.get()),
             "Violated min validators constraint: {} < {}",
             self.candidates.candidates.len(),
             self.config.min_validators.get(),
@@ -287,7 +287,7 @@ impl TestCtx {
                 NotEnoughValidators => {
                     assert!(
                         self.candidates.candidates.len() <=
-                            self.config.min_validators.get().into()
+                            usize::from(self.config.min_validators.get())
                     );
                 }
             }

--- a/common/lib/src/lib.rs
+++ b/common/lib/src/lib.rs
@@ -7,3 +7,4 @@ extern crate std;
 pub mod hash;
 #[cfg(any(feature = "test_utils", test))]
 pub mod test_utils;
+pub mod u3;

--- a/common/lib/src/u3.rs
+++ b/common/lib/src/u3.rs
@@ -1,0 +1,183 @@
+use core::ops;
+
+use bytemuck::Contiguous;
+
+/// An unsigned integer which accepts only values between 0 and 7.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Contiguous)]
+#[repr(u8)]
+pub enum U3 {
+    _0 = 0,
+    _1 = 1,
+    _2 = 2,
+    _3 = 3,
+    _4 = 4,
+    _5 = 5,
+    _6 = 6,
+    _7 = 7,
+}
+
+/// Error when trying to convert integer larger than 7 to [`U3`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ValueTooLargeError;
+
+/// Helper trait for unsigned integer types.
+pub trait Unsigned: Copy + From<u8> + ops::Div<Self> {
+    fn as_u8(self) -> u8;
+}
+
+impl U3 {
+    pub const MIN: U3 = U3::_0;
+    pub const MAX: U3 = U3::_7;
+
+    /// Constructs new object by dividing argument module eight.
+    pub fn wrap(value: impl Unsigned) -> U3 {
+        Self::from_integer(value.as_u8() % 8).unwrap()
+    }
+
+    /// Divides argument by eight and returns quotient and reminder of the
+    /// operation.
+    pub fn divmod<T: Unsigned>(value: T) -> (<T as ops::Div<T>>::Output, U3) {
+        (value / T::from(8), Self::wrap(value))
+    }
+
+    /// Returns an iterator over all `U3` values in ascending order.
+    pub fn all() -> impl core::iter::Iterator<Item = U3> {
+        (0..8).flat_map(Self::from_integer)
+    }
+
+    pub fn wrapping_add(self, rhs: impl Unsigned) -> U3 {
+        U3::wrap(self.into_integer().wrapping_add(rhs.as_u8()))
+    }
+
+    #[inline]
+    pub fn wrapping_inc(self) -> U3 { self.wrapping_add(1u8) }
+
+    pub fn wrapping_sub(self, rhs: impl Unsigned) -> U3 {
+        U3::wrap(self.into_integer().wrapping_sub(rhs.as_u8()))
+    }
+
+    #[inline]
+    pub fn wrapping_dec(self) -> U3 { self.wrapping_add(7u8) }
+
+    #[inline]
+    pub fn checked_inc(self) -> Option<U3> {
+        Self::from_integer(self.into_integer() + 1)
+    }
+
+    #[inline]
+    pub fn checked_dec(self) -> Option<U3> {
+        self.into_integer().checked_sub(1).and_then(Self::from_integer)
+    }
+}
+
+impl Default for U3 {
+    #[inline]
+    fn default() -> Self { Self::MIN }
+}
+
+macro_rules! impls {
+    (@base $int:ty) => {
+        impl From<U3> for $int {
+            #[inline]
+            fn from(x: U3) -> $int { x.into_integer() as $int }
+        }
+
+        impl TryFrom<$int> for U3 {
+            type Error = ValueTooLargeError;
+            #[inline]
+            fn try_from(x: $int) -> Result<Self, Self::Error> {
+                u8::try_from(x)
+                    .ok()
+                    .and_then(Self::from_integer)
+                    .ok_or(ValueTooLargeError)
+            }
+        }
+
+        impl PartialEq<U3> for $int {
+            #[inline]
+            fn eq(&self, rhs: &U3) -> bool { *self == <$int>::from(*rhs) }
+        }
+
+        impl PartialEq<$int> for U3 {
+            #[inline]
+            fn eq(&self, rhs: &$int) -> bool { <$int>::from(*self) == *rhs }
+        }
+
+        impl PartialOrd<U3> for $int {
+            #[inline]
+            fn partial_cmp(&self, rhs: &U3) -> Option<core::cmp::Ordering> {
+                self.partial_cmp(&<$int>::from(*rhs))
+            }
+        }
+
+        impl PartialOrd<$int> for U3 {
+            #[inline]
+            fn partial_cmp(&self, rhs: &$int) -> Option<core::cmp::Ordering> {
+                <$int>::from(*self).partial_cmp(rhs)
+            }
+        }
+
+        impl ops::Shl<U3> for $int {
+            type Output = <$int as ops::Shl<u32>>::Output;
+            fn shl(self, rhs: U3) -> Self::Output {
+                self << u32::from(rhs)
+            }
+        }
+
+        impl ops::Shr<U3> for $int {
+            type Output = <$int as ops::Shr<u32>>::Output;
+            fn shr(self, rhs: U3) -> Self::Output {
+                self >> u32::from(rhs)
+            }
+        }
+    };
+
+    (@unsigned $($int:ty),*) => {
+        $(impls!(@base $int);)*
+
+        $(
+            impl Unsigned for $int {
+                #[inline]
+                fn as_u8(self) -> u8 { self as u8 }
+            }
+        )*
+    };
+
+    (@signed $($int:ty),*) => {
+        $(impls!(@base $int);)*
+    }
+}
+
+impls!(@unsigned u8, u16, u32, u64, usize);
+impls!(@signed i8, i16, i32, i64, isize);
+
+impl core::fmt::Display for U3 {
+    #[inline]
+    fn fmt(&self, fmtr: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.into_integer().fmt(fmtr)
+    }
+}
+
+impl core::fmt::Debug for U3 {
+    #[inline]
+    fn fmt(&self, fmtr: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.into_integer().fmt(fmtr)
+    }
+}
+
+#[test]
+fn test() {
+    for n in 0..8u8 {
+        assert_eq!(n, U3::try_from(n).unwrap());
+    }
+    assert_eq!(Err(ValueTooLargeError), U3::try_from(8u8));
+
+    assert_eq!(0, U3::_0);
+    assert_eq!(5, U3::_0.wrapping_add(5u32));
+    assert_eq!(5, U3::_0.wrapping_add(805u32));
+    assert_eq!(5, U3::_0.wrapping_sub(3u32));
+    assert_eq!(5, U3::_0.wrapping_sub(803u32));
+
+    assert_eq!(8, 1 << U3::_3);
+    assert_eq!(1, 8 >> U3::_3);
+}

--- a/common/sealable-trie/src/bits.rs
+++ b/common/sealable-trie/src/bits.rs
@@ -909,23 +909,22 @@ fn test_owned_unshift() {
 
 #[test]
 fn test_owned_concat() {
-    for len in 0..8 {
+    for len in 0..=8 {
         let bytes = (0xFF00_u16 >> len).to_be_bytes();
-        let want = if len == 8 {
-            Slice::new(&bytes, 0, 16)
-        } else {
-            Slice::new(&bytes[1..], 0, 8)
-        }
-        .unwrap();
+        let want = Slice::new(&bytes[1..], 0, 8).unwrap();
 
         let prefix = Slice::new(&[255], 0, len).unwrap();
-        let suffix = Slice::new(
-            &[0],
-            (len % 8) as u8,
-            if len == 8 { 8 } else { 8 - len },
-        )
-        .unwrap();
+        let suffix = Slice::new(&[0], len as u8 % 8, 8 - len).unwrap();
         let got = Owned::concat(prefix, suffix).unwrap();
         assert_eq!(want, got, "len: {len}");
+    }
+}
+
+#[test]
+fn test_owned_concat_empty() {
+    for offset in 0..8 {
+        let slice = Slice::new(&[], offset, 0).unwrap();
+        let got = Owned::concat(slice, slice).unwrap();
+        assert_eq!(slice, got, "offset: {offset}");
     }
 }

--- a/common/sealable-trie/src/bits/ext_key.rs
+++ b/common/sealable-trie/src/bits/ext_key.rs
@@ -1,5 +1,7 @@
 use core::fmt;
 
+use lib::u3::U3;
+
 use crate::bits::Slice;
 use crate::nodes::MAX_EXTENSION_KEY_SIZE;
 
@@ -34,7 +36,7 @@ impl<'a> ExtKey<'a> {
     /// In addition to limits imposed by [`Slice::new`], constraints of the
     /// Extension key are checked and `None` returned if they aren’t met.
     #[inline]
-    pub fn new(bytes: &'a [u8], offset: u8, length: u16) -> Option<Self> {
+    pub fn new(bytes: &'a [u8], offset: U3, length: u16) -> Option<Self> {
         Slice::new(bytes, offset, length)
             .and_then(|slice| Self::try_from(slice).ok())
     }
@@ -79,7 +81,7 @@ impl<'a> ExtKey<'a> {
     pub(crate) fn decode(src: &'a [u8], tag: u8) -> Option<Self> {
         let (&[high, low], bytes) = stdx::split_at(src)?;
         let tag = u16::from_be_bytes([high ^ tag, low]);
-        let (offset, length) = ((tag % 8) as u8, tag / 8);
+        let (length, offset) = U3::divmod(tag);
         Slice::new_check_zeros(bytes, offset, length)
             .and_then(|slice| Self::try_from(slice).ok())
     }
@@ -176,7 +178,7 @@ impl<'a> core::iter::DoubleEndedIterator for Chunks<'a> {
 
         if chunks.next().is_none() {
             let empty = Slice {
-                offset: 0,
+                offset: U3::_0,
                 length: 0,
                 ptr: self.0.ptr,
                 phantom: Default::default(),
@@ -191,7 +193,7 @@ impl<'a> core::iter::DoubleEndedIterator for Chunks<'a> {
         self.0.length -= length;
 
         Some(ExtKey(Slice {
-            offset: 0,
+            offset: U3::_0,
             length,
             ptr: bytes.as_ptr(),
             phantom: Default::default(),
@@ -202,7 +204,7 @@ impl<'a> core::iter::DoubleEndedIterator for Chunks<'a> {
 #[test]
 fn test_encode() {
     #[track_caller]
-    fn test(want_encoded: &[u8], offset: u8, length: u16, bytes: &[u8]) {
+    fn test(want_encoded: &[u8], offset: U3, length: u16, bytes: &[u8]) {
         let slice = ExtKey::new(bytes, offset, length).unwrap();
 
         let mut want = [0; 36];
@@ -219,35 +221,35 @@ fn test_encode() {
         assert_eq!(slice, round_trip);
     }
 
-    test(&[0, 1 * 8 + 0, 0x80], 0, 1, &[0x80]);
-    test(&[0, 1 * 8 + 0, 0x80], 0, 1, &[0xFF]);
-    test(&[0, 1 * 8 + 4, 0x08], 4, 1, &[0xFF]);
-    test(&[0, 9 * 8 + 0, 0xFF, 0x80], 0, 9, &[0xFF, 0xFF]);
-    test(&[0, 9 * 8 + 4, 0x0F, 0xF8], 4, 9, &[0xFF, 0xFF]);
-    test(&[0, 17 * 8 + 0, 0xFF, 0xFF, 0x80], 0, 17, &[0xFF, 0xFF, 0xFF]);
-    test(&[0, 17 * 8 + 4, 0x0F, 0xFF, 0xF8], 4, 17, &[0xFF, 0xFF, 0xFF]);
+    test(&[0, 1 * 8 + 0, 0x80], U3::_0, 1, &[0x80]);
+    test(&[0, 1 * 8 + 0, 0x80], U3::_0, 1, &[0xFF]);
+    test(&[0, 1 * 8 + 4, 0x08], U3::_4, 1, &[0xFF]);
+    test(&[0, 9 * 8 + 0, 0xFF, 0x80], U3::_0, 9, &[0xFF, 0xFF]);
+    test(&[0, 9 * 8 + 4, 0x0F, 0xF8], U3::_4, 9, &[0xFF, 0xFF]);
+    test(&[0, 17 * 8 + 0, 0xFF, 0xFF, 0x80], U3::_0, 17, &[0xFF, 0xFF, 0xFF]);
+    test(&[0, 17 * 8 + 4, 0x0F, 0xFF, 0xF8], U3::_4, 17, &[0xFF, 0xFF, 0xFF]);
 
     let mut want = [0xFF; 36];
     want[0] = (272u16 >> 5) as u8;
     want[1] = (272u16 << 3) as u8;
-    test(&want[..], 0, 34 * 8, &[0xFF; 34][..]);
+    test(&want[..], U3::_0, 34 * 8, &[0xFF; 34][..]);
 
     want[0] = (271u16 >> 5) as u8;
     want[1] = (271u16 << 3) as u8;
     want[35] = 0xFE;
-    test(&want[..], 0, 34 * 8 - 1, &[0xFF; 34][..]);
+    test(&want[..], U3::_0, 34 * 8 - 1, &[0xFF; 34][..]);
 
     want[0] = (271u16 >> 5) as u8;
     want[1] = (271u16 << 3) as u8 + 1;
     want[2] = 0x7F;
     want[35] = 0xFF;
-    test(&want[..], 1, 34 * 8 - 1, &[0xFF; 34][..]);
+    test(&want[..], U3::_1, 34 * 8 - 1, &[0xFF; 34][..]);
 }
 
 #[test]
 fn test_decode() {
     #[track_caller]
-    fn ok(num: u16, bytes: &[u8], want_offset: u8, want_length: u16) {
+    fn ok(num: u16, bytes: &[u8], want_offset: U3, want_length: u16) {
         let bytes = [&num.to_be_bytes()[..], bytes].concat();
         let got = ExtKey::decode(&bytes, 0).unwrap_or_else(|| {
             panic!("Expected to get a ExtKey from {bytes:x?}")
@@ -256,9 +258,9 @@ fn test_decode() {
     }
 
     // Correct values, all bits zero.
-    ok(34 * 64, &[0; 34], 0, 34 * 8);
-    ok(33 * 64 + 7, &[0; 34], 7, 264);
-    ok(2 * 64, &[0, 0], 0, 16);
+    ok(34 * 64, &[0; 34], U3::_0, 34 * 8);
+    ok(33 * 64 + 7, &[0; 34], U3::_7, 264);
+    ok(2 * 64, &[0, 0], U3::_0, 16);
 
     // Empty
     assert_eq!(None, ExtKey::decode(&[], 0));
@@ -266,7 +268,8 @@ fn test_decode() {
     assert_eq!(None, ExtKey::decode(&[0, 0], 0));
 
     #[track_caller]
-    fn test(length: u16, offset: u8, bad: &[u8], good: &[u8]) {
+    fn test(length: u16, offset: U3, bad: &[u8], good: &[u8]) {
+        let offset = U3::try_from(offset).unwrap();
         let num = length * 8 + u16::from(offset);
         let bad = [&num.to_be_bytes()[..], bad].concat();
         assert_eq!(None, ExtKey::decode(&bad, 0));
@@ -293,36 +296,36 @@ fn test_decode() {
     }
 
     // Bytes buffer doesn’t match the length.
-    test(8, 0, &[], &[0]);
-    test(8, 7, &[0], &[0, 0]);
-    test(16, 1, &[0, 0], &[0, 0, 0]);
+    test(8, U3::_0, &[], &[0]);
+    test(8, U3::_7, &[0], &[0, 0]);
+    test(16, U3::_1, &[0, 0], &[0, 0, 0]);
 
     // Bits which should be zero aren’t.
     // Leading bits are skipped:
-    test(16 - 1, 1, &[0x80, 0], &[0x7F, 0xFF]);
-    test(16 - 2, 2, &[0x40, 0], &[0x3F, 0xFF]);
-    test(16 - 3, 3, &[0x20, 0], &[0x1F, 0xFF]);
-    test(16 - 4, 4, &[0x10, 0], &[0x0F, 0xFF]);
-    test(16 - 5, 5, &[0x08, 0], &[0x07, 0xFF]);
-    test(16 - 6, 6, &[0x04, 0], &[0x03, 0xFF]);
-    test(16 - 7, 7, &[0x02, 0], &[0x01, 0xFF]);
+    test(16 - 1, U3::_1, &[0x80, 0], &[0x7F, 0xFF]);
+    test(16 - 2, U3::_2, &[0x40, 0], &[0x3F, 0xFF]);
+    test(16 - 3, U3::_3, &[0x20, 0], &[0x1F, 0xFF]);
+    test(16 - 4, U3::_4, &[0x10, 0], &[0x0F, 0xFF]);
+    test(16 - 5, U3::_5, &[0x08, 0], &[0x07, 0xFF]);
+    test(16 - 6, U3::_6, &[0x04, 0], &[0x03, 0xFF]);
+    test(16 - 7, U3::_7, &[0x02, 0], &[0x01, 0xFF]);
 
     // Tailing bits are skipped:
-    test(16 - 1, 0, &[0, 0x01], &[0xFF, 0xFE]);
-    test(16 - 2, 0, &[0, 0x02], &[0xFF, 0xFC]);
-    test(16 - 3, 0, &[0, 0x04], &[0xFF, 0xF8]);
-    test(16 - 4, 0, &[0, 0x08], &[0xFF, 0xF0]);
-    test(16 - 5, 0, &[0, 0x10], &[0xFF, 0xE0]);
-    test(16 - 6, 0, &[0, 0x20], &[0xFF, 0xC0]);
-    test(16 - 7, 0, &[0, 0x40], &[0xFF, 0x80]);
+    test(16 - 1, U3::_0, &[0, 0x01], &[0xFF, 0xFE]);
+    test(16 - 2, U3::_0, &[0, 0x02], &[0xFF, 0xFC]);
+    test(16 - 3, U3::_0, &[0, 0x04], &[0xFF, 0xF8]);
+    test(16 - 4, U3::_0, &[0, 0x08], &[0xFF, 0xF0]);
+    test(16 - 5, U3::_0, &[0, 0x10], &[0xFF, 0xE0]);
+    test(16 - 6, U3::_0, &[0, 0x20], &[0xFF, 0xC0]);
+    test(16 - 7, U3::_0, &[0, 0x40], &[0xFF, 0x80]);
 
     // Some leading and some tailing bits are skipped of the same byte:
-    test(1, 1, &[!0x40], &[0x40]);
-    test(1, 2, &[!0x20], &[0x20]);
-    test(1, 3, &[!0x10], &[0x10]);
-    test(1, 4, &[!0x08], &[0x08]);
-    test(1, 5, &[!0x04], &[0x04]);
-    test(1, 6, &[!0x02], &[0x02]);
+    test(1, U3::_1, &[!0x40], &[0x40]);
+    test(1, U3::_2, &[!0x20], &[0x20]);
+    test(1, U3::_3, &[!0x10], &[0x10]);
+    test(1, U3::_4, &[!0x08], &[0x08]);
+    test(1, U3::_5, &[!0x04], &[0x04]);
+    test(1, U3::_6, &[!0x02], &[0x02]);
 }
 
 #[test]
@@ -330,10 +333,10 @@ fn test_chunks() {
     let data = (0..=255).collect::<alloc::vec::Vec<u8>>();
     let data = data.as_slice();
 
-    let slice = |off: u8, len: u16| Slice::new(data, off, len).unwrap();
+    let slice = |off: U3, len: u16| Slice::new(data, off, len).unwrap();
 
     // Single chunk
-    for offset in 0..8 {
+    for offset in U3::all() {
         for length in 1..(34 * 8 - u16::from(offset)) {
             let want = Some(ExtKey::new(data, offset, length).unwrap());
 
@@ -348,12 +351,13 @@ fn test_chunks() {
     }
 
     // Two chunks
-    for offset in 0..8 {
+    for offset in U3::all() {
         let want_first = Some(
             ExtKey::new(data, offset, 34 * 8 - u16::from(offset)).unwrap(),
         );
-        let want_second =
-            Some(ExtKey::new(&data[34..], 0, 10 + u16::from(offset)).unwrap());
+        let want_second = Some(
+            ExtKey::new(&data[34..], U3::_0, 10 + u16::from(offset)).unwrap(),
+        );
 
         let mut chunks = slice(offset, 34 * 8 + 10).chunks();
         assert_eq!(want_first, chunks.next());

--- a/common/sealable-trie/src/nodes/stress_tests.rs
+++ b/common/sealable-trie/src/nodes/stress_tests.rs
@@ -6,6 +6,7 @@
 //! variable.
 
 use lib::test_utils::get_iteration_count;
+use lib::u3::U3;
 use memory::Ptr;
 use pretty_assertions::assert_eq;
 
@@ -53,7 +54,7 @@ fn gen_random_raw_node(
         // regenerate random data.
 
         // Random length and offset for the key.
-        let offset = rng.gen::<u8>() % 8;
+        let offset = U3::wrap(rng.gen::<u8>());
         let max_length = (nodes::MAX_EXTENSION_KEY_SIZE * 8) as u16;
         let length = rng.gen_range(1..=max_length - u16::from(offset));
         let tag = 0x8000 | (length << 3) | u16::from(offset);
@@ -117,7 +118,7 @@ fn gen_random_node<'a>(
     match rng.gen_range(0..3) {
         0 => Node::branch(rand_ref(rng, &left), rand_ref(rng, &right)),
         1 => {
-            let offset = rng.gen::<u8>() % 8;
+            let offset = U3::wrap(rng.gen::<u8>());
             let max_length = (nodes::MAX_EXTENSION_KEY_SIZE * 8) as u16;
             let length = rng.gen_range(1..=max_length - u16::from(offset));
             let key = bits::ExtKey::new(&key[..], offset, length).unwrap();

--- a/common/sealable-trie/src/nodes/tests.rs
+++ b/common/sealable-trie/src/nodes/tests.rs
@@ -1,4 +1,5 @@
 use lib::hash::CryptoHash;
+use lib::u3::U3;
 use memory::Ptr;
 use pretty_assertions::assert_eq;
 
@@ -169,7 +170,7 @@ fn test_branch_encoding() {
 fn test_extension_encoding() {
     // Extension pointing at a node
     check_node_encoding(Node::Extension {
-        key: bits::ExtKey::new(&[0xFF; 34], 5, 25).unwrap(),
+        key: bits::ExtKey::new(&[0xFF; 34], U3::_5, 25).unwrap(),
         child: Reference::node(Some(DEAD), &ONE),
     }, [
         /* tag:  */ 0x80, 0xCD,
@@ -180,7 +181,7 @@ fn test_extension_encoding() {
 
     // Extension pointing at a sealed node
     check_node_encoding(Node::Extension {
-        key: bits::ExtKey::new(&[0xFF; 34], 5, 25).unwrap(),
+        key: bits::ExtKey::new(&[0xFF; 34], U3::_5, 25).unwrap(),
         child: Reference::node(None, &ONE),
     }, [
         /* tag:  */ 0x80, 0xCD,
@@ -191,7 +192,7 @@ fn test_extension_encoding() {
 
     // Extension pointing at a value
     check_node_encoding(Node::Extension {
-        key: bits::ExtKey::new(&[0xFF; 34], 4, 248).unwrap(),
+        key: bits::ExtKey::new(&[0xFF; 34], U3::_4, 248).unwrap(),
         child: Reference::value(false, &ONE),
     }, [
         /* tag:  */ 0x87, 0xC4,
@@ -203,7 +204,7 @@ fn test_extension_encoding() {
     ], "uU9GlH+fEQAnezn3HWuvo/ZSBIhuSkuE2IGjhUFdC04=");
 
     check_node_encoding(Node::Extension {
-        key: bits::ExtKey::new(&[0xFF; 34], 4, 248).unwrap(),
+        key: bits::ExtKey::new(&[0xFF; 34], U3::_4, 248).unwrap(),
         child: Reference::value(true, &ONE),
     }, [
         /* tag:  */ 0x87, 0xC4,

--- a/common/sealable-trie/src/proof/serialisation.rs
+++ b/common/sealable-trie/src/proof/serialisation.rs
@@ -331,6 +331,8 @@ fn test_item_borsh() {
 
 #[test]
 fn test_actual_borsh() {
+    use lib::u3::U3;
+
     #[track_caller]
     fn test(want_actual: Actual, want_bytes: &[u8]) {
         let got_bytes = borsh::to_vec(&want_actual).unwrap();
@@ -397,7 +399,7 @@ fn test_actual_borsh() {
     fn make_extension(
         left: u16,
         bytes: &[u8],
-        offset: u8,
+        offset: U3,
         length: u16,
         is_value: bool,
     ) -> Actual {
@@ -410,7 +412,7 @@ fn test_actual_borsh() {
     }
 
     #[rustfmt::skip]
-    test(make_extension(0, &[0xFF; 34], 0, 34 * 8, false), &[
+    test(make_extension(0, &[0xFF; 34], U3::_0, 34 * 8, false), &[
         /* tag: */ 0x84,
         /* left: */ 0, 0,
         /* key: */ 8, 128,
@@ -422,7 +424,7 @@ fn test_actual_borsh() {
     ]);
 
     #[rustfmt::skip]
-    test(make_extension(0xDEAD, &[1], 7, 1, true), &[
+    test(make_extension(0xDEAD, &[1], U3::_7, 1, true), &[
         /* tag: */ 0x85,
         /* left: */ 0xAD, 0xDE,
         /* key: */ 0, 15, 1,


### PR DESCRIPTION
Encode in type that slice’s offset can be at most 7 by introducing
a new lib::u3::U3 type and use it for storing the offset.  As the name
implies, the type is written to hold 3-bit unsigned integers, or in
other words numbers from 0 to 7.

This allows offset check to be removed from Slice and Owned
constructors and since everything is encapsulated the users of the
types need only minimal adjustments.

This actually fixes a bug in Owned::bit where the offset argument
wasn’t validated.  Since the only place which called that function
used offset taken from another slice this never created actual issue
but nonetheless the API is now tighter.
