### PR TITLE
solana-ibc: use a proper timestamp in mock headers

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
@@ -66,6 +66,7 @@ pub mod mock {
     pub use ibc_testkit::testapp::ibc::clients::mock::consensus_state::{
         MockConsensusState, MOCK_CONSENSUS_STATE_TYPE_URL,
     };
+    pub use ibc_testkit::testapp::ibc::clients::mock::header::MockHeader;
     pub use ibc_testkit::testapp::ibc::clients::mock::proto::{
         ClientState as ClientStatePB, ConsensusState as ConsensusStatePB,
     };

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -15,6 +15,9 @@ use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::ToAccountMetas;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
+use ::ibc::core::client::types::Height;
+use ::ibc::primitives::Timestamp;
+use ibc_testkit::testapp::ibc::clients::mock::header::MockHeader;
 
 use crate::ibc::ClientStateCommon;
 use crate::storage::PrivateStorage;
@@ -40,8 +43,12 @@ fn airdrop(client: &RpcClient, account: Pubkey, lamports: u64) -> Signature {
 
 fn create_mock_client_and_cs_state(
 ) -> (ibc::mock::MockClientState, ibc::mock::MockConsensusState) {
-    let mock_client_state = ibc::mock::MockClientState::new(Default::default());
-    let mock_cs_state = ibc::mock::MockConsensusState::new(Default::default());
+    let mock_header = MockHeader {
+        height: Height::new(0, 1).unwrap(),
+        timestamp: Timestamp::from_nanoseconds(1).unwrap(),
+    };
+    let mock_client_state = ibc::mock::MockClientState::new(mock_header);
+    let mock_cs_state = ibc::mock::MockConsensusState::new(mock_header);
     (mock_client_state, mock_cs_state)
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -3,8 +3,6 @@ use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 
-use ::ibc::core::client::types::Height;
-use ::ibc::primitives::Timestamp;
 use anchor_client::anchor_lang::system_program;
 use anchor_client::solana_client::rpc_client::RpcClient;
 use anchor_client::solana_client::rpc_config::RpcSendTransactionConfig;
@@ -17,7 +15,6 @@ use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::ToAccountMetas;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
-use ibc_testkit::testapp::ibc::clients::mock::header::MockHeader;
 
 use crate::ibc::ClientStateCommon;
 use crate::storage::PrivateStorage;
@@ -43,9 +40,9 @@ fn airdrop(client: &RpcClient, account: Pubkey, lamports: u64) -> Signature {
 
 fn create_mock_client_and_cs_state(
 ) -> (ibc::mock::MockClientState, ibc::mock::MockConsensusState) {
-    let mock_header = MockHeader {
-        height: Height::new(0, 1).unwrap(),
-        timestamp: Timestamp::from_nanoseconds(1).unwrap(),
+    let mock_header = ibc::mock::MockHeader {
+        height: ibc::Height::new(0, 1).unwrap(),
+        timestamp: ibc::Timestamp::from_nanoseconds(1).unwrap(),
     };
     let mock_client_state = ibc::mock::MockClientState::new(mock_header);
     let mock_cs_state = ibc::mock::MockConsensusState::new(mock_header);

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 
+use ::ibc::core::client::types::Height;
+use ::ibc::primitives::Timestamp;
 use anchor_client::anchor_lang::system_program;
 use anchor_client::solana_client::rpc_client::RpcClient;
 use anchor_client::solana_client::rpc_config::RpcSendTransactionConfig;
@@ -15,8 +17,6 @@ use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::ToAccountMetas;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
-use ::ibc::core::client::types::Height;
-use ::ibc::primitives::Timestamp;
 use ibc_testkit::testapp::ibc::clients::mock::header::MockHeader;
 
 use crate::ibc::ClientStateCommon;

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -41,7 +41,7 @@ fn airdrop(client: &RpcClient, account: Pubkey, lamports: u64) -> Signature {
 fn create_mock_client_and_cs_state(
 ) -> (ibc::mock::MockClientState, ibc::mock::MockConsensusState) {
     let mock_header = ibc::mock::MockHeader {
-        height: ibc::Height::new(0, 1).unwrap(),
+        height: ibc::Height::min(0),
         timestamp: ibc::Timestamp::from_nanoseconds(1).unwrap(),
     };
     let mock_client_state = ibc::mock::MockClientState::new(mock_header);


### PR DESCRIPTION
The timestamp default to `None` while setting up mock headers in the tests. Since they are not set ( `None` ), it fails while comparing the current timestamp. So using a value instead would solve it. The value has to be less than the current timestamp.