### PR TITLE
solana-ibc: remove packets storage

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -13,10 +13,8 @@ use borsh::BorshDeserialize;
 use ibc::core::ics23_commitment::commitment::CommitmentPrefix;
 use ibc::core::ics24_host::identifier::{ChannelId, ClientId, PortId};
 use ibc::core::router::{Module, ModuleId, Router};
-use ibc::core::MsgEnvelope;
 #[cfg(feature = "mocks")]
 use mocks::mock_deliver_impl;
-use storage::IbcPackets;
 
 pub const CHAIN_SEED: &[u8] = b"chain";
 pub const PACKET_SEED: &[u8] = b"packet";
@@ -124,7 +122,6 @@ pub mod solana_ibc {
         let private: &mut storage::PrivateStorage = &mut ctx.accounts.storage;
         // msg!("This is private: {:?}", private);
         let provable = storage::get_provable_from(&ctx.accounts.trie, "trie")?;
-        let packets = &mut ctx.accounts.packets;
         let host_head = host::Head::get()?;
 
         // Before anything else, try generating a new guest block.  However, if
@@ -135,7 +132,6 @@ pub mod solana_ibc {
         let mut store = storage::IbcStorage::new(storage::IbcStorageInner {
             private,
             provable,
-            packets,
             accounts: ctx.remaining_accounts.to_vec(),
             host_head,
         });
@@ -145,15 +141,6 @@ pub mod solana_ibc {
             ibc::core::dispatch(&mut store, &mut router, message.clone())
                 .map_err(error::Error::RouterError)
                 .map_err(|err| error!((&err)))?;
-        }
-        if let MsgEnvelope::Packet(packet) = message {
-            // store the packet if not exists
-            // TODO(dhruvja) Store in a PDA with channelId, portId and Sequence
-            let mut store = store.borrow_mut();
-            let packets = &mut store.packets.0;
-            if !packets.iter().any(|pack| &packet == pack) {
-                packets.push(packet);
-            }
         }
 
         // `store` is the only reference to inner storage making refcount == 1
@@ -257,10 +244,6 @@ pub struct Deliver<'info> {
     #[account(init_if_needed, payer = sender, seeds = [TRIE_SEED], bump, space = 10240)]
     trie: UncheckedAccount<'info>,
 
-    /// The account holding packets.
-    #[account(init_if_needed, payer = sender, seeds = [PACKET_SEED], bump, space = 10240)]
-    packets: Account<'info, storage::IbcPackets>,
-
     /// The guest blockchain data.
     #[account(init_if_needed, payer = sender, seeds = [CHAIN_SEED], bump, space = 10240)]
     chain: Box<Account<'info, chain::ChainData>>,
@@ -286,10 +269,6 @@ pub struct MockDeliver<'info> {
     /// function.
     #[account(mut , seeds = [TRIE_SEED], bump)]
     trie: UncheckedAccount<'info>,
-
-    /// The account holding packets.
-    #[account(mut , seeds = [PACKET_SEED], bump)]
-    packets: Box<Account<'info, IbcPackets>>,
 
     /// The below accounts are being created for testing purposes only.
     /// In real, we would run conditionally create an escrow account when the channel is created.

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -138,7 +138,7 @@ pub mod solana_ibc {
 
         {
             let mut router = store.clone();
-            ibc::core::dispatch(&mut store, &mut router, message.clone())
+            ibc::core::dispatch(&mut store, &mut router, message)
                 .map_err(error::Error::RouterError)
                 .map_err(|err| error!((&err)))?;
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
@@ -20,7 +20,6 @@ use ibc::core::ics24_host::path::{
 };
 use ibc::core::{ExecutionContext, ValidationContext};
 use ibc::mock::client_state::MockClientState;
-use storage::IbcPackets;
 
 use crate::{error, host, storage, MockDeliver, MINT_ESCROW_SEED};
 
@@ -36,7 +35,6 @@ pub fn mock_deliver_impl(
     let private: &mut storage::PrivateStorage = &mut ctx.accounts.storage;
     // msg!("This is private: {private:?}");
     let provable = storage::get_provable_from(&ctx.accounts.trie, "trie")?;
-    let packets: &mut IbcPackets = &mut ctx.accounts.packets;
     let accounts = ctx.remaining_accounts;
 
     let host_head = host::Head::get()?;
@@ -49,7 +47,6 @@ pub fn mock_deliver_impl(
     let mut store = storage::IbcStorage::new(storage::IbcStorageInner {
         private,
         provable,
-        packets,
         accounts: accounts.to_vec(),
         host_head,
     });

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -17,7 +17,6 @@ mod ibc {
     pub use ibc::core::ics03_connection::error::ConnectionError;
     pub use ibc::core::ics04_channel::channel::ChannelEnd;
     pub use ibc::core::ics04_channel::error::ChannelError;
-    pub use ibc::core::ics04_channel::msgs::PacketMsg;
     pub use ibc::core::ics04_channel::packet::Sequence;
     pub use ibc::core::ics24_host::identifier::{
         ChannelId, ClientId, ConnectionId, PortId,

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -139,10 +139,6 @@ impl<'a> core::ops::DerefMut for ClientMut<'a> {
 
 #[account]
 #[derive(Debug)]
-pub struct IbcPackets(pub Vec<ibc::PacketMsg>);
-
-#[account]
-#[derive(Debug)]
 /// The private IBC storage, i.e. data which doesn’t require proofs.
 pub struct PrivateStorage {
     /// Per-client information.
@@ -278,7 +274,6 @@ pub fn get_provable_from<'a, 'info>(
 pub(crate) struct IbcStorageInner<'a, 'b, 'c> {
     pub private: &'a mut PrivateStorage,
     pub provable: AccountTrie<'a, 'b>,
-    pub packets: &'a mut IbcPackets,
     pub accounts: Vec<AccountInfo<'c>>,
     pub host_head: crate::host::Head,
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -74,7 +74,6 @@ pub struct DeliverWithRemainingAccounts {
     sender: Pubkey,
     storage: Pubkey,
     trie: Pubkey,
-    packets: Pubkey,
     chain: Pubkey,
     system_program: Pubkey,
     remaining_accounts: Vec<AccountMeta>,
@@ -98,11 +97,6 @@ impl ToAccountMetas for DeliverWithRemainingAccounts {
             },
             AccountMeta {
                 pubkey: self.trie,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.packets,
                 is_signer: false,
                 is_writable: true,
             },
@@ -150,8 +144,6 @@ fn anchor_test_deliver() -> Result<()> {
     )
     .0;
     let trie = Pubkey::find_program_address(&[crate::TRIE_SEED], &crate::ID).0;
-    let packets =
-        Pubkey::find_program_address(&[crate::PACKET_SEED], &crate::ID).0;
     let chain =
         Pubkey::find_program_address(&[crate::CHAIN_SEED], &crate::ID).0;
 
@@ -179,7 +171,6 @@ fn anchor_test_deliver() -> Result<()> {
             sender: authority.pubkey(),
             storage,
             trie,
-            packets,
             chain,
             system_program: system_program::ID,
         })
@@ -235,7 +226,6 @@ fn anchor_test_deliver() -> Result<()> {
             sender: authority.pubkey(),
             storage,
             trie,
-            packets,
             chain: chain.clone(),
             system_program: system_program::ID,
         })
@@ -299,7 +289,6 @@ fn anchor_test_deliver() -> Result<()> {
             system_program: system_program::ID,
             associated_token_program: anchor_spl::associated_token::ID,
             token_program: anchor_spl::token::ID,
-            packets,
         })
         .args(instruction::MockDeliver {
             port_id: port_id.clone(),
@@ -422,7 +411,6 @@ fn anchor_test_deliver() -> Result<()> {
             storage,
             trie,
             system_program: system_program::ID,
-            packets,
             chain,
             remaining_accounts: remaining_accounts.clone(),
         })
@@ -500,7 +488,6 @@ fn anchor_test_deliver() -> Result<()> {
             storage,
             trie,
             system_program: system_program::ID,
-            packets,
             chain,
             remaining_accounts,
         })


### PR DESCRIPTION
Storing packets on chain would easily pile up since they are just
added and not removed.  The previous delivered packets aren’t needed
in the smart contract so there is no point in storing them there.  The
packets are required by the relayer which can be fetched by querying
the logs.
