### PR TITLE
solana-ibc: simplify storage lifetimes

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -139,7 +139,7 @@ impl borsh::BorshDeserialize for AnyClientState {
     }
 }
 
-impl ClientStateValidation<IbcStorage<'_, '_, '_>> for AnyClientState {
+impl ClientStateValidation<IbcStorage<'_, '_>> for AnyClientState {
     fn verify_client_message(
         &self,
         ctx: &IbcStorage,
@@ -334,7 +334,7 @@ impl ClientStateCommon for AnyClientState {
     }
 }
 
-impl ClientStateExecution<IbcStorage<'_, '_, '_>> for AnyClientState {
+impl ClientStateExecution<IbcStorage<'_, '_>> for AnyClientState {
     fn initialise(
         &self,
         ctx: &mut IbcStorage,
@@ -422,7 +422,7 @@ impl ClientStateExecution<IbcStorage<'_, '_, '_>> for AnyClientState {
     }
 }
 
-impl ibc::tm::CommonContext for IbcStorage<'_, '_, '_> {
+impl ibc::tm::CommonContext for IbcStorage<'_, '_> {
     type ConversionError = &'static str;
 
     type AnyConsensusState = AnyConsensusState;
@@ -458,7 +458,7 @@ impl ibc::tm::CommonContext for IbcStorage<'_, '_, '_> {
 }
 
 #[cfg(any(test, feature = "mocks"))]
-impl ibc::mock::MockClientContext for IbcStorage<'_, '_, '_> {
+impl ibc::mock::MockClientContext for IbcStorage<'_, '_> {
     type ConversionError = &'static str;
     type AnyConsensusState = AnyConsensusState;
 
@@ -478,7 +478,7 @@ impl ibc::mock::MockClientContext for IbcStorage<'_, '_, '_> {
     }
 }
 
