### PR TITLE
trie-ids: make `Tag` and related methods and traits public to create sub trie keys

### DIFF
--- a/common/trie-ids/Cargo.toml
+++ b/common/trie-ids/Cargo.toml
@@ -16,5 +16,6 @@ derive_more.workspace = true
 strum.workspace = true
 
 [dev-dependencies]
+hex-literal.workspace = true
 lib = { workspace = true, features = ["test_utils"] }
 rand.workspace = true

--- a/common/trie-ids/src/lib.rs
+++ b/common/trie-ids/src/lib.rs
@@ -14,5 +14,4 @@ mod ibc {
 
 pub use ids::{ChannelIdx, ClientIdx, ConnectionIdx, PortChannelPK, PortKey};
 pub use path::SequencePath;
-pub use trie_key::TrieKey;
-pub use trie_key::Tag;
+pub use trie_key::{Tag, TrieKey};

--- a/common/trie-ids/src/lib.rs
+++ b/common/trie-ids/src/lib.rs
@@ -15,3 +15,4 @@ mod ibc {
 pub use ids::{ChannelIdx, ClientIdx, ConnectionIdx, PortChannelPK, PortKey};
 pub use path::SequencePath;
 pub use trie_key::TrieKey;
+pub use trie_key::Tag;

--- a/common/trie-ids/src/trie_key.rs
+++ b/common/trie-ids/src/trie_key.rs
@@ -105,7 +105,7 @@ impl TrieKey {
     ///
     /// For keys consisting of a multiple components, a tuple component can be
     /// used.
-    fn new(tag: Tag, component: impl AsComponent) -> Self {
+    pub fn new(tag: Tag, component: impl AsComponent) -> Self {
         let mut key = TrieKey { bytes: [0; 22], len: 1 };
         key.bytes[0] = tag.into();
         component.append_into(&mut key);
@@ -174,7 +174,7 @@ impl TryFrom<&ibc::path::AckPath> for TrieKey {
 /// A discriminant used as the first byte of each trie key to create namespaces
 /// for different objects stored in the trie.
 #[repr(u8)]
-enum Tag {
+pub enum Tag {
     ClientState = 0,
     ConsensusState = 1,
     Connection = 2,
@@ -192,7 +192,7 @@ impl From<Tag> for u8 {
 /// Component of a [`TrieKey`].
 ///
 /// A `TrieKey` is constructed by concatenating a sequence of components.
-trait AsComponent {
+pub trait AsComponent {
     /// Appends the component into the trie key.
     fn append_into(&self, dest: &mut TrieKey);
 }

--- a/common/trie-ids/src/trie_key.rs
+++ b/common/trie-ids/src/trie_key.rs
@@ -289,48 +289,63 @@ fn test_encoding() {
         ($want:literal, $got:expr) => {
             assert_eq!(&hex_literal::hex!($want)[..], &$got[..]);
         };
-        ($want:literal, from $path:expr) => {
+        ($want:literal,from $path:expr) => {
             check!($want, TrieKey::try_from(&$path).unwrap());
         };
     }
 
-    let client = ids::ClientIdx::try_from(ibc::ClientId::from_str("foo-bar-1").unwrap()).unwrap();
+    let client =
+        ids::ClientIdx::try_from(ibc::ClientId::from_str("foo-bar-1").unwrap())
+            .unwrap();
     let height = ibc::Height::new(2, 3).unwrap();
-    let connection = ids::ConnectionIdx::try_from(ibc::ConnectionId::new(4)).unwrap();
+    let connection =
+        ids::ConnectionIdx::try_from(ibc::ConnectionId::new(4)).unwrap();
     let port_id = ibc::PortId::transfer();
     let channel_id = ibc::ChannelId::new(5);
-    let port_channel = ids::PortChannelPK::try_from(&port_id, &channel_id).unwrap();
+    let port_channel =
+        ids::PortChannelPK::try_from(&port_id, &channel_id).unwrap();
     let sequence = ibc::Sequence::from(6);
 
     check!("00 00000001", TrieKey::for_client_state(client));
-    check!("01 00000001 0000000000000002 0000000000000003",
-           TrieKey::for_consensus_state(client, height));
+    check!(
+        "01 00000001 0000000000000002 0000000000000003",
+        TrieKey::for_consensus_state(client, height)
+    );
     check!("02 00000004", TrieKey::for_connection(connection));
-    check!("03 b6b6a7b1f7abffffff 00000005",
-           TrieKey::for_channel_end(&port_channel));
-    check!("04 b6b6a7b1f7abffffff 00000005",
-           TrieKey::for_next_sequence(&port_channel));
+    check!(
+        "03 b6b6a7b1f7abffffff 00000005",
+        TrieKey::for_channel_end(&port_channel)
+    );
+    check!(
+        "04 b6b6a7b1f7abffffff 00000005",
+        TrieKey::for_next_sequence(&port_channel)
+    );
 
     check!("05 b6b6a7b1f7abffffff 00000005 0000000000000006",
-           from ibc::path::CommitmentPath {
-               port_id: port_id.clone(),
-               channel_id: channel_id.clone(),
-               sequence,
-           });
+    from ibc::path::CommitmentPath {
+        port_id: port_id.clone(),
+        channel_id: channel_id.clone(),
+        sequence,
+    });
     check!("06 b6b6a7b1f7abffffff 00000005 0000000000000006",
-           from ibc::path::ReceiptPath {
-               port_id: port_id.clone(),
-               channel_id: channel_id.clone(),
-               sequence,
-           });
+    from ibc::path::ReceiptPath {
+        port_id: port_id.clone(),
+        channel_id: channel_id.clone(),
+        sequence,
+    });
     check!("07 b6b6a7b1f7abffffff 00000005 0000000000000006",
-           from ibc::path::AckPath {
-               port_id: port_id.clone(),
-               channel_id: channel_id.clone(),
-               sequence,
-           });
+    from ibc::path::AckPath {
+        port_id: port_id.clone(),
+        channel_id: channel_id.clone(),
+        sequence,
+    });
 
     check!("01 00000001", TrieKey::new(Tag::ConsensusState, client));
-    check!("03 b6b6a7b1f7abffffff",
-           TrieKey::new(Tag::ChannelEnd, ids::PortKey::try_from(&port_id).unwrap()));
+    check!(
+        "03 b6b6a7b1f7abffffff",
+        TrieKey::new(
+            Tag::ChannelEnd,
+            ids::PortKey::try_from(&port_id).unwrap()
+        )
+    );
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -15,6 +15,8 @@ use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::ToAccountMetas;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
+use solana_trie::trie;
+use trie_ids::{PortChannelPK, TrieKey, Tag};
 
 use crate::ibc::ClientStateCommon;
 use crate::storage::PrivateStorage;
@@ -541,6 +543,20 @@ fn anchor_test_deliver() -> Result<()> {
         })?; // ? gives us the log messages on the why the tx did fail ( better than unwrap )
 
     println!("signature for sending packet: {sig}");
+
+    // let trie_account = sol_rpc_client 
+	// 		.get_account_with_commitment(&trie, CommitmentConfig::processed())
+	// 		.unwrap()
+	// 		.value
+	// 		.unwrap();
+    // let trie = trie::AccountTrie::new(trie_account.data).unwrap();
+
+    // let key =
+    // TrieKey::new(Tag::Commitment, PortChannelPK::try_from(port_id, channel_id_on_a).unwrap());
+
+    // let commitments: Vec<_> = trie.get_subtrie(&key).unwrap().iter().map(|c| c.hash.clone()).collect();
+
+    // println!("These are commitments {:?}", commitments);
 
     Ok(())
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -15,8 +15,6 @@ use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::ToAccountMetas;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
-use solana_trie::trie;
-use trie_ids::{PortChannelPK, Tag, TrieKey};
 
 use crate::ibc::ClientStateCommon;
 use crate::storage::PrivateStorage;
@@ -543,20 +541,6 @@ fn anchor_test_deliver() -> Result<()> {
         })?; // ? gives us the log messages on the why the tx did fail ( better than unwrap )
 
     println!("signature for sending packet: {sig}");
-
-    // let trie_account = sol_rpc_client
-    // 		.get_account_with_commitment(&trie, CommitmentConfig::processed())
-    // 		.unwrap()
-    // 		.value
-    // 		.unwrap();
-    // let trie = trie::AccountTrie::new(trie_account.data).unwrap();
-
-    // let key =
-    // TrieKey::new(Tag::Commitment, PortChannelPK::try_from(port_id, channel_id_on_a).unwrap());
-
-    // let commitments: Vec<_> = trie.get_subtrie(&key).unwrap().iter().map(|c| c.hash.clone()).collect();
-
-    // println!("These are commitments {:?}", commitments);
 
     Ok(())
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -16,7 +16,7 @@ use anchor_lang::ToAccountMetas;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
 use solana_trie::trie;
-use trie_ids::{PortChannelPK, TrieKey, Tag};
+use trie_ids::{PortChannelPK, Tag, TrieKey};
 
 use crate::ibc::ClientStateCommon;
 use crate::storage::PrivateStorage;
@@ -544,11 +544,11 @@ fn anchor_test_deliver() -> Result<()> {
 
     println!("signature for sending packet: {sig}");
 
-    // let trie_account = sol_rpc_client 
-	// 		.get_account_with_commitment(&trie, CommitmentConfig::processed())
-	// 		.unwrap()
-	// 		.value
-	// 		.unwrap();
+    // let trie_account = sol_rpc_client
+    // 		.get_account_with_commitment(&trie, CommitmentConfig::processed())
+    // 		.unwrap()
+    // 		.value
+    // 		.unwrap();
     // let trie = trie::AccountTrie::new(trie_account.data).unwrap();
 
     // let key =


### PR DESCRIPTION
Since we can fetch from trie using prefix of the key which is used to
fetch all the packet commitments, acks and recv, we need to make `Tag`
enum and the methods used to create new key as public so that we can
create sub trie keys.
