### PR TITLE
Crate.toml: prefer upstream patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,22 @@ anchor-client = "0.29.0"
 anyhow = "1.0.32"
 
 [patch.crates-io]
-aes-gcm-siv = { git = "https://github.com/dhruvja/AEADs", branch = "main-aes-gcm-siv-v0.10.3" }
-curve25519-dalek = { git = "https://github.com/dhruvja/curve25519-dalek", branch = "master" }
+# aes-gcm-siv 0.10.3 and curve25519-dalek 3.x pin zeroize to <1.4
+# which conflicts with other dependencies requiring zeroize ^1.5.
+# We’re patching both crates to unpin zeroize.
+#
+# For aes-gcm-siv we’re using the same revision Solana uses in
+# an (as of now) unreleased commit, see
+# https://github.com/solana-labs/solana/commit/01f1bf27994d9813fadfcd134befd3a449aaa0bd
+#
+# For curve25519-dalek we’re using commit from a PR, see
+# https://github.com/dalek-cryptography/curve25519-dalek/pull/606
+aes-gcm-siv = { git = "https://github.com/RustCrypto/AEADs", rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef" }
+curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "8274d5cbb6fc3f38cdc742b4798173895cd2a290" }
 
 # eyre has a mutable global variable which is something Solana
-# programs cannot have.  tendermint crate enables eyre; patch it to
-# version that doesn’t do that.
-tendermint = { git = "https://github.com/mina86/tendermint-rs.git", branch = "34.0-sans-eyre" }
+# programs cannot have.  tendermint 0.34 enables eyre unconditionally;
+# version which doesn’t do that hasn’t been released yet so we need to
+# refer to a commit on master.
+tendermint = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
+tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }


### PR DESCRIPTION
Rather than pointing at private repositories, point at commits within
upstream repositories for all the patched crates.