-impl ibc::tm::ValidationContext for IbcStorage<'_, '_, '_> {
+impl ibc::tm::ValidationContext for IbcStorage<'_, '_> {
     fn next_consensus_state(
         &self,
         client_id: &ibc::ClientId,
@@ -502,7 +502,7 @@ enum Direction {
     Prev,
 }
 
-impl IbcStorage<'_, '_, '_> {
+impl IbcStorage<'_, '_> {
     fn get_consensus_state(
         &self,
         client_id: &ibc::ClientId,

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -12,7 +12,7 @@ use crate::storage::{self, ids, IbcStorage};
 
 type Result<T = (), E = ibc::ContextError> = core::result::Result<T, E>;
 
-impl ibc::ClientExecutionContext for IbcStorage<'_, '_, '_> {
+impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
     type V = Self; // ClientValidationContext
     type AnyClientState = AnyClientState;
     type AnyConsensusState = AnyConsensusState;
@@ -125,7 +125,7 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_, '_> {
     }
 }
 
-impl ibc::ExecutionContext for IbcStorage<'_, '_, '_> {
+impl ibc::ExecutionContext for IbcStorage<'_, '_> {
     /// Does nothing in the current implementation.
     ///
     /// The clients are stored in the vector so we can easily find how many
@@ -308,7 +308,7 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_, '_> {
     fn get_client_execution_context(&mut self) -> &mut Self::E { self }
 }
 
-impl storage::IbcStorage<'_, '_, '_> {
+impl storage::IbcStorage<'_, '_> {
     fn store_commitment(&mut self, key: TrieKey, commitment: &[u8]) -> Result {
         // Caller promises that commitment is always 32 bytes.
         let commitment = <&CryptoHash>::try_from(commitment).unwrap();
@@ -337,7 +337,7 @@ impl storage::IbcStorage<'_, '_, '_> {
     }
 }
 
-impl storage::IbcStorageInner<'_, '_, '_> {
+impl storage::IbcStorageInner<'_, '_> {
     /// Serialises `value` and stores it in private storage along with its
     /// commitment in provable storage.
     ///

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -47,8 +47,7 @@ pub mod solana_ibc {
         config: chain::Config,
         genesis_epoch: chain::Epoch,
     ) -> Result<()> {
-        let mut provable =
-            storage::get_provable_from(&ctx.accounts.trie)?;
+        let mut provable = storage::get_provable_from(&ctx.accounts.trie)?;
         ctx.accounts.chain.initialise(&mut provable, config, genesis_epoch)
     }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
@@ -7,8 +7,8 @@ use crate::ibc::{ClientExecutionContext, ExecutionContext, ValidationContext};
 use crate::{error, host, ibc, storage, MockDeliver, MINT_ESCROW_SEED};
 
 
-pub fn mock_deliver_impl(
-    ctx: Context<MockDeliver>,
+pub fn mock_deliver_impl<'a, 'info>(
+    ctx: Context<'a, 'a, 'a, 'info, MockDeliver<'info>>,
     port_id: ibc::PortId,
     _channel_id: ibc::ChannelId,
     _base_denom: String,
@@ -17,8 +17,7 @@ pub fn mock_deliver_impl(
     counterparty_client_id: ibc::ClientId,
 ) -> Result<()> {
     let private = &mut ctx.accounts.storage;
-    let provable = storage::get_provable_from(&ctx.accounts.trie, "trie")?;
-    let accounts = ctx.remaining_accounts;
+    let provable = storage::get_provable_from(&ctx.accounts.trie)?;
 
     let host_head = host::Head::get()?;
     let (host_timestamp, host_height) = host_head
@@ -30,7 +29,7 @@ pub fn mock_deliver_impl(
     let mut store = storage::IbcStorage::new(storage::IbcStorageInner {
         private,
         provable,
-        accounts: accounts.to_vec(),
+        accounts: ctx.remaining_accounts,
         host_head,
     });
 

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -265,9 +265,7 @@ pub(crate) struct IbcStorageInner<'a, 'b> {
 /// Accessing the data must follow aliasing rules as enforced by `RefCell`.
 /// Violations will cause a panic.
 #[derive(Debug, Clone)]
-pub(crate) struct IbcStorage<'a, 'b>(
-    Rc<RefCell<IbcStorageInner<'a, 'b>>>,
-);
+pub(crate) struct IbcStorage<'a, 'b>(Rc<RefCell<IbcStorageInner<'a, 'b>>>);
 
 impl<'a, 'b> IbcStorage<'a, 'b> {
     /// Constructs a new object with given inner storage.

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -75,7 +75,7 @@ impl TryFrom<&AccountId> for Pubkey {
     }
 }
 
-impl TokenTransferExecutionContext for IbcStorage<'_, '_, '_> {
+impl TokenTransferExecutionContext for IbcStorage<'_, '_> {
     fn send_coins_execute(
         &mut self,
         from: &Self::AccountId,
@@ -243,7 +243,7 @@ impl TokenTransferExecutionContext for IbcStorage<'_, '_, '_> {
     }
 }
 
-impl TokenTransferValidationContext for IbcStorage<'_, '_, '_> {
+impl TokenTransferValidationContext for IbcStorage<'_, '_> {
     type AccountId = AccountId;
 
     fn get_port(&self) -> Result<ibc::PortId, TokenTransferError> {

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -11,7 +11,7 @@ use crate::storage::IbcStorage;
 
 mod impls;
 
-impl ibc::Module for IbcStorage<'_, '_, '_> {
+impl ibc::Module for IbcStorage<'_, '_> {
     fn on_chan_open_init_validate(
         &self,
         order: ibc::chan::Order,

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -12,7 +12,7 @@ use crate::storage::{self, ids, IbcStorage};
 
 type Result<T = (), E = ibc::ContextError> = core::result::Result<T, E>;
 
-impl ibc::ValidationContext for IbcStorage<'_, '_, '_> {
+impl ibc::ValidationContext for IbcStorage<'_, '_> {
     type V = Self; // ClientValidationContext
     type E = Self; // ibc::ClientExecutionContext
     type AnyConsensusState = AnyConsensusState;
@@ -265,7 +265,7 @@ impl ibc::ValidationContext for IbcStorage<'_, '_, '_> {
     }
 }
 
-impl ibc::ClientValidationContext for IbcStorage<'_, '_, '_> {
+impl ibc::ClientValidationContext for IbcStorage<'_, '_> {
     fn client_update_time(
         &self,
         client_id: &ibc::ClientId,
@@ -312,7 +312,7 @@ impl ibc::ClientValidationContext for IbcStorage<'_, '_, '_> {
     }
 }
 
-impl IbcStorage<'_, '_, '_> {
+impl IbcStorage<'_, '_> {
     fn get_next_sequence<'a>(
         &self,
         path: impl Into<storage::trie_key::SequencePath<'a>>,
@@ -320,7 +320,7 @@ impl IbcStorage<'_, '_, '_> {
         make_err: impl FnOnce(ibc::PortId, ibc::ChannelId) -> ibc::PacketError,
     ) -> Result<ibc::Sequence> {
         fn get(
-            this: &IbcStorage<'_, '_, '_>,
+            this: &IbcStorage<'_, '_>,
             port_channel: &ids::PortChannelPK,
             index: storage::SequenceTripleIdx,
         ) -> Option<ibc::Sequence> {


### PR DESCRIPTION
Tighten lifetimes in entrypoint functions so that we can get rid of
third lifetime argument in IbcStorage structure.  With that also
replace `accounts` field from being a vector into being a slice
reference which avoids allocation.
