### PR TITLE
solana-ibc: introduce Owned::extend and Owned::truncate

### DIFF
--- a/common/lib/src/u3.rs
+++ b/common/lib/src/u3.rs
@@ -21,7 +21,7 @@ pub enum U3 {
 pub struct ValueTooLargeError;
 
 /// Helper trait for unsigned integer types.
-pub trait Unsigned: Copy + From<u8> + ops::Div<Self> {
+pub trait Unsigned: Copy {
     fn as_u8(self) -> u8;
 }
 
@@ -36,9 +36,7 @@ impl U3 {
 
     /// Divides argument by eight and returns quotient and reminder of the
     /// operation.
-    pub fn divmod<T: Unsigned>(value: T) -> (<T as ops::Div<T>>::Output, U3) {
-        (value / T::from(8), Self::wrap(value))
-    }
+    pub fn divmod(value: u16) -> (u16, U3) { (value / 8, Self::wrap(value)) }
 
     /// Returns an iterator over all `U3` values in ascending order.
     pub fn all() -> impl core::iter::Iterator<Item = U3> {
@@ -73,6 +71,15 @@ impl U3 {
 impl Default for U3 {
     #[inline]
     fn default() -> Self { Self::MIN }
+}
+
+impl Unsigned for U3 {
+    fn as_u8(self) -> u8 { self.into_integer() }
+}
+
+impl ops::Neg for U3 {
+    type Output = U3;
+    fn neg(self) -> U3 { U3::_0.wrapping_sub(self) }
 }
 
 macro_rules! impls {

--- a/common/sealable-trie/src/bits.rs
+++ b/common/sealable-trie/src/bits.rs
@@ -3,8 +3,10 @@ use core::fmt;
 
 use lib::u3::U3;
 
+pub mod concat;
 pub mod ext_key;
 
+pub use concat::MisalignedSlice;
 pub use ext_key::{Chunks, ExtKey};
 #[cfg(test)]
 use pretty_assertions::assert_eq;
@@ -23,7 +25,7 @@ pub struct Slice<'a> {
     pub(crate) offset: U3,
 
     /// Length of the slice in bits.
-    pub(crate) length: u16,
+    length: u16,
 
     /// The bytes to read the bits from.
     ///
@@ -31,7 +33,7 @@ pub struct Slice<'a> {
     /// unspecified and shouldn’t be read.
     // Invariant: if `length` is non-zero, `ptr` points at `offset + length`
     // valid bits; in other words, at `(offset + length + 7) / 8` valid bytes.
-    pub(crate) ptr: *const u8,
+    ptr: *const u8,
 
     phantom: core::marker::PhantomData<&'a [u8]>,
 }
@@ -49,7 +51,8 @@ pub struct Owned {
     length: u16,
 
     /// The underlying bytes to read the bits from.
-    // Invariant: `bytes.len() == (offset + length + 7) / 8`.
+    // Invariant: If `length` is zero than `bytes.is_empty()`; otherwise
+    // `bytes.len() == (offset + length + 7) / 8`.
     bytes: Vec<u8>,
 }
 
@@ -63,17 +66,14 @@ impl<'a> Slice<'a> {
     ///
     /// `length` specifies length in bits of the entire bit slice.
     ///
-    /// Returns `None` if `offset + length` is too large (dosn’t fit `u16`) or
-    /// `bytes` doesn’t have enough underlying data for the length of the slice.
+    /// Returns `None` if `bytes` doesn’t have enough underlying data for the
+    /// length of the slice.
     #[inline]
     pub fn new(bytes: &'a [u8], offset: U3, length: u16) -> Option<Self> {
-        let needs_bits = length.checked_add(u16::from(offset))?;
-        (length == 0 ||
-            needs_bits <=
-                u16::try_from(bytes.len())
-                    .unwrap_or(u16::MAX)
-                    .saturating_mul(8))
-        .then_some(Self {
+        let needs_bits = u32::from(offset) + u32::from(length);
+        let got_bits =
+            u32::try_from(bytes.len().saturating_mul(8)).unwrap_or(u32::MAX);
+        (length == 0 || needs_bits <= got_bits).then_some(Self {
             offset,
             length,
             ptr: bytes.as_ptr(),
@@ -172,17 +172,17 @@ impl<'a> Slice<'a> {
     #[inline]
     pub fn pop_back(&mut self) -> Option<bool> {
         self.length = self.length.checked_sub(1)?;
-        let total_bits = self.underlying_bits_length();
+        let total_bits = u32::from(self.offset) + u32::from(self.length);
         // SAFETY: `ptr` is guaranteed to point at offset + original length
         // valid bits.  Furthermore, since original length was positive than
         // there’s at least one byte we can read.
-        let byte = unsafe { self.ptr.add(total_bits / 8).read() };
+        let byte = unsafe { self.ptr.add((total_bits / 8) as usize).read() };
         let mask = 0x80 >> (total_bits % 8);
         Some(byte & mask != 0)
     }
 
-    /// Returns subslice from the beginning of the slice shrinking the slice by
-    /// its length.
+    /// Returns subslice from the beginning of the slice shrinking it by length
+    /// of the returned prefix.
     ///
     /// Behaves like [`Self::split_at`] except instead of returning two slices
     /// it advances `self` and returns the head.  Returns `None` if the slice is
@@ -209,8 +209,8 @@ impl<'a> Slice<'a> {
         Some(head)
     }
 
-    /// Returns subslice from the end of the slice shrinking the slice by its
-    /// length.
+    /// Returns subslice from the end of the slice shrinking it by length
+    /// of the returned suffix.
     ///
     /// Behaves similarly to [`Self::split_at`] except the `length` is the
     /// length of the suffix and instead of returning two slices it shortens
@@ -440,23 +440,22 @@ impl<'a> Slice<'a> {
         (ExtKey::try_from(prefix).ok(), ExtKey::try_from(suffix).ok())
     }
 
-    /// Returns total number of underlying bits, i.e. bits in the slice plus the
-    /// offset.
-    fn underlying_bits_length(&self) -> usize {
-        usize::from(self.offset) + usize::from(self.length)
-    }
-
     /// Returns bytes underlying the bit slice.
     fn bytes(&self) -> &'a [u8] {
-        // We need to special-case zero length to make sure that in situation of
-        // non-zero offset and zero length we return an empty slice.
-        let len = match self.length {
-            0 => 0,
-            _ => (self.underlying_bits_length() + 7) / 8,
-        };
         // SAFETY: `ptr` is guaranteed to be valid pointer point at `offset +
         // length` valid bits.
-        unsafe { core::slice::from_raw_parts(self.ptr, len) }
+        unsafe { core::slice::from_raw_parts(self.ptr, self.bytes_len()) }
+    }
+
+    /// Calculates underlying bytes length of the slice.
+    fn bytes_len(&self) -> usize {
+        // We need to special-case zero length to make sure that in situation of
+        // non-zero offset and zero length we return an empty slice.
+        if self.length == 0 {
+            0
+        } else {
+            ((u32::from(self.offset) + u32::from(self.length) + 7) / 8) as usize
+        }
     }
 
     /// Helper method which returns masks for leading and trailing byte.
@@ -465,10 +464,7 @@ impl<'a> Slice<'a> {
     /// slice returns: mask of bits in the first byte that are part of the
     /// slice and mask of bits in the last byte that are part of the slice.
     fn masks(offset: U3, length: u16) -> (u8, u8) {
-        let bits = usize::from(offset) + usize::from(length);
-        // `1 << 20` is an arbitrary number which is divisible by 8 and greater
-        // than bits.
-        let tail = ((1 << 20) - bits) % 8;
+        let tail = -offset.wrapping_add(length);
         (0xFFu8 >> offset, 0xFFu8 << tail)
     }
 }
@@ -519,53 +515,17 @@ impl Owned {
         Self { bytes: alloc::vec![255 * u8::from(bit)], offset, length: 1 }
     }
 
-    /// Prepends given slice by a specified bit.
-    ///
-    /// Panics if length (in bits) of the resulting slice would exceed
-    /// `u16::MAX`.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use sealable_trie::bits::{Owned, Slice};
-    /// # use lib::u3::U3;
-    ///
-    /// let suffix = Slice::new(&[255], U3::_1, 5).unwrap();
-    /// let got = Owned::unshift(false, suffix);
-    /// assert_eq!(Slice::new(&[124], U3::_0, 6).unwrap(), got);
-    ///
-    /// let suffix = Slice::new(&[255], U3::_1, 5).unwrap();
-    /// let got = Owned::unshift(true, suffix);
-    /// assert_eq!(Slice::new(&[252], U3::_0, 6).unwrap(), got);
-    ///
-    /// let suffix = Slice::new(&[255], U3::_0, 5).unwrap();
-    /// let got = Owned::unshift(true, suffix);
-    /// assert_eq!(Slice::new(&[255, 255], U3::_7, 6).unwrap(), got);
-    /// ```
-    // TODO(mina86): Add consistent handling of length > u16::MAX.
-    pub fn unshift(bit: bool, suffix: Slice) -> Self {
-        let length = suffix.length.checked_add(1).unwrap();
-        let (bytes, offset) = if suffix.is_empty() {
-            let offset = suffix.offset.wrapping_dec();
-            let bytes = alloc::vec![255 * u8::from(bit)];
-            (bytes, offset)
-        } else if let Some(offset) = suffix.offset.checked_dec() {
-            let mut bytes = suffix.bytes().to_vec();
-            bytes[0] &= 0x7Fu8 >> offset;
-            bytes[0] |= (0x80 * u8::from(bit)) >> offset;
-            (bytes, offset)
-        } else {
-            let bit = u8::from(bit);
-            let bytes = [core::slice::from_ref(&bit), suffix.bytes()].concat();
-            (bytes, U3::MAX)
-        };
-        Self { bytes, offset, length }
+    /// Borrows the owned slice.
+    pub fn as_slice(&self) -> Slice {
+        Slice {
+            offset: self.offset,
+            length: self.length,
+            ptr: self.bytes.as_ptr(),
+            phantom: Default::default(),
+        }
     }
 
-    /// Append given bit to the slice.
-    ///
-    /// Returns `None` if length (in bits) of the resulting slice would exceed
-    /// `u16::MAX`.
+    /// Concatenates two slice-like objects.
     ///
     /// ## Example
     ///
@@ -573,36 +533,50 @@ impl Owned {
     /// # use sealable_trie::bits::{Owned, Slice};
     /// # use lib::u3::U3;
     ///
-    /// let bits = Slice::new(&[0b_0100_1101], U3::_1, 5).unwrap();
-    /// let mut bits = Owned::from(bits);
+    /// // Prepend single bit to a slice.
+    /// let suffix = Slice::new(&[255], U3::_0, 2).unwrap();
+    /// let got = Owned::concat(true, suffix).unwrap();
+    /// assert_eq!(Slice::new(&[1, 192], U3::_7, 3).unwrap(), got);
     ///
-    /// bits.push(true);
-    /// assert_eq!(Slice::new(&[0b_0100_1110], U3::_1, 6).unwrap(), bits);
-    ///
-    /// bits.push(false);
-    /// assert_eq!(Slice::new(&[0b_0100_1110], U3::_1, 7).unwrap(), bits);
-    ///
-    /// bits.push(true);
-    /// assert_eq!(Slice::new(&[0b_0100_1110, 0x80], U3::_1, 8).unwrap(), bits);
+    /// // Concatenate two slices
+    /// let prefix = Slice::new(&[0], U3::_3, 5).unwrap();
+    /// let suffix = Slice::new(&[255], U3::_0, 2).unwrap();
+    /// assert_eq!(Slice::new(&[0, 192], U3::_3, 7).unwrap(),
+    ///            Owned::concat(prefix, suffix).unwrap());
     /// ```
-    // TODO(mina86): Add consistent handling of length > u16::MAX.
-    pub fn push(&mut self, bit: bool) {
-        let off = self.underlying_bits_length() % 8;
-        self.length = self.length.checked_add(1).unwrap();
-        let mask = 0x80 >> off;
-        match self.bytes.last_mut() {
-            Some(byte) if off != 0 => {
-                // If self.bytes is non-empty and we’re not adding msb of a new
-                // byte (i.e. off != 0), modify the last byte.
-                *byte = (*byte & !mask) | (mask * u8::from(bit));
-            }
-            _ => {
-                // Otherwise, either self.bytes is empty (and thus we’re adding
-                // a new byte with given bit set) or we’re aligned at the byte
-                // boundary (and we’re adding a new byte with msb set).
-                self.bytes.push(mask * u8::from(bit));
-            }
-        }
+    pub fn concat<T: concat::Concat<U, Output = Owned>, U>(
+        prefix: T,
+        suffix: U,
+    ) -> Result<Owned, T::Error> {
+        T::concat_impl(prefix, suffix)
+    }
+
+    /// Extends this owned slice by given suffix.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use sealable_trie::bits::{Owned, Slice};
+    /// # use lib::u3::U3;
+    ///
+    /// // Append a slice.
+    /// let mut this = Owned::from(Slice::new(&[255, 255], U3::_7, 3).unwrap());
+    /// this.extend(Slice::new(&[0], U3::_2, 2).unwrap()).unwrap();
+    /// assert_eq!(Slice::new(&[1, 192], U3::_7, 5).unwrap(), this);
+    ///
+    /// /// Append a single bit.
+    /// let mut slice = Owned::from(Slice::new(&[77], U3::_1, 5).unwrap());
+    /// slice.extend(true);
+    /// assert_eq!(Slice::new(&[78], U3::_1, 6).unwrap(), slice);
+    /// ```
+    pub fn extend<'s, Rhs>(
+        &'s mut self,
+        suffix: Rhs,
+    ) -> Result<(), <&'s mut Owned as concat::Concat<Rhs>>::Error>
+    where
+        &'s mut Owned: concat::Concat<Rhs, Output = ()>,
+    {
+        <&'s mut Owned as concat::Concat<Rhs>>::concat_impl(self, suffix)
     }
 
     /// Returns the last bit in the slice shrinking the slice by one bit.
@@ -622,12 +596,44 @@ impl Owned {
     /// ```
     pub fn pop_back(&mut self) -> Option<bool> {
         self.length = self.length.checked_sub(1)?;
-        let off = self.underlying_bits_length() % 8;
-        let bit = *self.bytes.last().unwrap() & (0x80 >> off);
+        let off = self.offset.wrapping_add(self.length);
+        let bit = *self.bytes.last().unwrap() & (0x80u8 >> off);
         if off == 0 {
             self.bytes.pop();
         }
         Some(bit != 0)
+    }
+
+    /// Shortens the slice keeping the first `len` bits and dropping the rest.
+    ///
+    /// If `len` is greater or equal to the slice’s current length, this has no
+    /// effect.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use sealable_trie::bits::{Owned, Slice};
+    /// # use lib::u3::U3;
+    ///
+    /// let slice = Slice::new(&[255, 255], U3::_2, 8).unwrap();
+    /// let mut slice = Owned::from(slice);
+    /// assert_eq!(Slice::new(&[255, 255], U3::_2, 8).unwrap(), slice);
+    ///
+    /// slice.truncate(10);  // nop
+    /// assert_eq!(Slice::new(&[255, 255], U3::_2, 8).unwrap(), slice);
+    ///
+    /// slice.truncate(4);
+    /// assert_eq!(Slice::new(&[255], U3::_2, 4).unwrap(), slice);
+    ///
+    /// slice.truncate(0);
+    /// assert_eq!(Slice::new(&[], U3::_2, 0).unwrap(), slice);
+    /// ```
+    #[inline]
+    pub fn truncate(&mut self, len: u16) {
+        if len < self.length {
+            self.length = len;
+            self.bytes.truncate(self.as_slice().bytes_len());
+        }
     }
 
     /// Sets the last bit in the slice; panics if slice is empty.
@@ -648,82 +654,10 @@ impl Owned {
     /// assert_eq!(Slice::new(&[0x0f], U3::_4, 4).unwrap(), bits);
     /// ```
     pub fn set_last(&mut self, bit: bool) {
-        let bits = self.underlying_bits_length();
+        let shft = self.offset.wrapping_add(self.length).wrapping_dec();
+        let mask = 0x80u8 >> shft;
         let last = self.bytes.last_mut().unwrap();
-        let mask = 0x80 >> ((bits - 1) % 8);
         *last = (*last & !mask) | (mask * u8::from(bit));
-    }
-
-    /// Concatenates a [`Slice`] with [`Owned`].
-    ///
-    /// Returns `MisalignedError` if end of `prefix` doesn’t align with start
-    /// of `suffix` or if resulting length is too large.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// # use sealable_trie::bits::{Owned, Slice};
-    /// # use lib::u3::U3;
-    ///
-    /// let prefix = Slice::new(&[255], U3::_1, 5).unwrap();
-    /// let suffix = Owned::bit(true, U3::_6);
-    /// let got = Owned::concat(prefix, suffix.as_slice()).unwrap();
-    /// assert_eq!(Slice::new(&[126], U3::_1, 6).unwrap(), got);
-    ///
-    /// let prefix = Slice::new(&[0, 0], U3::_6, 3).unwrap();;
-    /// let suffix = got.as_slice();
-    /// let got = Owned::concat(prefix, suffix).unwrap();
-    /// assert_eq!(Slice::new(&[0, 126], U3::_6, 9).unwrap(), got);
-    /// ```
-    // TODO(mina86): Add consistent handling of length > u16::MAX.
-    pub fn concat(
-        prefix: Slice,
-        suffix: Slice,
-    ) -> Result<Self, MisalignedError> {
-        let prefix_bits =
-            usize::from(prefix.offset) + usize::from(prefix.length);
-        if usize::from(suffix.offset) != prefix_bits % 8 {
-            // Misaligned slices.
-            return Err(MisalignedError);
-        }
-
-        let pre_bytes = prefix.bytes();
-        let suf_bytes = suffix.bytes();
-        let bytes = if pre_bytes.is_empty() ||
-            suf_bytes.is_empty() ||
-            suffix.offset == 0
-        {
-            // If either of the slices is empty or they meet at a byte boundary
-            // we just need to concatenate the bytes and we’re good.
-            [pre_bytes, suf_bytes].concat()
-        } else {
-            // Otherwise, the two slices have one byte that overlaps.
-            // Concatenate excluding the first byte of the suffix and
-            let mut bytes = [pre_bytes, &suf_bytes[1..]].concat();
-            let mask = 255u8 >> suffix.offset;
-            bytes[pre_bytes.len() - 1] &= !mask;
-            bytes[pre_bytes.len() - 1] |= suf_bytes[0] & mask;
-            bytes
-        };
-
-        let length = suffix.length.checked_add(prefix.length).unwrap();
-        Ok(Self { bytes, offset: prefix.offset, length })
-    }
-
-    /// Borrows the owned slice.
-    pub fn as_slice(&self) -> Slice {
-        Slice {
-            offset: self.offset,
-            length: self.length,
-            ptr: self.bytes.as_ptr(),
-            phantom: Default::default(),
-        }
-    }
-
-    /// Returns total number of underlying bits, i.e. bits in the slice plus the
-    /// offset.
-    fn underlying_bits_length(&self) -> usize {
-        usize::from(self.offset) + usize::from(self.length)
     }
 }
 
@@ -782,53 +716,26 @@ impl core::cmp::PartialEq<Owned> for Slice<'_> {
 }
 
 
-/// Error when trying to concatenate bit slices or convert them into
-/// a continuous bytes vector.
-///
-/// # Example
-///
-/// The error can happen when trying to convert a bit slice which doesn’t cover
-/// full bytes into a vector of bytes.  This may happen even if the bit slice is
-/// empty if its offset is non-zero.
-///
-/// ```
-/// # use sealable_trie::bits::{MisalignedError, Slice};
-/// # use lib::u3::U3;
-///
-/// let slice = Slice::new(b"A", U3::_0, 8).unwrap();
-/// assert_eq!(b"A", <Vec<u8>>::try_from(slice).unwrap().as_slice());
-///
-/// let slice = Slice::new(b"A", U3::_0, 0).unwrap();
-/// assert_eq!(b"", <Vec<u8>>::try_from(slice).unwrap().as_slice());
-///
-/// let slice = Slice::new(b"A", U3::_0, 4).unwrap();
-/// assert_eq!(Err(MisalignedError), <Vec<u8>>::try_from(slice));
-///
-/// let slice = Slice::new(b"A", U3::_4, 0).unwrap();
-/// assert_eq!(Err(MisalignedError), <Vec<u8>>::try_from(slice));
-/// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct MisalignedError;
 
 impl TryFrom<Slice<'_>> for Vec<u8> {
-    type Error = MisalignedError;
+    type Error = MisalignedSlice;
     #[inline]
     fn try_from(slice: Slice<'_>) -> Result<Self, Self::Error> {
         if slice.offset == 0 && slice.length % 8 == 0 {
             Ok(slice.bytes().into())
         } else {
-            Err(MisalignedError)
+            Err(MisalignedSlice)
         }
     }
 }
 
 impl TryFrom<Owned> for Vec<u8> {
-    type Error = MisalignedError;
+    type Error = MisalignedSlice;
     fn try_from(slice: Owned) -> Result<Self, Self::Error> {
         if slice.offset == 0 && slice.length % 8 == 0 {
             Ok(slice.bytes)
         } else {
-            Err(MisalignedError)
+            Err(MisalignedSlice)
         }
     }
 }
@@ -845,17 +752,17 @@ impl fmt::Display for Slice<'_> {
             }
         }
 
-        let mut off = usize::from(self.offset);
-        let mut len = off + usize::from(self.length);
+        let mut off = u32::from(self.offset);
+        let mut len = off + u32::from(self.length);
         let mut buf = [AsciiChar::Null; 9];
         buf[0] = AsciiChar::b;
 
         fmtr.write_str(if self.length == 0 { "∅" } else { "0" })?;
         for byte in self.bytes() {
             fmt(&mut buf[1..], *byte);
-            buf[1..1 + off].fill(AsciiChar::Dot);
+            buf[1..1 + (off as usize)].fill(AsciiChar::Dot);
             if len < 8 {
-                buf[1 + len..].fill(AsciiChar::Dot);
+                buf[1 + (len as usize)..].fill(AsciiChar::Dot);
             } else {
                 off = 0;
                 len -= 8 - off;
@@ -1004,72 +911,4 @@ fn test_pop() {
 
     test_set(false, |slice| slice.pop_front());
     test_set(true, |slice| slice.pop_back());
-}
-
-#[test]
-fn test_owned_unshift() {
-    for offset in U3::all() {
-        let slice = Slice::new(&[255], offset, 1).unwrap();
-        let want = offset
-            .checked_dec()
-            .map_or_else(
-                || Slice::new(&[1, 128], U3::_7, 2),
-                |offset| Slice::new(&[255], offset, 2),
-            )
-            .unwrap();
-        assert_eq!(want, Owned::unshift(true, slice), "offset: {offset}");
-    }
-}
-
-#[test]
-fn test_owned_push() {
-    let mut bits = Owned::from(Slice::new(&[255], U3::_1, 1).unwrap());
-
-    let mut push = |bit, want| {
-        let want = Slice::new(want, U3::_1, bits.length + 1).unwrap();
-        bits.push(bit != 0);
-        assert_eq!(want, bits);
-    };
-
-    push(1, &[0b_0110_0000]);
-    push(1, &[0b_0111_0000]);
-    push(0, &[0b_0111_0000]);
-    push(0, &[0b_0111_0000]);
-    push(1, &[0b_0111_0010]);
-    push(1, &[0b_0111_0011]);
-    push(1, &[0b_0111_0011, 0b_1000_0000]);
-}
-
-#[test]
-fn test_owned_push_from_empty() {
-    for offset in U3::all() {
-        let mut bits = Owned::from(Slice::new(&[], offset, 0).unwrap());
-        for length in 1..=16 {
-            let want = Slice::new(&[255, 255, 255], offset, length).unwrap();
-            bits.push(true);
-            assert_eq!(want, bits);
-        }
-    }
-}
-
-#[test]
-fn test_owned_concat() {
-    for len in 0..=8 {
-        let bytes = (0xFF00_u16 >> len).to_be_bytes();
-        let want = Slice::new(&bytes[1..], U3::_0, 8).unwrap();
-
-        let prefix = Slice::new(&[255], U3::_0, len).unwrap();
-        let suffix = Slice::new(&[0], U3::wrap(len), 8 - len).unwrap();
-        let got = Owned::concat(prefix, suffix).unwrap();
-        assert_eq!(want, got, "len: {len}");
-    }
-}
-
-#[test]
-fn test_owned_concat_empty() {
-    for offset in U3::all() {
-        let slice = Slice::new(&[], offset, 0).unwrap();
-        let got = Owned::concat(slice, slice).unwrap();
-        assert_eq!(slice, got, "offset: {offset}");
-    }
 }

--- a/common/sealable-trie/src/bits/concat.rs
+++ b/common/sealable-trie/src/bits/concat.rs
@@ -1,0 +1,455 @@
+use alloc::vec::Vec;
+
+use lib::u3::U3;
+
+use super::{Owned, Slice};
+
+
+/// Trying to concatenate slices which result in slice whose size is too large.
+///
+/// Slice’s total underlying bits length (that is length plus offset) must not
+/// overflow u16.
+///
+/// ## Example
+///
+/// The error can happen when trying to convert a bit slice which doesn’t cover
+/// full bytes into a vector of bytes.  This may happen even if the bit slice is
+/// empty if its offset is non-zero.
+///
+/// ```
+/// # use sealable_trie::bits::{MisalignedSlice, Slice, Owned, concat};
+/// # use lib::u3::U3;
+///
+/// let buf = [255; 4096];
+/// let slice = Slice::from_bytes(&buf[..]).unwrap();
+/// assert_eq!(Err(concat::Error::SliceTooLong), Owned::concat(slice, slice));
+///
+/// let (suffix, _) = slice.split_at(slice.len() - 1).unwrap();
+/// Owned::concat(slice, suffix).unwrap();
+/// ```
+// TODO(mina86): Review code and weaken the requirement.  In reality we don’t
+// care if offset + length overflows u16.  Usually when we add those numbers we
+// either i) do it module eight or ii) do it to calculate underlying bytes
+// length in which case we can do intermediate calculation in u32.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SliceTooLong;
+
+/// Trying to concatenate misaligned slices or convert slices which doesn’t
+/// cover full bytes into a vector.
+///
+/// ## Example
+///
+/// The error can happen when trying to convert a bit slice which doesn’t cover
+/// full bytes into a vector of bytes.  This may happen even if the bit slice is
+/// empty if its offset is non-zero.
+///
+/// ```
+/// # use sealable_trie::bits::{MisalignedSlice, Slice, Owned, concat};
+/// # use lib::u3::U3;
+///
+/// // Converting slices into Vec<u8>.
+/// let slice = Slice::new(b"A", U3::_0, 8).unwrap();
+/// assert_eq!(b"A", <Vec<u8>>::try_from(slice).unwrap().as_slice());
+///
+/// let slice = Slice::new(b"A", U3::_0, 0).unwrap();
+/// assert_eq!(b"", <Vec<u8>>::try_from(slice).unwrap().as_slice());
+///
+/// let slice = Slice::new(b"A", U3::_0, 4).unwrap();
+/// assert_eq!(Err(MisalignedSlice), <Vec<u8>>::try_from(slice));
+///
+/// let slice = Slice::new(b"A", U3::_4, 0).unwrap();
+/// assert_eq!(Err(MisalignedSlice), <Vec<u8>>::try_from(slice));
+/// ```
+///
+/// It also happens when concatenating misaligned bit slices (that is extending
+/// a slice whose end bit offset doesn’t match suffix’s start bit offset).
+/// Alas, in those cases the error is returned through a [`Error`] enum.
+///
+/// ```
+/// # use sealable_trie::bits::{MisalignedSlice, Slice, Owned, concat};
+/// # use lib::u3::U3;
+///
+/// // Failure when concatenating misaligned slices.
+/// let prefix = Slice::new(&[255], U3::_1, 5).unwrap();
+/// let suffix = Slice::new(&[255], U3::_3, 2).unwrap();
+/// assert_eq!(Err(concat::Error::Misaligned), Owned::concat(prefix, suffix));
+/// ```
+#[derive(Debug, PartialEq, Eq)]
+pub struct MisalignedSlice;
+
+/// Error during concatenation of two slice-like objects.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    SliceTooLong,
+    Misaligned,
+}
+
+impl From<SliceTooLong> for Error {
+    fn from(_: SliceTooLong) -> Error { Error::SliceTooLong }
+}
+
+impl From<MisalignedSlice> for Error {
+    fn from(_: MisalignedSlice) -> Error { Error::Misaligned }
+}
+
+
+pub trait Concat<Rhs> {
+    type Output;
+    type Error: Into<Error>;
+
+    fn concat_impl(
+        prefix: Self,
+        suffix: Rhs,
+    ) -> Result<Self::Output, Self::Error>;
+}
+
+
+impl<'a> Concat<Slice<'a>> for bool {
+    type Output = Owned;
+    type Error = SliceTooLong;
+
+    /// Prepends given slice by a specified bit.
+    ///
+    /// Returns error if length (in bits) including of the resulting slice would
+    /// be too long.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use sealable_trie::bits::{Owned, Slice};
+    /// # use lib::u3::U3;
+    ///
+    /// let suffix = Slice::new(&[255], U3::_1, 5).unwrap();
+    /// let got = Owned::concat(false, suffix).unwrap();
+    /// assert_eq!(Slice::new(&[124], U3::_0, 6).unwrap(), got);
+    ///
+    /// let suffix = Slice::new(&[255], U3::_1, 5).unwrap();
+    /// let got = Owned::concat(true, suffix).unwrap();
+    /// assert_eq!(Slice::new(&[252], U3::_0, 6).unwrap(), got);
+    ///
+    /// let suffix = Slice::new(&[255], U3::_0, 5).unwrap();
+    /// let got = Owned::concat(true, suffix).unwrap();
+    /// assert_eq!(Slice::new(&[255, 255], U3::_7, 6).unwrap(), got);
+    /// ```
+    fn concat_impl(
+        bit: bool,
+        suffix: Slice<'a>,
+    ) -> Result<Self::Output, Self::Error> {
+        let offset = suffix.offset.wrapping_dec();
+        let length = check_length(1, suffix.length)?;
+        let bytes = if suffix.is_empty() {
+            alloc::vec![255 * u8::from(bit)]
+        } else if offset == U3::MAX {
+            let bit = u8::from(bit);
+            [core::slice::from_ref(&bit), suffix.bytes()].concat()
+        } else {
+            let mut bytes = suffix.bytes().to_vec();
+            bytes[0] &= 0x7Fu8 >> offset;
+            bytes[0] |= (0x80 * u8::from(bit)) >> offset;
+            bytes
+        };
+        Ok(Owned { offset, length, bytes })
+    }
+}
+
+impl<'a, 'b> Concat<Slice<'b>> for Slice<'a> {
+    type Output = Owned;
+    type Error = Error;
+
+    /// Concatenates two slices.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use sealable_trie::bits::{Owned, Slice};
+    /// # use lib::u3::U3;
+    ///
+    /// let prefix = Slice::new(&[255], U3::_1, 5).unwrap();
+    /// let suffix = Slice::new(&[255], U3::_6, 1).unwrap();
+    /// let got = Owned::concat(prefix, suffix).unwrap();
+    /// assert_eq!(Slice::new(&[126], U3::_1, 6).unwrap(), got);
+    ///
+    /// let prefix = Slice::new(&[0, 0], U3::_6, 3).unwrap();;
+    /// let suffix = got.as_slice();
+    /// let got = Owned::concat(prefix, suffix).unwrap();
+    /// assert_eq!(Slice::new(&[0, 126], U3::_6, 9).unwrap(), got);
+    /// ```
+    fn concat_impl(
+        prefix: Slice<'a>,
+        suffix: Slice<'b>,
+    ) -> Result<Self::Output, Self::Error> {
+        let length = check_alignment_and_length(
+            prefix.offset,
+            prefix.length,
+            suffix.offset,
+            suffix.length,
+        )?;
+        if length == 0 {
+            return Ok(if prefix.is_empty() { suffix } else { prefix }.into());
+        }
+
+        let capacity = (u32::from(prefix.offset) + u32::from(length) + 7) / 8;
+        let mut bytes = Vec::with_capacity(capacity as usize);
+        bytes.extend_from_slice(prefix.bytes());
+        let mut slice =
+            Owned { offset: prefix.offset, length: prefix.length, bytes };
+        // SAFETY: We’ve checked aligned using check_alignment and length when
+        // calculating total_bits.
+        unsafe { extend_impl(&mut slice, suffix) };
+        Ok(slice)
+    }
+}
+
+impl<'a> Concat<Slice<'a>> for Owned {
+    type Output = Self;
+    type Error = Error;
+
+    /// Appends suffix to given owned slice and returns the slice after
+    /// modification.
+    fn concat_impl(
+        mut this: Self,
+        suffix: Slice<'a>,
+    ) -> Result<Self, Self::Error> {
+        <&mut Owned>::concat_impl(&mut this, suffix)?;
+        Ok(this)
+    }
+}
+
+impl<'a, 's> Concat<Slice<'a>> for &'s mut Owned {
+    type Output = ();
+    type Error = Error;
+
+    /// Appends suffix to given owned slice in place.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use sealable_trie::bits::{Owned, Slice};
+    /// # use lib::u3::U3;
+    ///
+    /// let mut this = Owned::from(Slice::new(&[255], U3::_1, 5).unwrap());
+    /// this.extend(Slice::new(&[255], U3::_6, 1).unwrap()).unwrap();
+    /// assert_eq!(Slice::new(&[126], U3::_1, 6).unwrap(), this);
+    ///
+    /// this.extend(Slice::new(&[255], U3::_7, 1).unwrap()).unwrap();
+    /// assert_eq!(Slice::new(&[127], U3::_1, 7).unwrap(), this);
+    /// ```
+    fn concat_impl(
+        prefix: &'s mut Owned,
+        suffix: Slice<'a>,
+    ) -> Result<Self::Output, Self::Error> {
+        check_alignment_and_length(
+            prefix.offset,
+            prefix.length,
+            suffix.offset,
+            suffix.length,
+        )?;
+        // SAFETY: We’ve just checked aligned and length.
+        unsafe { extend_impl(prefix, suffix) };
+        Ok(())
+    }
+}
+
+impl Concat<bool> for Owned {
+    type Output = Self;
+    type Error = SliceTooLong;
+
+    fn concat_impl(mut this: Self, suffix: bool) -> Result<Self, Self::Error> {
+        <&mut Owned>::concat_impl(&mut this, suffix)?;
+        Ok(this)
+    }
+}
+
+impl<'s> Concat<bool> for &'s mut Owned {
+    type Output = ();
+    type Error = SliceTooLong;
+
+    /// Append given bit to the slice.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use sealable_trie::bits::{Owned, Slice};
+    /// # use lib::u3::U3;
+    ///
+    /// let bits = Slice::new(&[0b_0100_1101], U3::_1, 5).unwrap();
+    /// let mut bits = Owned::from(bits);
+    ///
+    /// bits.extend(true);
+    /// assert_eq!(Slice::new(&[0b_0100_1110], U3::_1, 6).unwrap(), bits);
+    ///
+    /// bits.extend(false);
+    /// assert_eq!(Slice::new(&[0b_0100_1110], U3::_1, 7).unwrap(), bits);
+    ///
+    /// bits.extend(true);
+    /// assert_eq!(Slice::new(&[0b_0100_1110, 0x80], U3::_1, 8).unwrap(), bits);
+    /// ```
+    fn concat_impl(
+        this: &'s mut Owned,
+        bit: bool,
+    ) -> Result<Self::Output, Self::Error> {
+        check_length(this.length, 1)?;
+        let off = this.offset.wrapping_add(this.length);
+        let mask: u8 = 0x80u8 >> off;
+        match this.bytes.last_mut() {
+            Some(byte) if off != 0 => {
+                // If this.bytes is non-empty and we’re not adding msb of
+                // a new byte (i.e. off != 0), modify the last byte.
+                *byte = (*byte & !mask) | (mask * u8::from(bit));
+            }
+            _ => {
+                // Otherwise, either this.bytes is empty (and thus we’re
+                // adding a new byte with given bit set) or we’re aligned at the
+                // byte boundary (and we’re adding a new byte with msb set).
+                this.bytes.push(mask * u8::from(bit));
+            }
+        }
+        this.length += 1;
+        Ok(())
+    }
+}
+
+
+/// Extends owned slice with given suffix.
+///
+/// ## Safety
+///
+/// It’s caller’s responsibility to check i) alignment of the two slices (see
+/// [`check_alignment`])) and ii) length of the resulting slice (see
+/// [`check_length`]).
+unsafe fn extend_impl(this: &mut Owned, suffix: Slice) {
+    if cfg!(debug_assertions) {
+        check_alignment_and_length(
+            this.offset,
+            this.length,
+            suffix.offset,
+            suffix.length,
+        )
+        .unwrap();
+    }
+
+    let bytes = match (this.bytes.last_mut(), suffix.bytes()) {
+        (Some(last), &[first, ref rest @ ..]) if suffix.offset != 0 => {
+            // Neither slice is empty and they don’t meet at a byte boundary.
+            // There’s an overlapping byte which needs special adjustment.  Once
+            // that’s done, the rest of the suffix can be appended.
+            let mask = 255u8 >> suffix.offset;
+            *last = (*last & !mask) | (first & mask);
+            rest
+        }
+        (_, suffix) => {
+            // Either one of the slices is empty or they meet at a byte
+            // boundary.  We just need to append suffix.
+            suffix
+        }
+    };
+    this.bytes.extend_from_slice(bytes);
+    this.length += suffix.length;
+}
+
+
+/// Checks that concatenating two slices produces slice whose length doesn’t
+/// overflow `u16`.
+fn check_length(pre_len: u16, suf_len: u16) -> Result<u16, SliceTooLong> {
+    pre_len.checked_add(suf_len).ok_or(SliceTooLong)
+}
+
+/// Checks that two slices are aligned.
+///
+/// Checks that prefix slice’s end bit offset equals suffix slice’s offset.
+/// That is, that `pre_off + pre_len` is congruent to `suf_off`.
+fn check_alignment(
+    pre_off: U3,
+    pre_len: u16,
+    suf_off: U3,
+) -> Result<(), MisalignedSlice> {
+    if U3::wrap(pre_len).wrapping_add(pre_off) != suf_off {
+        return Err(MisalignedSlice);
+    }
+    Ok(())
+}
+
+/// Checks that two slices are aligned and, when concatenated, produce slice
+/// with valid length.
+///
+/// Combines checks performed by [`check_length`] and [`check_alignment`].  If
+/// both checks fail, it’s unspecified which error is returned.
+fn check_alignment_and_length(
+    pre_off: U3,
+    pre_len: u16,
+    suf_off: U3,
+    suf_len: u16,
+) -> Result<u16, Error> {
+    check_alignment(pre_off, pre_len, suf_off)?;
+    Ok(check_length(pre_len, suf_len)?)
+}
+
+
+#[test]
+fn test_unshift() {
+    for offset in U3::all() {
+        let slice = Slice::new(&[255], offset, 1).unwrap();
+        let want = offset
+            .checked_dec()
+            .map_or_else(
+                || Slice::new(&[1, 128], U3::_7, 2),
+                |offset| Slice::new(&[255], offset, 2),
+            )
+            .unwrap();
+        let got = Owned::concat(true, slice).unwrap();
+        assert_eq!(want, got, "offset: {offset}");
+    }
+}
+
+#[test]
+fn test_push() {
+    let mut bits = Owned::from(Slice::new(&[255], U3::_1, 1).unwrap());
+
+    let mut push = |bit, want| {
+        let want = Slice::new(want, U3::_1, bits.length + 1).unwrap();
+        bits.extend(bit != 0).unwrap();
+        assert_eq!(want, bits);
+    };
+
+    push(1, &[0b_0110_0000]);
+    push(1, &[0b_0111_0000]);
+    push(0, &[0b_0111_0000]);
+    push(0, &[0b_0111_0000]);
+    push(1, &[0b_0111_0010]);
+    push(1, &[0b_0111_0011]);
+    push(1, &[0b_0111_0011, 0b_1000_0000]);
+}
+
+#[test]
+fn test_push_from_empty() {
+    for offset in U3::all() {
+        let mut bits = Owned::from(Slice::new(&[], offset, 0).unwrap());
+        for length in 1..=16 {
+            let want = Slice::new(&[255, 255, 255], offset, length).unwrap();
+            bits.extend(true).unwrap();
+            assert_eq!(want, bits);
+        }
+    }
+}
+
+#[test]
+fn test_concat() {
+    for len in 0..=8 {
+        let bytes = (0xFF00_u16 >> len).to_be_bytes();
+        let want = Slice::new(&bytes[1..], U3::_0, 8).unwrap();
+
+        let prefix = Slice::new(&[255], U3::_0, len).unwrap();
+        let suffix = Slice::new(&[0], U3::wrap(len), 8 - len).unwrap();
+        let got = Owned::concat(prefix, suffix).unwrap();
+        assert_eq!(want, got, "len: {len}");
+    }
+}
+
+#[test]
+fn test_concat_empty() {
+    for offset in U3::all() {
+        let slice = Slice::new(&[], offset, 0).unwrap();
+        let got = Owned::concat(slice, slice).unwrap();
+        assert_eq!(slice, got, "offset: {offset}");
+    }
+}

--- a/common/sealable-trie/src/trie/del.rs
+++ b/common/sealable-trie/src/trie/del.rs
@@ -113,7 +113,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
         let child = children[1 - side];
         Ok(self
             .maybe_pop_extension(child, &|key| {
-                bits::Owned::unshift(side == 0, key.into())
+                bits::Owned::concat(side == 0, key.into_slice()).unwrap()
             })?
             .unwrap_or_else(|| {
                 Action::Ext(
@@ -140,7 +140,8 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
                 Action::Ext(bits::Slice::from(key).into(), child)
             }
             Action::Ext(suffix, child) => {
-                let key = bits::Owned::concat(key.into(), suffix.as_slice());
+                let key =
+                    bits::Owned::concat(key.into_slice(), suffix.as_slice());
                 Action::Ext(key.unwrap(), child)
             }
         })


### PR DESCRIPTION
Add Owned::extend method which allows appending slices to the owned slice.

Do this through a generic concat::Concat trait and refactor other
concatenating methods to use a unified interface.  Specifically, this
removes unshift and push in favour of more flexible concat and a new
extend method.  Hopefully `Owned::concat(true, slice)` is more
descriptive than `Owned::unshift(true, slice)`.

With the new unified interfaces also comes more uniform error
handling.  Introduce concat::Error, concat::MisalignedSlice and
concat::SliceTooLong errors which are now consistently returned when
concatenation fails.  This covers length checking better and
eliminates panics if length of a concatenated slice is too large.

Furthermore, add Owned::truncate method which allows shortening of the
slice to specified length.  The method is akin to Vec::truncate and
has no effect if given length is longer than length of the slice.
