### PR TITLE
solana-ibc: remove dependent arguments from send_packet method

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/error.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/error.rs
@@ -126,6 +126,13 @@ impl From<ibc::ClientError> for Error {
     }
 }
 
+impl From<ibc::ChannelError> for Error {
+    #[inline]
+    fn from(err: ibc::ChannelError) -> Self {
+        ibc::ContextError::from(err).into()
+    } 
+}
+
 impl From<Error> for anchor_lang::error::AnchorError {
     fn from(err: Error) -> Self {
         let error_msg = err.to_string();

--- a/solana/solana-ibc/programs/solana-ibc/src/error.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/error.rs
@@ -130,7 +130,7 @@ impl From<ibc::ChannelError> for Error {
     #[inline]
     fn from(err: ibc::ChannelError) -> Self {
         ibc::ContextError::from(err).into()
-    } 
+    }
 }
 
 impl From<Error> for anchor_lang::error::AnchorError {

--- a/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports)]
 
 pub use ibc::apps;
+pub use ibc::core::channel::context::SendPacketValidationContext;
 pub use ibc::core::channel::types::acknowledgement::Acknowledgement;
 pub use ibc::core::channel::types::channel::ChannelEnd;
 pub use ibc::core::channel::types::commitment::{
@@ -10,7 +11,6 @@ pub use ibc::core::channel::types::error::{ChannelError, PacketError};
 pub use ibc::core::channel::types::msgs::{MsgRecvPacket, PacketMsg};
 pub use ibc::core::channel::types::packet::{Packet, Receipt};
 pub use ibc::core::channel::types::timeout::TimeoutHeight;
-pub use ibc::core::channel::context::SendPacketValidationContext;
 pub use ibc::core::channel::types::Version;
 pub use ibc::core::client::context::client_state::{
     ClientStateCommon, ClientStateExecution, ClientStateValidation,

--- a/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
@@ -10,6 +10,7 @@ pub use ibc::core::channel::types::error::{ChannelError, PacketError};
 pub use ibc::core::channel::types::msgs::{MsgRecvPacket, PacketMsg};
 pub use ibc::core::channel::types::packet::{Packet, Receipt};
 pub use ibc::core::channel::types::timeout::TimeoutHeight;
+pub use ibc::core::channel::context::SendPacketValidationContext;
 pub use ibc::core::channel::types::Version;
 pub use ibc::core::client::context::client_state::{
     ClientStateCommon, ClientStateExecution, ClientStateValidation,

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -238,7 +238,9 @@ pub mod solana_ibc {
             .map_err(|err| error!((&err)))?;
         }
 
-        // Since we do all the checks present in validate above, there is no need to call validate again. Hence validate is only called during tests.
+        // Since we do all the checks present in validate above, there is no
+        // need to call validate again.  Hence validate is only called during
+        // tests.
         ::ibc::core::channel::handler::send_packet_execute(&mut store, packet)
             .map_err(error::Error::ContextError)
             .map_err(|err| error!((&err)))

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -38,12 +38,9 @@ mod validation_context;
 
 #[anchor_lang::program]
 pub mod solana_ibc {
-    use ::ibc::core::{
-        channel::{
-            context::SendPacketValidationContext, types::packet::Packet,
-        },
-        host::types::path::SeqSendPath,
-    };
+    use ::ibc::core::channel::context::SendPacketValidationContext;
+    use ::ibc::core::channel::types::packet::Packet;
+    use ::ibc::core::host::types::path::SeqSendPath;
     use trie_ids::PortChannelPK;
 
     use super::*;
@@ -179,20 +176,28 @@ pub mod solana_ibc {
             .map_err(error::Error::ContextError)
             .map_err(|err| error!((&err)))?;
 
-        let port_channel_pk = PortChannelPK::try_from(port_id.clone(), channel_id.clone()).map_err(|e| error::Error::ContextError(e.into()))?;
+        let port_channel_pk =
+            PortChannelPK::try_from(port_id.clone(), channel_id.clone())
+                .map_err(|e| error::Error::ContextError(e.into()))?;
 
         let port_channel_store = private
             .port_channel
-            .get(&port_channel_pk).ok_or(error::Error::Internal("Port channel not found"))?;
+            .get(&port_channel_pk)
+            .ok_or(error::Error::Internal("Port channel not found"))?;
 
-        let channel_end = port_channel_store.channel_end().map_err(|e| error::Error::ContextError(e.into()))?.ok_or(error::Error::Internal("Channel end doesnt exist"))?;
+        let channel_end = port_channel_store
+            .channel_end()
+            .map_err(|e| error::Error::ContextError(e.into()))?
+            .ok_or(error::Error::Internal("Channel end doesnt exist"))?;
 
         let packet = Packet {
             seq_on_a: sequence,
             port_id_on_a: port_id,
             chan_id_on_a: channel_id,
             port_id_on_b: channel_end.counterparty().port_id.clone(),
-            chan_id_on_b: channel_end.counterparty().channel_id.clone().ok_or(error::Error::Internal("Counterparty channel id doesnt exist"))?,
+            chan_id_on_b: channel_end.counterparty().channel_id.clone().ok_or(
+                error::Error::Internal("Counterparty channel id doesnt exist"),
+            )?,
             data,
             timeout_height_on_b: timeout_height,
             timeout_timestamp_on_b: timeout_timestamp,

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -11,6 +11,7 @@ use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use borsh::BorshDeserialize;
 use trie_ids::PortChannelPK;
+
 use crate::ibc::SendPacketValidationContext;
 
 pub const CHAIN_SEED: &[u8] = b"chain";
@@ -167,16 +168,19 @@ pub mod solana_ibc {
         let mut store = storage::from_ctx!(ctx);
 
         let sequence = store
-            .get_next_sequence_send(&ibc::path::SeqSendPath::new(&port_id, &channel_id))
+            .get_next_sequence_send(&ibc::path::SeqSendPath::new(
+                &port_id,
+                &channel_id,
+            ))
             .map_err(error::Error::ContextError)
             .map_err(|err| error!((&err)))?;
 
-        let port_channel_pk =
-            PortChannelPK::try_from(&port_id, &channel_id)
-                .map_err(|e| error::Error::ContextError(e.into()))?;
+        let port_channel_pk = PortChannelPK::try_from(&port_id, &channel_id)
+            .map_err(|e| error::Error::ContextError(e.into()))?;
 
         let private_store = store.borrow();
-        let port_channel_store = private_store.private
+        let port_channel_store = private_store
+            .private
             .port_channel
             .get(&port_channel_pk)
             .ok_or(error::Error::Internal("Port channel not found"))?;

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -194,8 +194,8 @@ pub mod solana_ibc {
             seq_on_a: sequence,
             port_id_on_a: port_id,
             chan_id_on_a: channel_id,
-            port_id_on_b: channel_end.counterparty().port_id.clone(),
-            chan_id_on_b: channel_end.counterparty().channel_id.clone().ok_or(
+            port_id_on_b: channel_end.remote.port_id,
+            chan_id_on_b: channel_end.remote.channel_id.ok_or(
                 error::Error::Internal("Counterparty channel id doesnt exist"),
             )?,
             data,

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -232,7 +232,7 @@ pub mod solana_ibc {
 
         if cfg!(test) || cfg!(feature = "mocks") {
             ::ibc::core::channel::handler::send_packet_validate(
-                &mut store, &packet,
+                &store, &packet,
             )
             .map_err(error::Error::ContextError)
             .map_err(|err| error!((&err)))?;

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -602,7 +602,13 @@ fn anchor_test_deliver() -> Result<()> {
             chain,
             system_program: system_program::ID,
         })
-        .args(instruction::SendPacket { port_id, channel_id: channel_id_on_a.clone(), data: packet.data, timeout_height: packet.timeout_height_on_b, timeout_timestamp: packet.timeout_timestamp_on_b  })
+        .args(instruction::SendPacket {
+            port_id,
+            channel_id: channel_id_on_a.clone(),
+            data: packet.data,
+            timeout_height: packet.timeout_height_on_b,
+            timeout_timestamp: packet.timeout_timestamp_on_b,
+        })
         .payer(authority.clone())
         .signer(&*authority)
         .send_with_spinner_and_config(RpcSendTransactionConfig {

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -602,7 +602,7 @@ fn anchor_test_deliver() -> Result<()> {
             chain,
             system_program: system_program::ID,
         })
-        .args(instruction::SendPacket { packet })
+        .args(instruction::SendPacket { port_id, channel_id: channel_id_on_a.clone(), data: packet.data, timeout_height: packet.timeout_height_on_b, timeout_timestamp: packet.timeout_timestamp_on_b  })
         .payer(authority.clone())
         .signer(&*authority)
         .send_with_spinner_and_config(RpcSendTransactionConfig {


### PR DESCRIPTION
Currently send_packet takes Packet as an argument.  This means that
caller has to know not only port and channel identifiers on our side
but also provide counterparty information and sequence number.  This,
however, makes no sense.

For counterparty information, it makes no sense because then we fetch
that information ourselves to figure out if it’s correct.  How about,
we just populate that information ourselves instead?

For sequence number this is actually a bug since it causes competing
send packet requests to clash.  If next squence number is 42 and two
users want to send a packet, only one of them will be accepted.
Again, instead of requiring user to send that information, fill it
ourselves.

Change the prototype of send_packet method such that it doesn’t take
counterparty information and sequence number.  Instead make the method
derive that information.

Closes: https://github.com/ComposableFi/emulated-light-client/issues/152
