### PR TITLE
solana-ibc: introduce separate mock_init_escrow instruction

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -28,7 +28,7 @@ pub mod events;
 mod execution_context;
 mod host;
 mod ibc;
-#[cfg(feature = "mocks")]
+#[cfg_attr(not(feature = "mocks"), path = "no-mocks.rs")]
 mod mocks;
 pub mod storage;
 #[cfg(test)]
@@ -141,27 +141,17 @@ pub mod solana_ibc {
 
     /// Called to set up escrow and mint accounts for given channel and denom.
     /// Panics if called without `mocks` feature.
-    #[allow(unused_variables)]
     pub fn mock_init_escrow<'a, 'info>(
         ctx: Context<'a, 'a, 'a, 'info, MockInitEscrow<'info>>,
         port_id: ibc::PortId,
         channel_id_on_b: ibc::ChannelId,
         base_denom: String,
     ) -> Result<()> {
-        #[cfg(feature = "mocks")]
-        return mocks::mock_init_escrow(
-            ctx,
-            port_id,
-            channel_id_on_b,
-            base_denom,
-        );
-        #[cfg(not(feature = "mocks"))]
-        panic!("This method is only for mocks");
+        mocks::mock_init_escrow(ctx, port_id, channel_id_on_b, base_denom)
     }
 
     /// Called to set up a connection, channel and store the next
     /// sequence.  Will panic if called without `mocks` feature.
-    #[allow(unused_variables)]
     pub fn mock_deliver<'a, 'info>(
         ctx: Context<'a, 'a, 'a, 'info, MockDeliver<'info>>,
         port_id: ibc::PortId,
@@ -171,8 +161,7 @@ pub mod solana_ibc {
         client_id: ibc::ClientId,
         counterparty_client_id: ibc::ClientId,
     ) -> Result<()> {
-        #[cfg(feature = "mocks")]
-        return mocks::mock_deliver(
+        mocks::mock_deliver(
             ctx,
             port_id,
             channel_id_on_b,
@@ -180,9 +169,7 @@ pub mod solana_ibc {
             commitment_prefix,
             client_id,
             counterparty_client_id,
-        );
-        #[cfg(not(feature = "mocks"))]
-        panic!("This method is only for mocks");
+        )
     }
 
     /// Should be called after setting up client, connection and channels.

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -139,6 +139,26 @@ pub mod solana_ibc {
             .map_err(move |err| error!((&err)))
     }
 
+    /// Called to set up escrow and mint accounts for given channel and denom.
+    /// Panics if called without `mocks` feature.
+    #[allow(unused_variables)]
+    pub fn mock_init_escrow<'a, 'info>(
+        ctx: Context<'a, 'a, 'a, 'info, MockInitEscrow<'info>>,
+        port_id: ibc::PortId,
+        channel_id_on_b: ibc::ChannelId,
+        base_denom: String,
+    ) -> Result<()> {
+        #[cfg(feature = "mocks")]
+        return mocks::mock_init_escrow(
+            ctx,
+            port_id,
+            channel_id_on_b,
+            base_denom,
+        );
+        #[cfg(not(feature = "mocks"))]
+        panic!("This method is only for mocks");
+    }
+
     /// Called to set up a connection, channel and store the next
     /// sequence.  Will panic if called without `mocks` feature.
     #[allow(unused_variables)]
@@ -152,7 +172,7 @@ pub mod solana_ibc {
         counterparty_client_id: ibc::ClientId,
     ) -> Result<()> {
         #[cfg(feature = "mocks")]
-        return mocks::mock_deliver_impl(
+        return mocks::mock_deliver(
             ctx,
             port_id,
             channel_id_on_b,
@@ -289,10 +309,34 @@ pub struct Deliver<'info> {
     trie: UncheckedAccount<'info>,
 
     /// The guest blockchain data.
-    #[account(mut, seeds = [CHAIN_SEED],
-              bump)]
+    #[account(mut, seeds = [CHAIN_SEED], bump)]
     chain: Account<'info, chain::ChainData>,
 
+    system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(port_id: ibc::PortId, channel_id_on_b: ibc::ChannelId, base_denom: String)]
+pub struct MockInitEscrow<'info> {
+    #[account(mut)]
+    sender: Signer<'info>,
+
+    /// CHECK:
+    #[account(init_if_needed, payer = sender, seeds = [MINT_ESCROW_SEED],
+              bump, space = 100)]
+    mint_authority: UncheckedAccount<'info>,
+
+    #[account(init_if_needed, payer = sender, seeds = [base_denom.as_bytes()],
+              bump, mint::decimals = 6, mint::authority = mint_authority)]
+    token_mint: Account<'info, Mint>,
+
+    #[account(init_if_needed, payer = sender, seeds = [
+        port_id.as_bytes(), channel_id_on_b.as_bytes(), base_denom.as_bytes()
+    ], bump, token::mint = token_mint, token::authority = mint_authority)]
+    escrow_account: Box<Account<'info, TokenAccount>>,
+
+    associated_token_program: Program<'info, AssociatedToken>,
+    token_program: Program<'info, Token>,
     system_program: Program<'info, System>,
 }
 
