### PR TITLE
trie-ids: introduce PathInfo structure holding info of parsed IBC path

### DIFF
--- a/common/trie-ids/Cargo.toml
+++ b/common/trie-ids/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+ascii.workspace = true
 base64.workspace = true
 borsh = { workspace = true, optional = true }
 ibc-core-channel-types.workspace = true

--- a/common/trie-ids/src/lib.rs
+++ b/common/trie-ids/src/lib.rs
@@ -1,5 +1,6 @@
 mod ids;
 mod path;
+pub mod path_info;
 mod trie_key;
 
 mod ibc {
@@ -14,4 +15,5 @@ mod ibc {
 
 pub use ids::{ChannelIdx, ClientIdx, ConnectionIdx, PortChannelPK, PortKey};
 pub use path::SequencePath;
+pub use path_info::PathInfo;
 pub use trie_key::{Tag, TrieKey};

--- a/common/trie-ids/src/path_info.rs
+++ b/common/trie-ids/src/path_info.rs
@@ -1,0 +1,341 @@
+use crate::{ibc, Tag, TrieKey};
+
+/// Information gathered from parsing an IBC path into a trie key.
+///
+/// Apart from holding the key, this stores two additional pieces of
+/// information: client id and index if the path included client id (see
+/// [`Self::client`] field)) and sequence number type if path was for Send, Recv
+/// or Ack sequence number (see [`Self::seq_type`] field).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PathInfo {
+    /// The key in the trie path maps to.
+    pub key: TrieKey,
+
+    /// Client the key has been at least partially derived from, if any.
+    ///
+    /// `ClientState` and `ConsensusState` paths are derived partially from the
+    /// client id.  However, the key doesn’t encode the entirety of the id and
+    /// different client ids may map to the same key.
+    ///
+    /// If this field is set, it’s caller’s responsibility to verify that the
+    /// client id provided by the user corresponds to client id that the light
+    /// client expects at given index.
+    pub client: Option<(ibc::ClientId, crate::ClientIdx)>,
+
+    /// Sequence type if the path was for the next sequence number.
+    ///
+    /// Next send, receive and ack sequence numbers are stored in a single value
+    /// in the trie.  In other words, IBC paths to those values map to the same
+    /// trie key.  This field is used to distinguish between the three sequence
+    /// number applications.
+    pub seq_kind: Option<SequenceKind>,
+}
+
+/// Type of a sequence number referenced in a path; see [`PathInfo::seq_kind`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SequenceKind {
+    Send = 0,
+    Recv = 1,
+    Ack = 2,
+}
+
+impl From<SequenceKind> for usize {
+    fn from(kind: SequenceKind) -> usize { kind as usize }
+}
+
+/// Error when converting IBC path into a trie key.
+#[derive(Debug, PartialEq, Eq, derive_more::From)]
+pub enum Error {
+    BadChannel(ibc::ChannelId),
+    BadClient(ibc::ClientId),
+    BadConnection(ibc::ConnectionId),
+    BadPort(ibc::PortId),
+    UnsupportedPath(ibc::path::Path),
+}
+
+macro_rules! try_from_impl {
+    ($( $Variant:ident($path:ident: $Path:ident) => $body:tt )*) => {
+        $(
+            impl TryFrom<ibc::path::$Path> for PathInfo {
+                type Error = Error;
+                fn try_from($path: ibc::path::$Path) -> Result<Self, Self::Error> {
+                    $body
+                }
+            }
+        )*
+
+        impl TryFrom<ibc::path::Path> for PathInfo {
+            type Error = Error;
+            fn try_from(path: ibc::path::Path) -> Result<Self, Self::Error> {
+                match path {
+                    $(
+                        ibc::path::Path::$Variant(path) => path.try_into(),
+                    )*
+                }
+            }
+        }
+    }
+}
+
+try_from_impl! {
+    ClientState(path: ClientStatePath) => {
+        Self::with_client(path.0, TrieKey::for_client_state)
+    }
+
+    ClientConsensusState(path: ClientConsensusStatePath) => {
+        let height = (path.revision_number, path.revision_height);
+        Self::with_client(path.client_id, |idx| {
+            TrieKey::new(Tag::ConsensusState, (idx, height))
+        })
+    }
+
+    ClientConnection(path: ClientConnectionPath) => {
+        Err(ibc::path::Path::from(path).into())
+    }
+
+    Connection(path: ConnectionPath) => {
+        let connection = crate::ConnectionIdx::try_from(&path.0)
+            .map_err(|_| path.0)?;
+        Ok(Self {
+            key: TrieKey::for_connection(connection),
+            client: None,
+            seq_kind: None,
+        })
+    }
+
+    Ports(path: PortPath) => {
+        Err(ibc::path::Path::from(path).into())
+    }
+
+    ChannelEnd(path: ChannelEndPath) => {
+        Self::with_channel(Tag::ChannelEnd, path.0, path.1)
+    }
+    SeqSend(path: SeqSendPath) => {
+        Self::for_sequence(SequenceKind::Send, path.0, path.1)
+    }
+    SeqRecv(path: SeqRecvPath) => {
+        Self::for_sequence(SequenceKind::Recv, path.0, path.1)
+    }
+    SeqAck(path: SeqAckPath) => {
+        Self::for_sequence(SequenceKind::Ack, path.0, path.1)
+    }
+
+    Commitment(path: CommitmentPath) => {
+        Self::with_seq(
+        Tag::Commitment,
+        path.port_id,
+        path.channel_id,
+        path.sequence,
+        )
+    }
+    Ack(path: AckPath) => {Self::with_seq(
+        Tag::Ack,
+        path.port_id,
+        path.channel_id,
+        path.sequence,
+    )}
+    Receipt(path: ReceiptPath) => {Self::with_seq(
+        Tag::Receipt,
+        path.port_id,
+        path.channel_id,
+        path.sequence,
+    )}
+
+    UpgradeClient(path: UpgradeClientPath) => {
+        Err(ibc::path::Path::from(path).into())
+    }
+}
+
+impl PathInfo {
+    fn with_client(
+        client_id: ibc::ClientId,
+        make: impl FnOnce(crate::ClientIdx) -> TrieKey,
+    ) -> Result<Self, Error> {
+        match crate::ClientIdx::try_from(&client_id) {
+            Ok(client_idx) => Ok(Self {
+                key: make(client_idx),
+                client: Some((client_id, client_idx)),
+                seq_kind: None,
+            }),
+            Err(_) => Err(client_id.into()),
+        }
+    }
+
+    fn with_channel(
+        tag: Tag,
+        port_id: ibc::PortId,
+        channel_id: ibc::ChannelId,
+    ) -> Result<Self, Error> {
+        let port_key =
+            crate::PortKey::try_from(&port_id).map_err(|_| port_id)?;
+        let channel_idx =
+            crate::ChannelIdx::try_from(&channel_id).map_err(|_| channel_id)?;
+        Ok(Self {
+            key: TrieKey::new(tag, (port_key, channel_idx)),
+            client: None,
+            seq_kind: None,
+        })
+    }
+
+    fn for_sequence(
+        seq_kind: SequenceKind,
+        port_id: ibc::PortId,
+        channel_id: ibc::ChannelId,
+    ) -> Result<Self, Error> {
+        Self::with_channel(Tag::NextSequence, port_id, channel_id)
+            .map(|info| Self { seq_kind: Some(seq_kind), ..info })
+    }
+
+    fn with_seq(
+        tag: Tag,
+        port_id: ibc::PortId,
+        channel_id: ibc::ChannelId,
+        seq: ibc::Sequence,
+    ) -> Result<Self, Error> {
+        let port_key =
+            crate::PortKey::try_from(&port_id).map_err(|_| port_id)?;
+        let channel_idx =
+            crate::ChannelIdx::try_from(&channel_id).map_err(|_| channel_id)?;
+        Ok(Self {
+            key: TrieKey::new(tag, ((port_key, channel_idx), u64::from(seq))),
+            client: None,
+            seq_kind: None,
+        })
+    }
+}
+
+
+#[test]
+fn test_try_from_path() {
+    use std::str::FromStr;
+
+    #[track_caller]
+    fn test<P>(want_key: &[u8], want_client: bool, want_seq: i8, path: P)
+    where
+        P: Clone + Into<ibc::path::Path> + TryInto<PathInfo, Error = Error>,
+    {
+        let want = Ok(PathInfo {
+            key: TrieKey::from_bytes(want_key),
+            client: want_client.then(|| {
+                let id = ibc::ClientId::from_str("foo-bar-1").unwrap();
+                let idx = crate::ClientIdx::try_from(&id).unwrap();
+                (id, idx)
+            }),
+            seq_kind: match want_seq {
+                0 => Some(SequenceKind::Send),
+                1 => Some(SequenceKind::Recv),
+                2 => Some(SequenceKind::Ack),
+                -1 => None,
+                _ => panic!(),
+            },
+        });
+
+        assert_eq!(want, path.clone().try_into());
+        assert_eq!(want, path.into().try_into());
+    }
+
+    #[track_caller]
+    fn test_bad<P>(path: P)
+    where
+        P: Clone + Into<ibc::path::Path> + TryInto<PathInfo, Error = Error>,
+    {
+        let want = Err(Error::UnsupportedPath(path.clone().into()));
+        assert_eq!(want, path.clone().try_into());
+        assert_eq!(want, path.into().try_into());
+    }
+
+    macro_rules! check {
+        (err, $path:expr) => {
+            test_bad($path)
+        };
+        ($want:literal, $client:expr, $seq:expr, $path:expr $(,)?) => {
+            test(&hex_literal::hex!($want), $client, $seq, $path)
+        };
+    }
+
+    let client_id = ibc::ClientId::from_str("foo-bar-1").unwrap();
+    let connection = ibc::ConnectionId::new(4);
+    let port_id = ibc::PortId::transfer();
+    let channel_id = ibc::ChannelId::new(5);
+    let sequence = ibc::Sequence::from(6);
+
+    check!(
+        "00 00000001",
+        true,
+        -1,
+        ibc::path::ClientStatePath(client_id.clone())
+    );
+    check!(
+        "01 00000001 0000000000000002 0000000000000003",
+        true,
+        -1,
+        ibc::path::ClientConsensusStatePath {
+            client_id: client_id.clone(),
+            revision_number: 2,
+            revision_height: 3,
+        },
+    );
+    check!(err, ibc::path::ClientConnectionPath(client_id.clone()));
+    check!(
+        "02 00000004",
+        false,
+        -1,
+        ibc::path::ConnectionPath(connection.clone()),
+    );
+    check!(err, ibc::path::PortPath(port_id.clone()));
+    check!(
+        "03 b6b6a7b1f7abffffff 00000005",
+        false,
+        -1,
+        ibc::path::ChannelEndPath(port_id.clone(), channel_id.clone()),
+    );
+    check!(
+        "04 b6b6a7b1f7abffffff 00000005",
+        false,
+        0,
+        ibc::path::SeqSendPath(port_id.clone(), channel_id.clone()),
+    );
+    check!(
+        "04 b6b6a7b1f7abffffff 00000005",
+        false,
+        1,
+        ibc::path::SeqRecvPath(port_id.clone(), channel_id.clone()),
+    );
+    check!(
+        "04 b6b6a7b1f7abffffff 00000005",
+        false,
+        2,
+        ibc::path::SeqAckPath(port_id.clone(), channel_id.clone()),
+    );
+    check!(
+        "05 b6b6a7b1f7abffffff 00000005 0000000000000006",
+        false,
+        -1,
+        ibc::path::CommitmentPath {
+            port_id: port_id.clone(),
+            channel_id: channel_id.clone(),
+            sequence,
+        },
+    );
+    check!(
+        "07 b6b6a7b1f7abffffff 00000005 0000000000000006",
+        false,
+        -1,
+        ibc::path::AckPath {
+            port_id: port_id.clone(),
+            channel_id: channel_id.clone(),
+            sequence,
+        },
+    );
+    check!(
+        "06 b6b6a7b1f7abffffff 00000005 0000000000000006",
+        false,
+        -1,
+        ibc::path::ReceiptPath {
+            port_id: port_id.clone(),
+            channel_id: channel_id.clone(),
+            sequence,
+        },
+    );
+    check!(err, ibc::path::UpgradeClientPath::UpgradedClientState(42));
+}

