### PR TITLE
solana-ibc: initialise chain in Anchor test

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -42,3 +42,5 @@ anchor-client.workspace = true
 anyhow.workspace = true
 ibc-testkit.workspace = true
 insta.workspace = true
+
+lib = { workspace = true, features = ["test_utils"] }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -257,7 +257,8 @@ pub struct Deliver<'info> {
     /// The guest blockchain data.
     #[account(init_if_needed, payer = sender, seeds = [CHAIN_SEED],
               bump, space = 10240)]
-    chain: Box<Account<'info, chain::ChainData>>,
+    chain: Account<'info, chain::ChainData>,
+
     system_program: Program<'info, System>,
 }
 
@@ -329,7 +330,8 @@ pub struct SendPacket<'info> {
 
     /// The guest blockchain data.
     #[account(mut, seeds = [CHAIN_SEED], bump)]
-    chain: Box<Account<'info, chain::ChainData>>,
+    chain: Account<'info, chain::ChainData>,
+
     system_program: Program<'info, System>,
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -192,13 +192,19 @@ pub mod solana_ibc {
     }
 }
 
+/// All the storage accounts are initialized here since it is only called once in the lifetime of the program.
 #[derive(Accounts)]
 pub struct Chain<'info> {
     #[account(mut)]
     sender: Signer<'info>,
 
+    /// The account holding private IBC storage.
+    #[account(init, payer = sender, seeds = [SOLANA_IBC_STORAGE_SEED],
+        bump, space = 10240)]
+    storage: Account<'info, storage::PrivateStorage>,
+
     /// The guest blockchain data.
-    #[account(init_if_needed, payer = sender, seeds = [CHAIN_SEED], bump, space = 10240)]
+    #[account(init, payer = sender, seeds = [CHAIN_SEED], bump, space = 10240)]
     chain: Account<'info, chain::ChainData>,
 
     /// The account holding the trie which corresponds to guest blockchain’s
@@ -206,7 +212,7 @@ pub struct Chain<'info> {
     ///
     /// CHECK: Account’s owner is checked by [`storage::get_provable_from`]
     /// function.
-    #[account(init_if_needed, payer = sender, seeds = [TRIE_SEED], bump, space = 10240)]
+    #[account(init, payer = sender, seeds = [TRIE_SEED], bump, space = 10240)]
     trie: UncheckedAccount<'info>,
 
     system_program: Program<'info, System>,
@@ -218,7 +224,7 @@ pub struct ChainWithVerifier<'info> {
     sender: Signer<'info>,
 
     /// The guest blockchain data.
-    #[account(init_if_needed, payer = sender, seeds = [CHAIN_SEED], bump, space = 10240)]
+    #[account(mut, seeds = [CHAIN_SEED], bump)]
     chain: Account<'info, chain::ChainData>,
 
     /// The account holding the trie which corresponds to guest blockchain’s
@@ -226,7 +232,7 @@ pub struct ChainWithVerifier<'info> {
     ///
     /// CHECK: Account’s owner is checked by [`storage::get_provable_from`]
     /// function.
-    #[account(init_if_needed, payer = sender, seeds = [TRIE_SEED], bump, space = 10240)]
+    #[account(mut, seeds = [TRIE_SEED], bump)]
     trie: UncheckedAccount<'info>,
 
     #[account(address = solana_program::sysvar::instructions::ID)]
@@ -242,21 +248,21 @@ pub struct Deliver<'info> {
     sender: Signer<'info>,
 
     /// The account holding private IBC storage.
-    #[account(init_if_needed, payer = sender, seeds = [SOLANA_IBC_STORAGE_SEED],
-              bump, space = 10240)]
+    #[account(mut,seeds = [SOLANA_IBC_STORAGE_SEED],
+              bump)]
     storage: Account<'info, storage::PrivateStorage>,
 
     /// The account holding provable IBC storage, i.e. the trie.
     ///
     /// CHECK: Account’s owner is checked by [`storage::get_provable_from`]
     /// function.
-    #[account(init_if_needed, payer = sender, seeds = [TRIE_SEED],
-              bump, space = 10240)]
+    #[account(mut, seeds = [TRIE_SEED],
+              bump)]
     trie: UncheckedAccount<'info>,
 
     /// The guest blockchain data.
-    #[account(init_if_needed, payer = sender, seeds = [CHAIN_SEED],
-              bump, space = 10240)]
+    #[account(mut, seeds = [CHAIN_SEED],
+              bump)]
     chain: Account<'info, chain::ChainData>,
 
     system_program: Program<'info, System>,

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -1,3 +1,4 @@
+use core::num::{NonZeroU128, NonZeroU16};
 use std::rc::Rc;
 use std::str::FromStr;
 use std::thread::sleep;
@@ -18,7 +19,7 @@ use anyhow::Result;
 
 use crate::ibc::ClientStateCommon;
 use crate::storage::PrivateStorage;
