### PR TITLE
sealable-trie: prohibit storing values at key prefixes

### DIFF
--- a/common/sealable-trie/src/bits/ext_key.rs
+++ b/common/sealable-trie/src/bits/ext_key.rs
@@ -61,9 +61,6 @@ impl<'a> ExtKey<'a> {
     /// Returns the length of relevant portion of the buffer.  For example, if
     /// slice’s length is say 20 bits with zero offset returns five (two bytes
     /// for the encoded length and three bytes for the 20 bits).
-    ///
-    /// Returns `None` if the slice is empty or too long and won’t fit in the
-    /// destination buffer.
     pub(crate) fn encode_into(&self, dest: &mut [u8; 36], tag: u8) -> usize {
         let bytes = self.0.bytes();
         let (num, tail) = stdx::split_array_mut::<2, 34, 36>(dest);
@@ -92,11 +89,9 @@ impl<'a> ExtKey<'a> {
 
     /// Encodes offset and length as a two-byte number.
     ///
-    /// The encoding is `llll_llll llll_looo`, i.e. 13-bit length in the most
-    /// significant bits and 3-bit offset in the least significant bits.  The
+    /// The encoding is `0000_llll llll_looo`, i.e. (starting from most
+    /// significant bits) four zero bits, 9-bit length and 3-bit offset.  The
     /// first byte is then further xored with the `tag` argument.
-    ///
-    /// This method doesn’t check whether the length and offset are within range.
     fn encode_num(&self, tag: u8) -> [u8; 2] {
         let num = (self.0.length << 3) | u16::from(self.0.offset);
         (num ^ (u16::from(tag) << 8)).to_be_bytes()

--- a/common/sealable-trie/src/nodes/tests.rs
+++ b/common/sealable-trie/src/nodes/tests.rs
@@ -4,7 +4,7 @@ use memory::Ptr;
 use pretty_assertions::assert_eq;
 
 use crate::bits;
-use crate::nodes::{Node, NodeRef, RawNode, Reference, ValueRef};
+use crate::nodes::{Node, RawNode, Reference};
 
 const DEAD: Ptr = match Ptr::new(0xDEAD) {
     Ok(Some(ptr)) => ptr,
@@ -214,28 +214,4 @@ fn test_extension_encoding() {
         /* ptr:  */ 0x60, 0, 0, 0,
         /* hash: */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     ], "uU9GlH+fEQAnezn3HWuvo/ZSBIhuSkuE2IGjhUFdC04=");
-}
-
-#[test]
-#[rustfmt::skip]
-fn test_value_encoding() {
-    check_node_encoding(Node::Value {
-        value: ValueRef::new((), &ONE),
-        child: NodeRef::new(Some(BEEF), &TWO),
-    }, [
-        /* tag:   */ 0xC0, 0, 0, 0,
-        /* vhash: */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        /* ptr:   */ 0, 0, 0xBE, 0xEF,
-        /* chash: */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
-    ], "1uLWUNQTQCTNVP3Wle2aK1vQlrOPXf9EC0J6TLl4hrY=");
-
-    check_node_encoding(Node::Value {
-        value: ValueRef::new((), &ONE),
-        child: NodeRef::new(None, &TWO),
-    }, [
-        /* tag:   */ 0xC0, 0, 0, 0,
-        /* vhash: */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        /* ptr:   */ 0, 0, 0, 0,
-        /* chash: */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
-    ], "1uLWUNQTQCTNVP3Wle2aK1vQlrOPXf9EC0J6TLl4hrY=");
 }

--- a/common/sealable-trie/src/trie/tests.rs
+++ b/common/sealable-trie/src/trie/tests.rs
@@ -87,6 +87,7 @@ fn test_prefix() {
 
 /// Tests inserting 256 subsequent keys and then trying to manipulate its
 /// parent.
+#[cfg(not(miri))]
 #[test]
 fn test_sealed_parent() {
     let want_root = "rV4Guri3HSKkNvmODKQiKO1KCKGIMpyoTEzRj/VaC9E=";

--- a/common/sealable-trie/src/trie/tests.rs
+++ b/common/sealable-trie/src/trie/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::println;
 
 use hex_literal::hex;
@@ -8,14 +8,13 @@ use rand::Rng;
 
 #[track_caller]
 fn make_trie_impl<'a>(
-    keys: impl IntoIterator<Item = &'a [u8]>,
+    mut keys: impl KeyGen<'a>,
     mut set: impl FnMut(&mut TestTrie, &'a [u8]),
     want: Option<(&str, usize)>,
 ) -> TestTrie {
-    let keys = keys.into_iter();
-    let count = keys.size_hint().1.unwrap_or(1000).saturating_mul(4).max(100);
+    let count = keys.count().unwrap_or(1000).saturating_mul(4).max(100);
     let mut trie = TestTrie::new(count);
-    for key in keys {
+    while let Some(key) = keys.next(&trie.mapping) {
         set(&mut trie, key)
     }
     if let Some((want_root, want_nodes)) = want {
@@ -28,7 +27,7 @@ fn make_trie_impl<'a>(
 /// Constructs a trie with given keys.
 #[track_caller]
 fn make_trie_from_keys<'a>(
-    keys: impl IntoIterator<Item = &'a [u8]>,
+    keys: impl KeyGen<'a>,
     want: Option<(&str, usize)>,
     verbose: bool,
 ) -> TestTrie {
@@ -42,7 +41,7 @@ fn make_trie_from_keys<'a>(
 /// them sealed.
 #[track_caller]
 fn make_sealed_trie_from_keys<'a>(
-    keys: impl IntoIterator<Item = &'a [u8]>,
+    keys: impl KeyGen<'a>,
     want: Option<(&str, usize)>,
     verbose: bool,
 ) -> TestTrie {
@@ -54,7 +53,7 @@ fn make_sealed_trie_from_keys<'a>(
 #[test]
 fn test_msb_difference() {
     make_trie_from_keys(
-        [&[0][..], &[0x80][..]],
+        IterKeyGen::new([&[0][..], &[0x80][..]]),
         Some(("Stmrss0PVu2RSGiHibdgHlBNxN/XPsqJsIlWoAAdI5g=", 3)),
         true,
     );
@@ -64,7 +63,7 @@ fn test_msb_difference() {
 #[test]
 fn test_2byte_extension() {
     make_trie_from_keys(
-        [&[123, 40][..], &[134, 233][..]],
+        IterKeyGen::new([&[123, 40][..], &[134, 233][..]]),
         Some(("KuGB/DlpPNpq95GPa47hyiWwWLqBvwStKohETSTCTWQ=", 3)),
         true,
     );
@@ -73,17 +72,17 @@ fn test_2byte_extension() {
 /// Tests setting value on a key and on a prefix of the key.
 #[test]
 fn test_prefix() {
-    let key = b"xy";
-    make_trie_from_keys(
-        [&key[..], &key[..1]],
-        Some(("gVrQ18qbqdhGPIIXSvlVD5dSyTy1OvduWpPsl4viANw=", 3)),
-        true,
-    );
-    make_trie_from_keys(
-        [&key[..1], &key[..]],
-        Some(("8LpINasPAwifquBydtqD7RFSgBZidoc2XmtNkThh23U=", 3)),
-        true,
-    );
+    fn test(key1: &[u8], key2: &[u8], want_root: &str) {
+        let mut trie = TestTrie::new(5);
+        trie.set(key1, true);
+        assert_eq!(Err(super::Error::BadKeyPrefix), trie.try_set(key2, true));
+
+        let want_root = CryptoHash::from_base64(want_root).unwrap();
+        assert_eq!((&want_root, 1), (trie.hash(), trie.nodes_count()));
+    }
+
+    test(b"xy", b"x", "RSLrcmouOB+n1azKsAoLZNf/AIMC9/TuzgLJ5SNaoF4=");
+    test(b"x", b"xy", "Lk8hhrdROehhinFrorqk9hRvRbwHx+9OYXn8jlqozCk=");
 }
 
 /// Creates a trie with sequential keys.  Returns `(trie, keys)` pair.
@@ -102,18 +101,12 @@ fn make_trie(small: bool, sealed: bool) -> (TestTrie, &'static [u8]) {
     } else {
         (16, "T9199/qDmjbqYqxaHrGh024lQRuTZcXBisiXCSwfNd4=", 16, 1)
     };
+    let keygen =
+        IterKeyGen::new(KEYS[..keys].iter().map(core::slice::from_ref));
     let trie = if sealed {
-        make_sealed_trie_from_keys(
-            KEYS[..keys].iter().map(core::slice::from_ref),
-            Some((hash, sealed_count)),
-            true,
-        )
+        make_sealed_trie_from_keys(keygen, Some((hash, sealed_count)), true)
     } else {
-        make_trie_from_keys(
-            KEYS[..keys].iter().map(core::slice::from_ref),
-            Some((hash, count)),
-            true,
-        )
+        make_trie_from_keys(keygen, Some((hash, count)), true)
     };
     (trie, &KEYS[..keys])
 }
@@ -191,7 +184,7 @@ fn test_del_extension_0() {
         )[..],
     ];
     let mut trie = make_trie_from_keys(
-        keys,
+        IterKeyGen::new(keys),
         Some(("k/+TqL56p1FI5Y7prnZ488jE6QsP1HjbxMNrLvnDEHw=", 5)),
         true,
     );
@@ -203,12 +196,12 @@ fn test_del_extension_0() {
 /// Extension nodes to be merged.
 #[test]
 fn test_del_extension_1() {
-    // Construct a trie with `Extension → Value → Extension` chain and delete
-    // the Value.  The Extensions should be merged into one.
-    let keys = [&hex!("00")[..], &hex!("00 FF")[..]];
+    // Construct a trie with `Extension → Branch → Extension` chain and delete
+    // the Branch.  The Extensions should be merged into one.
+    let keys = [&hex!("01")[..], &hex!("00 FF")[..]];
     let mut trie = make_trie_from_keys(
-        keys,
-        Some(("nmNwDIXQlBwdFRUKHk+1A6mki0W6O3EP5/LIzexY1lc=", 3)),
+        IterKeyGen::new(keys),
+        Some(("BQCCUp6s+joW9WfEixck9C/Qk3cDilx43Dwo2YSCxdk=", 3)),
         true,
     );
     trie.del(keys[0], true);
@@ -217,34 +210,60 @@ fn test_del_extension_1() {
 
 #[test]
 fn stress_test() {
+    fn check_prefix(x: &[u8], y: &[u8]) -> bool {
+        (x.len() != y.len()) && {
+            let len = x.len().min(y.len());
+            x[..len] == y[..len]
+        }
+    }
+
     struct RandKeys<'a> {
         buf: &'a mut [u8; 35],
         rng: rand::rngs::ThreadRng,
+        count: usize,
     }
 
-    impl<'a> Iterator for RandKeys<'a> {
-        type Item = &'a [u8];
+    impl<'a> RandKeys<'a> {
+        fn generate(&mut self, known: &BTreeMap<Key, CryptoHash>) -> &'a [u8] {
+            'outer: loop {
+                let len = self.rng.gen_range(1..self.buf.len());
+                let key = &mut self.buf[..len];
+                self.rng.fill(key);
+                let key = &key[..];
 
-        fn next(&mut self) -> Option<Self::Item> {
-            let len = self.rng.gen_range(1..self.buf.len());
-            let key = &mut self.buf[..len];
-            self.rng.fill(key);
-            let key = &key[..];
-            // Transmute lifetimes.  This is probably not sound in general but
-            // it works for our needs in this test.
-            unsafe { core::mem::transmute(key) }
+                for existing in known.keys() {
+                    if check_prefix(existing.as_bytes(), key) {
+                        continue 'outer;
+                    }
+                }
+                // Transmute lifetimes.  This is unsound in general but it works
+                // for our needs in this test.
+                break unsafe { core::mem::transmute(key) };
+            }
         }
+    }
+
+    impl<'a> KeyGen<'a> for RandKeys<'a> {
+        fn next(
+            &mut self,
+            known: &BTreeMap<Key, CryptoHash>,
+        ) -> Option<&'a [u8]> {
+            self.count = self.count.checked_sub(1)?;
+            Some(self.generate(known))
+        }
+
+        fn count(&self) -> Option<usize> { Some(self.count) }
     }
 
     let count = lib::test_utils::get_iteration_count(500);
 
     // Insert count/2 random keys.
-    let mut rand_keys = RandKeys { buf: &mut [0; 35], rng: rand::thread_rng() };
-    let mut trie = make_trie_from_keys(
-        (&mut rand_keys).take((count / 2).max(1)),
-        None,
-        false,
-    );
+    let mut rand_keys = RandKeys {
+        buf: &mut [0; 35],
+        rng: rand::thread_rng(),
+        count: (count / 2).max(1),
+    };
+    let mut trie = make_trie_from_keys(&mut rand_keys, None, false);
 
     // Now insert and delete keys randomly total of count times.  On average
     // that means count/2 deletions and count/2 new insertions.
@@ -263,8 +282,8 @@ fn stress_test() {
             let key = keys.remove(idx);
             trie.del(&key, false);
         } else {
-            let key = rand_keys.next().unwrap();
-            trie.set(&key, false);
+            let key = rand_keys.generate(&trie.mapping);
+            trie.set(key, false);
         }
     }
 
@@ -300,7 +319,11 @@ impl Key {
 
 impl core::ops::Deref for Key {
     type Target = [u8];
-    fn deref(&self) -> &[u8] { &self.buf[..usize::from(self.len)] }
+    fn deref(&self) -> &[u8] { self.as_bytes() }
+}
+
+impl alloc::borrow::Borrow<[u8]> for Key {
+    fn borrow(&self) -> &[u8] { self.as_bytes() }
 }
 
 impl core::cmp::PartialEq for Key {
@@ -325,9 +348,36 @@ impl core::fmt::Debug for Key {
     }
 }
 
+
+trait KeyGen<'a> {
+    fn next(&mut self, known: &BTreeMap<Key, CryptoHash>) -> Option<&'a [u8]>;
+    fn count(&self) -> Option<usize>;
+}
+
+impl<'a, 'b, T: KeyGen<'b>> KeyGen<'b> for &'a mut T {
+    fn next(&mut self, known: &BTreeMap<Key, CryptoHash>) -> Option<&'b [u8]> {
+        (**self).next(known)
+    }
+    fn count(&self) -> Option<usize> { (**self).count() }
+}
+
+struct IterKeyGen<I>(I);
+
+impl<'a, I: Iterator<Item = &'a [u8]>> IterKeyGen<I> {
+    fn new(it: impl IntoIterator<IntoIter = I>) -> Self { Self(it.into_iter()) }
+}
+
+impl<'a, I: Iterator<Item = &'a [u8]>> KeyGen<'a> for IterKeyGen<I> {
+    fn next(&mut self, _known: &BTreeMap<Key, CryptoHash>) -> Option<&'a [u8]> {
+        self.0.next()
+    }
+    fn count(&self) -> Option<usize> { self.0.size_hint().1 }
+}
+
+
 struct TestTrie {
     trie: super::Trie<TestAllocator<super::Value>>,
-    mapping: HashMap<Key, CryptoHash>,
+    mapping: BTreeMap<Key, CryptoHash>,
     count: usize,
 }
 
@@ -354,18 +404,30 @@ impl TestTrie {
     pub fn nodes_count(&self) -> usize { self.trie.alloc.count() }
 
     pub fn set(&mut self, key: &[u8], verbose: bool) {
+        self.try_set(key, verbose).unwrap()
+    }
+
+    fn try_set(
+        &mut self,
+        key: &[u8],
+        verbose: bool,
+    ) -> Result<(), super::Error> {
         let key = Key::new(key);
 
         let value = self.next_value();
         println!("{}Inserting {key:?}", if verbose { "\n" } else { "" });
-        self.trie
-            .set(&key, &value)
-            .unwrap_or_else(|err| panic!("Failed setting ‘{key:?}’: {err}"));
-        self.mapping.insert(key, value);
+        let res = self.trie.set(&key, &value);
+        match &res {
+            Ok(_) => {
+                self.mapping.insert(key, value);
+            }
+            Err(err) => println!("Failed setting ‘{key:?}’: {err}"),
+        }
         if verbose {
             self.trie.print();
         }
         self.check_all_reads();
+        res
     }
 
     pub fn seal(&mut self, key: &[u8], verbose: bool) {


### PR DESCRIPTION
Due to the nature of sealable trie, storing values at a prefix of an
existing key isn’t supported.  To understand why, consider the
following sequence of operations:

* set 0000 → foo
* set 0001 → bar
* seal 0000
* seal 0001
* set 000 → baz

After the second seal operation, node 000 is sealed as well.  This is
what makes sealing a worthwhile pursue allowing us to prune subtries
as the leafs are sealed.

But if 000 is sealed than setting 000 → baz cannot happen even though
the key wasn’t explicitly sealed.  However, if that operation was
performed earlier, it would succeed with the key being able to be
modified.

Similarly, it’s already been codded that sealing a key seals the
entire subtrie.

All of this is somewhat surprising and inconsistent.  To avoid all
that confusion, simply prohibit setting values for prefixes of
existing keys.