--- a/common/trie-ids/src/trie_key.rs
+++ b/common/trie-ids/src/trie_key.rs
@@ -162,24 +162,9 @@ impl core::ops::Deref for TrieKey {
 
 impl core::fmt::Display for TrieKey {
     fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> core::fmt::Result {
-        const DIGITS: [ascii::AsciiChar; 16] = [
-            ascii::AsciiChar::_0,
-            ascii::AsciiChar::_1,
-            ascii::AsciiChar::_2,
-            ascii::AsciiChar::_3,
-            ascii::AsciiChar::_4,
-            ascii::AsciiChar::_5,
-            ascii::AsciiChar::_6,
-            ascii::AsciiChar::_7,
-            ascii::AsciiChar::_8,
-            ascii::AsciiChar::_9,
-            ascii::AsciiChar::a,
-            ascii::AsciiChar::b,
-            ascii::AsciiChar::c,
-            ascii::AsciiChar::d,
-            ascii::AsciiChar::e,
-            ascii::AsciiChar::f,
-        ];
+        use ascii::AsciiChar::*;
+        const DIGITS: [ascii::AsciiChar; 16] =
+            [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, a, b, c, d, e, f];
 
         let mut out = [ascii::AsciiChar::Null; 44];
         for (dst, byte) in out.chunks_exact_mut(2).zip(self.iter()) {

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -267,11 +267,7 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_> {
         seq: ibc::Sequence,
     ) -> Result {
         msg!("store_next_sequence_send: path: {}, seq: {}", path, seq);
-        self.store_next_sequence(
-            path.into(),
-            storage::SequenceTripleIdx::Send,
-            seq,
-        )
+        self.store_next_sequence(path.into(), storage::SequenceKind::Send, seq)
     }
 
     fn store_next_sequence_recv(
@@ -280,11 +276,7 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_> {
         seq: ibc::Sequence,
     ) -> Result {
         msg!("store_next_sequence_recv: path: {}, seq: {}", path, seq);
-        self.store_next_sequence(
-            path.into(),
-            storage::SequenceTripleIdx::Recv,
-            seq,
-        )
+        self.store_next_sequence(path.into(), storage::SequenceKind::Recv, seq)
     }
 
     fn store_next_sequence_ack(
@@ -293,11 +285,7 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_> {
         seq: ibc::Sequence,
     ) -> Result {
         msg!("store_next_sequence_ack: path: {}, seq: {}", path, seq);
-        self.store_next_sequence(
-            path.into(),
-            storage::SequenceTripleIdx::Ack,
-            seq,
-        )
+        self.store_next_sequence(path.into(), storage::SequenceKind::Ack, seq)
     }
 
     fn increase_channel_counter(&mut self) -> Result {
@@ -340,7 +328,7 @@ impl storage::IbcStorage<'_, '_> {
     fn store_next_sequence(
         &mut self,
         path: trie_ids::SequencePath<'_>,
-        index: storage::SequenceTripleIdx,
+        index: storage::SequenceKind,
         seq: ibc::Sequence,
     ) -> Result {
         let key =

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -32,24 +32,20 @@ pub struct SequenceTriple {
     mask: u8,
 }
 
-#[derive(Clone, Copy)]
-pub enum SequenceTripleIdx {
-    Send = 0,
-    Recv = 1,
-    Ack = 2,
-}
+pub use trie_ids::path_info::SequenceKind;
 
 impl SequenceTriple {
     /// Returns sequence at given index or `None` if it wasn’t set yet.
-    pub fn get(&self, idx: SequenceTripleIdx) -> Option<ibc::Sequence> {
-        let idx = idx as usize;
-        (self.mask & (1 << idx) != 0).then_some(self.sequences[idx].into())
+    pub fn get(&self, idx: SequenceKind) -> Option<ibc::Sequence> {
+        let idx = usize::from(idx);
+        (self.mask & (1 << idx) != 0)
+            .then_some(ibc::Sequence::from(self.sequences[idx]))
     }
 
     /// Sets sequence at given index.
-    pub(crate) fn set(&mut self, idx: SequenceTripleIdx, seq: ibc::Sequence) {
-        self.sequences[idx as usize] = u64::from(seq);
-        self.mask |= 1 << (idx as u32)
+    pub(crate) fn set(&mut self, idx: SequenceKind, seq: ibc::Sequence) {
+        self.sequences[usize::from(idx)] = u64::from(seq);
+        self.mask |= 1 << usize::from(idx);
     }
 
     /// Encodes the object as a `CryptoHash` so it can be stored in the trie
@@ -510,7 +506,7 @@ fn make_err(err: io::Error) -> ibc::ClientError {
 #[test]
 fn test_sequence_triple() {
     use hex_literal::hex;
-    use SequenceTripleIdx::{Ack, Recv, Send};
+    use SequenceKind::{Ack, Recv, Send};
 
     let mut triple = SequenceTriple::default();
     assert_eq!(None, triple.get(Send));

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -148,7 +148,7 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
     ) -> Result<ibc::Sequence> {
         self.get_next_sequence(
             path,
-            storage::SequenceTripleIdx::Send,
+            storage::SequenceKind::Send,
             |port_id, channel_id| ibc::PacketError::MissingNextSendSeq {
                 port_id,
                 channel_id,
@@ -162,7 +162,7 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
     ) -> Result<ibc::Sequence> {
         self.get_next_sequence(
             path,
-            storage::SequenceTripleIdx::Recv,
+            storage::SequenceKind::Recv,
             |port_id, channel_id| ibc::PacketError::MissingNextRecvSeq {
                 port_id,
                 channel_id,
@@ -176,7 +176,7 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
     ) -> Result<ibc::Sequence> {
         self.get_next_sequence(
             path,
-            storage::SequenceTripleIdx::Ack,
+            storage::SequenceKind::Ack,
             |port_id, channel_id| ibc::PacketError::MissingNextAckSeq {
                 port_id,
                 channel_id,
@@ -329,13 +329,13 @@ impl IbcStorage<'_, '_> {
     fn get_next_sequence<'a>(
         &self,
         path: impl Into<trie_ids::SequencePath<'a>>,
-        index: storage::SequenceTripleIdx,
+        index: storage::SequenceKind,
         make_err: impl FnOnce(ibc::PortId, ibc::ChannelId) -> ibc::PacketError,
     ) -> Result<ibc::Sequence> {
         fn get(
             this: &IbcStorage<'_, '_>,
             port_channel: &trie_ids::PortChannelPK,
-            index: storage::SequenceTripleIdx,
+            index: storage::SequenceKind,
         ) -> Option<ibc::Sequence> {
             this.borrow()
                 .private


### PR DESCRIPTION
Client state implementation deals with IBC’s Path type (which is an
enum of all possible paths) rather than concrete path types.  It
therefore needs code for converting that enum into TrieKey.  Introduce
it in the form of a PathInfo type.