-use crate::{accounts, ibc, instruction, MINT_ESCROW_SEED};
+use crate::{accounts, chain, ibc, instruction, MINT_ESCROW_SEED};
 
 const IBC_TRIE_PREFIX: &[u8] = b"ibc/";
 const BASE_DENOM: &str = "PICA";
@@ -135,14 +136,51 @@ fn anchor_test_deliver() -> Result<()> {
         Pubkey::find_program_address(&[crate::CHAIN_SEED], &crate::ID).0;
 
     /*
-     *
-     * Create New Mock Client
-     *
+     * Initialise chain
      */
 
+    println!("\nInitialising");
+    let sig = program
+        .request()
+        .accounts(accounts::Chain {
+            sender: authority.pubkey(),
+            trie,
+            chain,
+            system_program: system_program::ID,
+        })
+        .args(instruction::Initialise {
+            config: chain::Config {
+                min_validators: NonZeroU16::MIN,
+                max_validators: NonZeroU16::MAX,
+                min_validator_stake: NonZeroU128::new(1000).unwrap(),
+                min_total_stake: NonZeroU128::new(1000).unwrap(),
+                min_quorum_stake: NonZeroU128::new(1000).unwrap(),
+                min_block_length: 5.into(),
+                min_epoch_length: 200_000.into(),
+            },
+            genesis_epoch: chain::Epoch::new(
+                vec![chain::Validator::new(
+                    authority.pubkey().into(),
+                    NonZeroU128::new(2000).unwrap(),
+                )],
+                NonZeroU128::new(1000).unwrap(),
+            )
+            .unwrap(),
+        })
+        .payer(authority.clone())
+        .signer(&*authority)
+        .send_with_spinner_and_config(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        })?;
+    println!("  Signature: {sig}");
+
+    /*
+     * Create New Mock Client
+     */
+
+    println!("\nCreating Mock Client");
     let (mock_client_state, mock_cs_state) = create_mock_client_and_cs_state();
-    let _client_id =
-        ibc::ClientId::new(mock_client_state.client_type(), 0).unwrap();
     let message = make_message!(
         ibc::MsgCreateClient::new(
             ibc::Any::from(mock_client_state),
@@ -152,7 +190,6 @@ fn anchor_test_deliver() -> Result<()> {
         ibc::ClientMsg::CreateClient,
         ibc::MsgEnvelope::Client,
     );
-
     let sig = program
         .request()
         .accounts(accounts::Deliver {
@@ -168,22 +205,23 @@ fn anchor_test_deliver() -> Result<()> {
         .send_with_spinner_and_config(RpcSendTransactionConfig {
             skip_preflight: true,
             ..RpcSendTransactionConfig::default()
-        })?; // ? gives us the log messages on the why the tx did fail ( better than unwrap )
-
-    println!("signature for create client: {sig}");
+        })?;
+    println!("  Signature: {sig}");
 
     // Retrieve and validate state
     let solana_ibc_storage_account: PrivateStorage =
         program.account(storage).unwrap();
 
-    println!("This is solana storage account {:?}", solana_ibc_storage_account);
+    println!(
+        "  This is solana storage account {:?}",
+        solana_ibc_storage_account
+    );
 
     /*
-     *
      * Create New Mock Connection Open Init
-     *
      */
 
+    println!("\nIssuing Connection Open Init");
     let client_id =
         ibc::ClientId::new(mock_client_state.client_type(), 0).unwrap();
 
@@ -219,7 +257,7 @@ fn anchor_test_deliver() -> Result<()> {
             sender: authority.pubkey(),
             storage,
             trie,
-            chain: chain.clone(),
+            chain,
             system_program: system_program::ID,
         })
         .args(instruction::Deliver { message })
@@ -228,20 +266,19 @@ fn anchor_test_deliver() -> Result<()> {
         .send_with_spinner_and_config(RpcSendTransactionConfig {
             skip_preflight: true,
             ..RpcSendTransactionConfig::default()
-        })?; // ? gives us the log messages on the why the tx did fail ( better than unwrap )
-
-    println!("signature for connection open init: {sig}");
+        })?;
+    println!("  Signature: {sig}");
 
     /*
-    *
-    * Setup mock connection and channel
-       Steps before we proceed
-       - Create PDAs for the above keys,
-       - Create the token mint
-       - Get token account for receiver and sender
-    *
-    */
+     * Setup mock connection and channel
+     *
+     * Steps before we proceed
+     *  - Create PDAs for the above keys,
+     *  - Create the token mint
+     *  - Get token account for receiver and sender
+     */
 
+    println!("\nSetting up mock connection and channel");
     let port_id = ibc::PortId::transfer();
     let channel_id_on_a = ibc::ChannelId::new(0);
     let channel_id_on_b = ibc::ChannelId::new(1);
@@ -294,24 +331,20 @@ fn anchor_test_deliver() -> Result<()> {
             skip_preflight: true,
             ..RpcSendTransactionConfig::default()
         })?;