@@ -316,25 +360,25 @@ pub struct MockDeliver<'info> {
     #[account(mut , seeds = [TRIE_SEED], bump)]
     trie: UncheckedAccount<'info>,
 
+    /// The guest blockchain data.
+    #[account(mut, seeds = [CHAIN_SEED], bump)]
+    chain: Account<'info, chain::ChainData>,
+
     /// The below accounts are being created for testing purposes only.  In
     /// real, we would run conditionally create an escrow account when the
     /// channel is created.  And we could have another method that can create
     /// a mint given the denom.
-    #[account(init_if_needed, payer = sender, seeds = [MINT_ESCROW_SEED],
-              bump, space = 100)]
+    #[account(mut, seeds = [MINT_ESCROW_SEED], bump)]
     /// CHECK:
     mint_authority: UncheckedAccount<'info>,
-    #[account(init_if_needed, payer = sender, seeds = [base_denom.as_bytes()],
+    #[account(mut, seeds = [base_denom.as_bytes()],
               bump, mint::decimals = 6, mint::authority = mint_authority)]
     token_mint: Box<Account<'info, Mint>>,
-    #[account(init_if_needed, payer = sender, seeds = [
+    #[account(mut, seeds = [
         port_id.as_bytes(), channel_id_on_b.as_bytes(), base_denom.as_bytes()
     ], bump, token::mint = token_mint, token::authority = mint_authority)]
     escrow_account: Box<Account<'info, TokenAccount>>,
-    #[account(init_if_needed, payer = sender,
-              associated_token::mint = token_mint,
-              associated_token::authority = sender)]
-    sender_token_account: Box<Account<'info, TokenAccount>>,
+
     #[account(init_if_needed, payer = sender,
               associated_token::mint = token_mint,
               associated_token::authority = receiver)]

--- a/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
@@ -1,5 +1,3 @@
-extern crate alloc;
-
 use anchor_lang::prelude::*;
 use anchor_spl::token::MintTo;
 
@@ -9,7 +7,7 @@ use crate::{
 };
 
 
