### PR TITLE
solana-ibc: fix bug in SequenceTripple returning None for Recv and Ack

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -40,6 +40,7 @@ trie-ids = { workspace = true, features = ["borsh"] }
 [dev-dependencies]
 anchor-client.workspace = true
 anyhow.workspace = true
+hex-literal.workspace = true
 ibc-testkit.workspace = true
 insta.workspace = true
 


### PR DESCRIPTION
Due to error in a way bit was checked in a bitmap, SequenceTripple
would always return None for Recv and Ack sequences.  Fix that.
