### PR TITLE
solana-ibc: implement host_timestamp and host_height in terms of guest chain

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -45,8 +45,10 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
             ibc::Height::new(path.revision_number, path.revision_height)?;
 
         let mut store = self.borrow_mut();
-        let processed_time = store.host_head.timestamp;
-        let processed_height = store.host_head.height;
+        let (processed_time, processed_height) = {
+            let head = store.chain.head()?;
+            (head.host_timestamp, head.block_height)
+        };
 
         let mut client = store.private.client_mut(&path.client_id, false)?;
         let state = storage::ClientConsensusState::new(

--- a/solana/solana-ibc/programs/solana-ibc/src/host.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/host.rs
@@ -20,20 +20,6 @@ impl Head {
         use solana_program::sysvar::Sysvar;
         Ok(solana_program::clock::Clock::get()?.into())
     }
-
-    /// Returns height as an IBC type.
-    #[inline]
-    pub fn ibc_height(&self) -> Result<ibc::Height, ibc::ClientError> {
-        ibc::Height::new(0, self.height.into())
-    }
-
-    /// Returns timestamp as an IBC type.
-    #[inline]
-    pub fn ibc_timestamp(&self) -> Result<ibc::Timestamp, ibc::ClientError> {
-        ibc::Timestamp::from_nanoseconds(self.timestamp.get()).map_err(|err| {
-            ibc::ClientError::Other { description: err.to_string() }
-        })
-    }
 }
 
 impl From<solana_program::clock::Clock> for Head {

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -96,7 +96,7 @@ impl ClientStore {
 /// ```ignore
 /// struct Inner {
 ///     processed_time: NonZeroU64,
-///     processed_height: HostHeight,
+///     processed_height: BlockHeight,
 ///     serialised_state: [u8],
 /// }
 /// struct ClientConsensusState(Box<Inner>);
@@ -106,7 +106,7 @@ impl ClientStore {
 /// provided.
 #[derive(Clone, Debug, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ClientConsensusState(
-    Serialised<(NonZeroU64, blockchain::HostHeight, AnyConsensusState)>,
+    Serialised<(NonZeroU64, blockchain::BlockHeight, AnyConsensusState)>,
 );
 
 impl ClientConsensusState {
@@ -117,7 +117,7 @@ impl ClientConsensusState {
     /// consensus state.
     pub fn new(
         processed_time: NonZeroU64,
-        processed_height: blockchain::HostHeight,
+        processed_height: blockchain::BlockHeight,
         state: &AnyConsensusState,
     ) -> Result<Self, ibc::ClientError> {
         Serialised::new(&(processed_time, processed_height, state))
@@ -135,7 +135,7 @@ impl ClientConsensusState {
     }
 
     /// Returns processed height for this client consensus state.
-    pub fn processed_height(&self) -> Option<blockchain::HostHeight> {
+    pub fn processed_height(&self) -> Option<blockchain::BlockHeight> {
         self.0
             .as_bytes()
             .get(8..16)
@@ -313,8 +313,8 @@ pub fn get_provable_from<'a, 'info>(
 pub(crate) struct IbcStorageInner<'a, 'b> {
     pub private: &'a mut PrivateStorage,
     pub provable: AccountTrie<'a, 'b>,
+    pub chain: &'a mut crate::chain::ChainData,
     pub accounts: &'a [AccountInfo<'b>],
-    pub host_head: crate::host::Head,
 }
 
 /// A reference-counted reference to the IBC storage.


### PR DESCRIPTION
Rather than using Solana timestamp and slot number for the host
timestamp and height use that information from guest blockchain’s head
block.  This is because in terms of IBC, the ‘host’ is the guest
blockchain since IBC communication happens between counterparty and
the guest blockchain and not directly with Solana.