-
-    println!(
-        "signature for setting up channel and connection with next seq: {sig}"
-    );
+    println!("  Signature: {sig}");
 
     let mint_info = sol_rpc_client.get_token_supply(&token_mint_key).unwrap();
 
-    println!("This is the mint information {:?}", mint_info);
+    println!("  This is the mint information {:?}", mint_info);
 
     // Make sure all the accounts needed for transfer are ready ( mint, escrow etc.)
     // Pass the instruction for transfer
 
     /*
-     *
      * On Source chain
-     *
      */
 
+    println!("\nRecving on source chain");
     let packet = construct_packet_from_denom(
         port_id.clone(),
         channel_id_on_a.clone(),
@@ -339,8 +372,8 @@ fn anchor_test_deliver() -> Result<()> {
         ibc::MsgEnvelope::Packet,
     );
 
-    println!("This is trie {:?}", trie);
-    println!("This is storage {:?}", storage);
+    println!("  This is trie {:?}", trie);
+    println!("  This is storage {:?}", storage);
 
     /*
         The remaining accounts consists of the following accounts
@@ -385,7 +418,7 @@ fn anchor_test_deliver() -> Result<()> {
         },
     ];
 
-    println!("These are remaining accounts {:?}", remaining_accounts);
+    println!("  These are remaining accounts {:?}", remaining_accounts);
 
     let escrow_account_balance_before =
         sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
@@ -412,9 +445,8 @@ fn anchor_test_deliver() -> Result<()> {
         .send_with_spinner_and_config(RpcSendTransactionConfig {
             skip_preflight: true,
             ..RpcSendTransactionConfig::default()
-        })?; // ? gives us the log messages on the why the tx did fail ( better than unwrap )
-
-    println!("signature for transfer packet on Source chain: {sig}");
+        })?;
+    println!("  Signature: {sig}");
 
     let escrow_account_balance_after =
         sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
@@ -437,11 +469,10 @@ fn anchor_test_deliver() -> Result<()> {
     );
 
     /*
-     *
      * On Destination chain
-     *
      */
 
+    println!("\nRecving on destination chain");
     let account_balance_before = sol_rpc_client
         .get_token_account_balance(&receiver_token_address)
         .unwrap();
@@ -491,9 +522,8 @@ fn anchor_test_deliver() -> Result<()> {
         .send_with_spinner_and_config(RpcSendTransactionConfig {
             skip_preflight: true,
             ..RpcSendTransactionConfig::default()
-        })?; // ? gives us the log messages on the why the tx did fail ( better than unwrap )
-
-    println!("signature for transfer packet on destination chain: {sig}");
+        })?;
+    println!("  Signature: {sig}");
 
     let account_balance_after = sol_rpc_client
         .get_token_account_balance(&receiver_token_address)
@@ -507,11 +537,10 @@ fn anchor_test_deliver() -> Result<()> {
     );
 
     /*
-     *
      * Send Packets
-     *
      */
 
+    println!("\nSend packet");
     let packet = construct_packet_from_denom(
         port_id.clone(),
         channel_id_on_a.clone(),
@@ -529,7 +558,7 @@ fn anchor_test_deliver() -> Result<()> {
             sender: authority.pubkey(),
             storage,
             trie,
-            chain: chain.clone(),
+            chain,
             system_program: system_program::ID,
         })
         .args(instruction::SendPacket { packet })
@@ -538,9 +567,8 @@ fn anchor_test_deliver() -> Result<()> {
         .send_with_spinner_and_config(RpcSendTransactionConfig {
             skip_preflight: true,
             ..RpcSendTransactionConfig::default()
-        })?; // ? gives us the log messages on the why the tx did fail ( better than unwrap )
-
-    println!("signature for sending packet: {sig}");
+        })?;
+    println!("  Signature: {sig}");
 
     Ok(())
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -144,6 +144,7 @@ fn anchor_test_deliver() -> Result<()> {
         .request()
         .accounts(accounts::Chain {
             sender: authority.pubkey(),
+            storage,
             trie,
             chain,
             system_program: system_program::ID,

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -142,7 +142,7 @@ fn anchor_test_deliver() -> Result<()> {
     println!("\nInitialising");
     let sig = program
         .request()
-        .accounts(accounts::Chain {
+        .accounts(accounts::Initialise {
             sender: authority.pubkey(),
             storage,
             trie,


### PR DESCRIPTION
Most notably, add chain initialisation to the Anchor test. During chain initialization, we also initialize all the storage accounts ( private storage, trie and chain data ) since its only called once in the lifetime of the program. Hence the use `inif_if_needed` for storage accounts serve no purpose thus save us some from `re-initialization` attacks. While at
it, change some logging in the test so it’s easier to read the logs.
