### PR TITLE
solana-ibc: fix `anchor build` and add it to CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -50,6 +50,23 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features -- -D warnings
 
+      - name: Miri tests
+        run: cargo miri test -- -Z unstable-options --report-time --skip ::anchor
+
+  anchor-build:
+    name: Anchor Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        id: install-rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt
+
       - name: Cache Anchor
         id: cache-anchor
         uses: actions/cache@v3
@@ -90,7 +107,9 @@ jobs:
     name: Build SBF
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -111,7 +130,9 @@ jobs:
     name: Rust tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -126,17 +147,3 @@ jobs:
 
       - name: Run tests (all features)
         run: cargo test --all-features
-
-  nightly:
-    name: Rust Miri tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-          components: miri
-
-      - name: Run tests with Miri
-        run: cargo miri test -- -Z unstable-options --report-time --skip ::anchor

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,15 +9,19 @@ on:
       - master
 
 env:
-  SOLANA_VERSION: v1.16.3
+  SOLANA_VERSION: v1.17.7
+  ANCHOR_VERSION: 0.29.0
 
 jobs:
   misc:
     name: Miscellaneous checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Install Rust
+        id: install-rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
@@ -38,10 +42,48 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features -- -D warnings
 
-  solana-build: 
+      - name: Cache Anchor
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .avm
+            .cargo/bin/avm
+            .cargo/bin/anchor
+            .config/solana/
+            .local/share/solana/
+          key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}-$SOLANA_VERSION-$ANCHOR_VERSION-tools
+
+      - name: Install Solana
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          set -eux
+          curl -sSfL https://release.solana.com/$SOLANA_VERSION/install | sh
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+          cp solana/solana-ibc/keypair.json ~/.config/solana/id.json
+
+      - name: Install Solana PATH
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      - name: Install Anchor
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          set -eux
+          cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
+          avm install $ANCHOR_VERSION
+          avm use $ANCHOR_VERSION
+
+      - name: Anchor Build
+        run: anchor build
+
+      - name: Anchor Build (with mocks)
+        run: anchor build -- --features=mocks
+
+  solana-build:
     name: Build SBF
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@v3
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -50,7 +92,7 @@ jobs:
           components: rustfmt
 
       - name: Install Solana CLI
-        run: | 
+        run: |
           set -eux
           curl -sSfL https://release.solana.com/$SOLANA_VERSION/install | sh
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,7 +30,15 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+      - name: Cache cargo-deny
+        id: cache-cargo-deny
+        uses: actions/cache@v3
+        with:
+          path: .cargo/bin/cargo-deny
+          key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}-cargo-deny
+
       - name: Install cargo-deny
+        if: steps.cache-cargo-deny.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-deny
 
       - name: Check bans
@@ -43,7 +51,7 @@ jobs:
           args: --all-features -- -D warnings
 
       - name: Cache Anchor
-        id: cache
+        id: cache-anchor
         uses: actions/cache@v3
         with:
           path: |
@@ -52,22 +60,20 @@ jobs:
             .cargo/bin/anchor
             .config/solana/
             .local/share/solana/
-          key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}-$SOLANA_VERSION-$ANCHOR_VERSION-tools
+          key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}-${{ env.SOLANA_VERSION }}-${{ env.ANCHOR_VERSION }}-anchor
 
       - name: Install Solana
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-anchor.outputs.cache-hit != 'true'
         run: |
           set -eux
           curl -sSfL https://release.solana.com/$SOLANA_VERSION/install | sh
-          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
           cp solana/solana-ibc/keypair.json ~/.config/solana/id.json
 
       - name: Install Solana PATH
-        if: steps.cache.outputs.cache-hit == 'true'
         run: echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
       - name: Install Anchor
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-anchor.outputs.cache-hit != 'true'
         run: |
           set -eux
           cargo install --git https://github.com/coral-xyz/anchor avm --locked --force

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,7 +25,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: clippy rustfmt
+          components: clippy rustfmt miri
 
       - name: Check formatting
         run: cargo fmt --all --check

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,7 +34,7 @@ jobs:
         id: cache-cargo-deny
         uses: actions/cache@v3
         with:
-          path: .cargo/bin/cargo-deny
+          path: ~/.cargo/bin/cargo-deny
           key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}-cargo-deny
 
       - name: Install cargo-deny
@@ -55,11 +55,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            .avm
-            .cargo/bin/avm
-            .cargo/bin/anchor
-            .config/solana/
-            .local/share/solana/
+            ~/.avm
+            ~/.cargo/bin/avm
+            ~/.cargo/bin/anchor
+            ~/.config/solana/
+            ~/.local/share/solana/
           key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}-${{ env.SOLANA_VERSION }}-${{ env.ANCHOR_VERSION }}-anchor
 
       - name: Install Solana

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -86,7 +86,7 @@ jobs:
           curl -sSfL https://release.solana.com/$SOLANA_VERSION/install | sh
           cp solana/solana-ibc/keypair.json ~/.config/solana/id.json
 
-      - name: Install Solana PATH
+      - name: Setup Solana PATH
         run: echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
       - name: Install Anchor
@@ -103,30 +103,7 @@ jobs:
       - name: Anchor Build (with mocks)
         run: anchor build -- --features=mocks
 
-  solana-build:
-    name: Build SBF
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: rustfmt
-
-      - name: Install Solana CLI
-        run: |
-          set -eux
-          curl -sSfL https://release.solana.com/$SOLANA_VERSION/install | sh
-          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
-          cp solana/solana-ibc/keypair.json ~/.config/solana/id.json
-
-      - name: Run build-sbf
-        run: cargo build-sbf
-
-  stable:
+  tests:
     name: Rust tests
     runs-on: ubuntu-latest
     steps:

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,8 +1,10 @@
 [features]
 seeds = false
 skip-lint = false
+
 [programs.localnet]
 solana_ibc = "EnfDJsAK7BGgetnmKzBx86CsgC5kfSPcsktFCQ4YLC81"
+
 [programs.devnet]
 solana_ibc = "EnfDJsAK7BGgetnmKzBx86CsgC5kfSPcsktFCQ4YLC81"
 
@@ -21,3 +23,7 @@ wallet = "~/.config/solana/id.json"
 [scripts]
 # test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test = "cargo test --lib -- --nocapture --include-ignored ::anchor"
+
+[toolchain]
+anchor_version = "0.29.0"
+solana_version = "1.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ rand = { version = "0.8.5" }
 serde = "1"
 serde_json = "1"
 sha2 = { version = "0.10.7", default-features = false }
-solana-client = "1.16.14"
-solana-program = "1.16.14"
-solana-sdk = "1.16.14"
+solana-client = "1.17.7"
+solana-program = "1.17.7"
+solana-sdk = "1.17.7"
 spl-associated-token-account = "2.2.0"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 uint = "0.9.5"

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -77,7 +77,9 @@ pub mod solana_ibc {
     /// will be added at a later time.
     pub fn sign_block(
         ctx: Context<ChainWithVerifier>,
-        signature: [u8; ed25519::Signature::LENGTH],
+        // Note: 64 = ed25519::Signature::LENGTH.  `anchor build` doesn’t like
+        // non-literals in array sizes.  Yeah, it’s dumb.
+        signature: [u8; 64],
     ) -> Result<()> {
         let provable = storage::get_provable_from(&ctx.accounts.trie)?;
         let verifier = ed25519::Verifier::new(&ctx.accounts.ix_sysvar)?;


### PR DESCRIPTION
Anchor doesn’t like when array sizes aren’t integer literals.  This is
dumb but there’s not much we can do other than change argument type
from a somewhat descriptive `[u8; ed25519::Signature::LENGTH]` to
a somewhat cryptic `[u8; 64]`.  This fixes `anchor build` run.

With that, add Anchor Build to CI so it’s tested on each PR.  While
doing that, rearrange CI jobs a little so that their run time is more
balanced.