-pub fn mock_init_escrow<'a, 'info>(
+pub(crate) fn mock_init_escrow<'a, 'info>(
     _ctx: Context<'a, 'a, 'a, 'info, MockInitEscrow<'info>>,
     _port_id: ibc::PortId,
     _channel_id: ibc::ChannelId,
@@ -18,7 +16,7 @@ pub fn mock_init_escrow<'a, 'info>(
     Ok(())
 }
 
-pub fn mock_deliver<'a, 'info>(
+pub(crate) fn mock_deliver<'a, 'info>(
     ctx: Context<'a, 'a, 'a, 'info, MockDeliver<'info>>,
     port_id: ibc::PortId,
     _channel_id: ibc::ChannelId,

--- a/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
@@ -4,10 +4,21 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::MintTo;
 
 use crate::ibc::{ClientExecutionContext, ExecutionContext, ValidationContext};
-use crate::{error, host, ibc, storage, MockDeliver, MINT_ESCROW_SEED};
+use crate::{
+    error, host, ibc, storage, MockDeliver, MockInitEscrow, MINT_ESCROW_SEED,
+};
 
 
-pub fn mock_deliver_impl<'a, 'info>(
+pub fn mock_init_escrow<'a, 'info>(
+    _ctx: Context<'a, 'a, 'a, 'info, MockInitEscrow<'info>>,
+    _port_id: ibc::PortId,
+    _channel_id: ibc::ChannelId,
+    _base_denom: String,
+) -> Result<()> {
+    Ok(())
+}
+
+pub fn mock_deliver<'a, 'info>(
     ctx: Context<'a, 'a, 'a, 'info, MockDeliver<'info>>,
     port_id: ibc::PortId,
     _channel_id: ibc::ChannelId,
@@ -170,9 +181,10 @@ pub fn mock_deliver_impl<'a, 'info>(
         .unwrap();
 
     // Minting some tokens to the escrow so that he can do the transfer
-    let bump_vector = ctx.bumps.mint_authority.to_le_bytes();
-    let inner = vec![MINT_ESCROW_SEED, bump_vector.as_ref()];
-    let outer = vec![inner.as_slice()];
+    let bump = ctx.bumps.mint_authority;
+    let seeds = [MINT_ESCROW_SEED, core::slice::from_ref(&bump)];
+    let seeds = seeds.as_ref();
+    let seeds = core::slice::from_ref(&seeds);
 
     // Mint some tokens to escrow account
     let mint_instruction = MintTo {
@@ -183,7 +195,7 @@ pub fn mock_deliver_impl<'a, 'info>(
     let cpi_ctx = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
         mint_instruction,
-        outer.as_slice(), //signer PDA
+        seeds, //signer PDA
     );
     anchor_spl::token::mint_to(cpi_ctx, 10000000)?;
     Ok(())

--- a/solana/solana-ibc/programs/solana-ibc/src/no-mocks.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/no-mocks.rs
@@ -1,0 +1,26 @@
+#![allow(unused_variables)]
+
+use anchor_lang::prelude::*;
+
+use crate::{ibc, MockDeliver, MockInitEscrow};
+
+pub(crate) fn mock_init_escrow<'a, 'info>(
+    ctx: Context<'a, 'a, 'a, 'info, MockInitEscrow<'info>>,
+    port_id: ibc::PortId,
+    channel_id: ibc::ChannelId,
+    base_denom: String,
+) -> Result<()> {
+    panic!("This instruction is only available in mocks build")
+}
+
+pub(crate) fn mock_deliver<'a, 'info>(
+    ctx: Context<'a, 'a, 'a, 'info, MockDeliver<'info>>,
+    port_id: ibc::PortId,
+    channel_id: ibc::ChannelId,
+    base_denom: String,
+    commitment_prefix: ibc::CommitmentPrefix,
+    client_id: ibc::ClientId,
+    counterparty_client_id: ibc::ClientId,
+) -> Result<()> {
+    panic!("This instruction is only available in mocks build")
+}

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -103,7 +103,7 @@ impl TokenTransferExecutionContext for IbcStorage<'_, '_> {
 
         let (_token_mint_key, _bump) =
             Pubkey::find_program_address(&[base_denom.as_ref()], &crate::ID);
-        let (mint_authority_key, mint_authority_bump) =
+        let (mint_auth_key, mint_auth_bump) =
             Pubkey::find_program_address(&[MINT_ESCROW_SEED], &crate::ID);
         let store = self.borrow();
         let accounts = &store.accounts;
@@ -113,7 +113,7 @@ impl TokenTransferExecutionContext for IbcStorage<'_, '_> {
         let token_program = get_account_info_from_key(accounts, spl_token::ID)?;
 
         let authority = if matches!(from, AccountId::Escrow(_)) {
-            get_account_info_from_key(accounts, mint_authority_key)?
+            get_account_info_from_key(accounts, mint_auth_key)?
         } else {
             let sender_token_account =
                 TokenAccount::try_deserialize(&mut &sender.data.borrow()[..])
@@ -121,8 +121,7 @@ impl TokenTransferExecutionContext for IbcStorage<'_, '_> {
             get_account_info_from_key(accounts, sender_token_account.owner)?
         };
 
-        let bump_vector = mint_authority_bump.to_le_bytes();
-        let seeds = [MINT_ESCROW_SEED, bump_vector.as_ref()];
+        let seeds = [MINT_ESCROW_SEED, core::slice::from_ref(&mint_auth_bump)];
         let seeds = seeds.as_ref();
         let seeds = core::slice::from_ref(&seeds);
 
@@ -161,18 +160,16 @@ impl TokenTransferExecutionContext for IbcStorage<'_, '_> {
 
         let (token_mint_key, _bump) =
             Pubkey::find_program_address(&[base_denom.as_ref()], &crate::ID);
-        let (mint_authority_key, mint_authority_bump) =
+        let (mint_auth_key, mint_auth_bump) =
             Pubkey::find_program_address(&[MINT_ESCROW_SEED], &crate::ID);
         let store = self.borrow();
         let accounts = &store.accounts;
         let receiver = get_account_info_from_key(accounts, receiver_id)?;
         let token_mint = get_account_info_from_key(accounts, token_mint_key)?;
         let token_program = get_account_info_from_key(accounts, spl_token::ID)?;
-        let mint_authority =
-            get_account_info_from_key(accounts, mint_authority_key)?;
+        let mint_auth = get_account_info_from_key(accounts, mint_auth_key)?;
 
-        let bump_vector = mint_authority_bump.to_le_bytes();
-        let seeds = [MINT_ESCROW_SEED, bump_vector.as_ref()];
+        let seeds = [MINT_ESCROW_SEED, core::slice::from_ref(&mint_auth_bump)];
         let seeds = seeds.as_ref();
         let seeds = core::slice::from_ref(&seeds);
 
@@ -180,7 +177,7 @@ impl TokenTransferExecutionContext for IbcStorage<'_, '_> {
         let transfer_instruction = MintTo {
             mint: token_mint.clone(),
             to: receiver.clone(),
-            authority: mint_authority.clone(),
+            authority: mint_auth.clone(),
         };
         let cpi_ctx = CpiContext::new_with_signer(
             token_program.clone(),
@@ -210,18 +207,16 @@ impl TokenTransferExecutionContext for IbcStorage<'_, '_> {
         let amount_in_u64 = check_amount_overflow(amt.amount)?;
         let (token_mint_key, bump) =
             Pubkey::find_program_address(&[base_denom.as_ref()], &crate::ID);
-        let (mint_authority_key, _bump) =
+        let (mint_auth_key, _bump) =
             Pubkey::find_program_address(&[MINT_ESCROW_SEED], &crate::ID);
         let store = self.borrow();
         let accounts = &store.accounts;
         let burner = get_account_info_from_key(accounts, burner_id)?;
         let token_mint = get_account_info_from_key(accounts, token_mint_key)?;
         let token_program = get_account_info_from_key(accounts, spl_token::ID)?;
-        let mint_authority =
-            get_account_info_from_key(accounts, mint_authority_key)?;
+        let mint_auth = get_account_info_from_key(accounts, mint_auth_key)?;
 
-        let bump_vector = bump.to_le_bytes();
-        let seeds = [MINT_ESCROW_SEED, bump_vector.as_ref()];
+        let seeds = [MINT_ESCROW_SEED, core::slice::from_ref(&bump)];
         let seeds = seeds.as_ref();
         let seeds = core::slice::from_ref(&seeds);
 
@@ -229,7 +224,7 @@ impl TokenTransferExecutionContext for IbcStorage<'_, '_> {
         let transfer_instruction = Burn {
             mint: token_mint.clone(),
             from: burner.clone(),
-            authority: mint_authority.clone(),
+            authority: mint_auth.clone(),
         };
         let cpi_ctx = CpiContext::new_with_signer(
             token_program.clone(),


### PR DESCRIPTION
Split out mint and escrow initialisation out of mock_deliver and into
mock_init_escrow instruction.  This is done so that the former has
fewer things to initialise and we don’t run into stack or heap memory
issues.

Also, sneak in addition of chain field to the MockDeliver to
demonstrate that this indeed achieves desired result.  Previously,
adding the field into the struct would lead to stack frame overflow.
