### PR TITLE
solana-ibc: mix client id into trie values whose key depends on client

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -53,7 +53,7 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
             processed_height,
             &state,
         )?;
-        let hash = state.digest()?;
+        let hash = state.digest(&path.client_id)?;
         client.consensus_states.insert(height, state);
 
         let trie_key =

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -150,12 +150,23 @@ impl ClientConsensusState {
         AnyConsensusState::try_from_slice(bytes).map_err(make_err)
     }
 
-    /// Returns digest of the consensus state.
-    pub fn digest(&self) -> Result<CryptoHash, ibc::ClientError> {
-        let err = || ibc::ClientError::ClientSpecific {
-            description: "Internal: Bad AnyConsensusState".into(),
-        };
-        self.0.as_bytes().get(16..).map(CryptoHash::digest).ok_or_else(err)
+    /// Returns digest of the consensus state with client id mixed in.
+    ///
+    /// Because we don’t store full client id in the trie key, it’s important to
+    /// reflect it somehow in the value stored in the trie.  We therefore hash
+    /// the id together with the serialised state to get the final hash.
+    ///
+    /// Specifically, calculates `digest(client_id || b'0' || serialised)`.
+    pub fn digest(
+        &self,
+        client_id: &ibc::ClientId,
+    ) -> Result<CryptoHash, ibc::ClientError> {
+        match self.0.as_bytes().get(16..) {
+            Some(serialised) => Ok(digest_with_client(client_id, serialised)),
+            None => Err(ibc::ClientError::ClientSpecific {
+                description: "Internal: Bad AnyConsensusState".into(),
+            }),
+        }
     }
 }
 
@@ -463,7 +474,27 @@ impl<T> Serialised<T> {
 
     pub fn as_bytes(&self) -> &[u8] { self.0.as_slice() }
 
+    /// Returns digest of the serialised value.
+    #[inline]
     pub fn digest(&self) -> CryptoHash { CryptoHash::digest(self.0.as_slice()) }
+
+    /// Returns digest of the serialised value with client id mixed in.
+    ///
+    /// Because we don’t store full client id in the trie key, for paths which
+    /// include client path, it’s important to reflect it somehow in the value
+    /// stored in the trie.  This therefore hash the id together with the
+    /// serialised values to get the final value hash.
+    ///
+    /// Specifically, calculates `digest(client_id || b'0' || serialised)`.
+    #[inline]
+    pub fn digest_with_client(&self, client_id: &ibc::ClientId) -> CryptoHash {
+        digest_with_client(client_id, self.as_bytes())
+    }
+}
+
+/// Returns digest of the bytes with client id mixed in.
+fn digest_with_client(client_id: &ibc::ClientId, bytes: &[u8]) -> CryptoHash {
+    CryptoHash::digestv(&[client_id.as_bytes(), b"\0", bytes])
 }
 
 impl<T: borsh::BorshSerialize> Serialised<T> {


### PR DESCRIPTION
When computing trie key for paths which include client id, we’re
stripping out the client type part of the id.  So keys to states of
clients ‘foo-0’ and ‘bar-0’ are the same.

To make sure that someone doesn’t produce a malicious proof which uses
wrong client type, (non-)membership verification algorithm must be
able to check the client id.  Make that possible by mixing in the
client id into the hash stored in the trie.

This way, if the path includes client id, the verification can
calculate the hash from value and client id and check if that was
stored in the trie.
