### PR TITLE
blockchain: change timestamp to be non-zero

### DIFF
--- a/common/blockchain/src/block.rs
+++ b/common/blockchain/src/block.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroU64;
+
 use lib::hash::CryptoHash;
 
 type Result<T, E = borsh::maybestd::io::Error> = core::result::Result<T, E>;
@@ -28,7 +30,7 @@ pub struct Block<PK> {
     /// Height of the host blockchain’s block in which this block was created.
     pub host_height: crate::HostHeight,
     /// Timestamp of the host blockchani’s block in which this block was created.
-    pub host_timestamp: u64,
+    pub host_timestamp: NonZeroU64,
     /// Hash of the root node of the state trie, i.e. the commitment
     /// of the state.
     pub state_root: CryptoHash,
@@ -97,7 +99,7 @@ impl<PK: crate::PubKey> Block<PK> {
     pub fn generate_next(
         &self,
         host_height: crate::HostHeight,
-        host_timestamp: u64,
+        host_timestamp: NonZeroU64,
         state_root: CryptoHash,
         next_epoch: Option<crate::Epoch<PK>>,
     ) -> Result<Self, GenerateError> {
@@ -134,7 +136,7 @@ impl<PK: crate::PubKey> Block<PK> {
     pub fn generate_genesis(
         block_height: crate::BlockHeight,
         host_height: crate::HostHeight,
-        host_timestamp: u64,
+        host_timestamp: NonZeroU64,
         state_root: CryptoHash,
         next_epoch: crate::Epoch<PK>,
     ) -> Result<Self, GenerateError> {
@@ -229,7 +231,7 @@ fn test_block_generation() {
     let genesis = Block::generate_genesis(
         crate::BlockHeight::from(0),
         crate::HostHeight::from(42),
-        24,
+        NonZeroU64::new(24).unwrap(),
         CryptoHash::test(66),
         crate::Epoch::test(&[(0, 10), (1, 10)]),
     )
@@ -253,7 +255,7 @@ fn test_block_generation() {
         Err(GenerateError::BadHostHeight),
         genesis.generate_next(
             crate::HostHeight::from(42),
-            100,
+            NonZeroU64::new(100).unwrap(),
             CryptoHash::test(99),
             None
         )
@@ -262,7 +264,7 @@ fn test_block_generation() {
         Err(GenerateError::BadHostTimestamp),
         genesis.generate_next(
             crate::HostHeight::from(43),
-            24,
+            NonZeroU64::new(24).unwrap(),
             CryptoHash::test(99),
             None
         )
@@ -272,7 +274,7 @@ fn test_block_generation() {
     let block = genesis
         .generate_next(
             crate::HostHeight::from(50),
-            50,
+            NonZeroU64::new(50).unwrap(),
             CryptoHash::test(99),
             None,
         )
@@ -290,7 +292,7 @@ fn test_block_generation() {
     let block = block
         .generate_next(
             crate::HostHeight::from(60),
-            60,
+            NonZeroU64::new(60).unwrap(),
             CryptoHash::test(99),
             epoch,
         )
@@ -305,7 +307,7 @@ fn test_block_generation() {
     let block = block
         .generate_next(
             crate::HostHeight::from(65),
-            65,
+            NonZeroU64::new(65).unwrap(),
             CryptoHash::test(99),
             None,
         )

--- a/common/blockchain/src/height.rs
+++ b/common/blockchain/src/height.rs
@@ -51,7 +51,7 @@ impl<T> Height<T> {
 macro_rules! impls {
     ($ty:ident) => {
         impl<T> Clone for $ty<T> {
-            fn clone(&self) -> Self { Self(self.0, self.1) }
+            fn clone(&self) -> Self { *self }
         }
 
         impl<T> Copy for $ty<T> {}

--- a/common/blockchain/src/height.rs
+++ b/common/blockchain/src/height.rs
@@ -1,20 +1,12 @@
+use core::{cmp, fmt};
+
+use borsh::maybestd::io;
+
 /// Block height.
 ///
 /// The generic argument allows the value to be tagged to distinguish it from
 /// host blockchain height and emulated blockchain height.
-#[derive(
-    Clone,
-    Copy,
-    Default,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-)]
-pub struct Height<T>(u64, core::marker::PhantomData<*const T>);
+pub struct Height<T>(u64, core::marker::PhantomData<T>);
 
 /// Delta between two host heights.
 ///
@@ -22,29 +14,15 @@ pub struct Height<T>(u64, core::marker::PhantomData<*const T>);
 ///
 /// The generic argument allows the value to be tagged to distinguish it from
 /// host blockchain height and emulated blockchain height.
-#[derive(
-    Clone,
-    Copy,
-    Default,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-)]
-pub struct Delta<T>(u64, core::marker::PhantomData<*const T>);
+pub struct Delta<T>(u64, core::marker::PhantomData<T>);
 
 /// Tag for use with [`Height`] and [`Delta`] to indicate it’s host blockchain
 /// height.
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Host;
+pub enum Host {}
 
 /// Tag for use with [`Height`] and [`Delta`] to indicate it’s emulated
 /// blockchain height.
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Block;
+pub enum Block {}
 
 pub type HostHeight = Height<Host>;
 pub type HostDelta = Delta<Host>;
@@ -59,49 +37,77 @@ impl<T> Height<T> {
     ///
     /// In essence, returns `self - past_height >= min`.
     pub fn check_delta_from(self, past_height: Self, min: Delta<T>) -> bool {
-        self.0.checked_sub(past_height.0).map_or(false, |age| age >= min.0)
+        self.checked_sub(past_height).map_or(false, |age| age >= min)
+    }
+
+    /// Performs checked integer subtraction returning `None` on overflow.
+    pub fn checked_sub(self, rhs: Self) -> Option<Delta<T>> {
+        self.0.checked_sub(rhs.0).map(|d| Delta(d, Default::default()))
     }
 }
 
-impl<T> From<u64> for Height<T> {
-    fn from(value: u64) -> Self { Self(value, Default::default()) }
+// Implement everything explicitly because derives create implementations which
+// include bounds on type T.  We don’t want that.
+macro_rules! impls {
+    ($ty:ident) => {
+        impl<T> Clone for $ty<T> {
+            fn clone(&self) -> Self { Self(self.0, self.1) }
+        }
+
+        impl<T> Copy for $ty<T> {}
+
+        impl<T> From<u64> for $ty<T> {
+            fn from(value: u64) -> Self { Self(value, Default::default()) }
+        }
+
+        impl<T> From<$ty<T>> for u64 {
+            fn from(value: $ty<T>) -> u64 { value.0 }
+        }
+
+        impl<T> fmt::Debug for $ty<T> {
+            fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(fmtr)
+            }
+        }
+
+        impl<T> fmt::Display for $ty<T> {
+            fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(fmtr)
+            }
+        }
+
+        impl<T> PartialEq for $ty<T> {
+            fn eq(&self, rhs: &Self) -> bool { self.0 == rhs.0 }
+        }
+
+        impl<T> Eq for $ty<T> {}
+
+        impl<T> PartialOrd for $ty<T> {
+            fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
+                Some(self.cmp(rhs))
+            }
+        }
+
+        impl<T> Ord for $ty<T> {
+            fn cmp(&self, rhs: &Self) -> cmp::Ordering { self.0.cmp(&rhs.0) }
+        }
+
+        impl<T> borsh::BorshSerialize for $ty<T> {
+            fn serialize<W: io::Write>(&self, wr: &mut W) -> io::Result<()> {
+                self.0.serialize(wr)
+            }
+        }
+
+        impl<T> borsh::BorshDeserialize for $ty<T> {
+            fn deserialize_reader<R: io::Read>(rd: &mut R) -> io::Result<Self> {
+                u64::deserialize_reader(rd).map(|x| Self(x, Default::default()))
+            }
+        }
+    };
 }
 
-impl<T> From<u64> for Delta<T> {
-    fn from(value: u64) -> Self { Self(value, Default::default()) }
-}
-
-impl<T> From<Height<T>> for u64 {
-    fn from(value: Height<T>) -> u64 { value.0 }
-}
-
-impl<T> From<Delta<T>> for u64 {
-    fn from(value: Delta<T>) -> u64 { value.0 }
-}
-
-impl<T> core::fmt::Display for Height<T> {
-    fn fmt(&self, fmtr: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.fmt(fmtr)
-    }
-}
-
-impl<T> core::fmt::Debug for Height<T> {
-    fn fmt(&self, fmtr: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.fmt(fmtr)
-    }
-}
-
-impl<T> core::fmt::Display for Delta<T> {
-    fn fmt(&self, fmtr: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.fmt(fmtr)
-    }
-}
-
-impl<T> core::fmt::Debug for Delta<T> {
-    fn fmt(&self, fmtr: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.fmt(fmtr)
-    }
-}
+impls!(Height);
+impls!(Delta);
 
 #[test]
 fn test_sanity() {

--- a/solana/solana-ibc/programs/solana-ibc/src/events.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/events.rs
@@ -220,7 +220,7 @@ mod snapshot_tests {
         let block = crate::chain::Block::generate_genesis(
             blockchain::BlockHeight::from(0),
             blockchain::HostHeight::from(42),
-            24,
+            core::num::NonZeroU64::new(24).unwrap(),
             CryptoHash::test(66),
             blockchain::Epoch::new(validators, 11.try_into().unwrap()).unwrap(),
         )


### PR DESCRIPTION
Use NonZeroU64 for the host_timestamp field of a block.  1970 was half
a century age and any timestamps the blockchain will work are way past
that so there’s no need to handle zero timestamp.
