### PR TITLE
sealable-trie: simplify extend implementation

### DIFF
--- a/common/sealable-trie/src/trie/iter.rs
+++ b/common/sealable-trie/src/trie/iter.rs
@@ -177,7 +177,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
 
         match <&RawNode>::from(self.alloc.get(ptr)).decode()? {
             Node::Branch { children } => {
-                self.prefix.extend(false).unwrap();
+                self.prefix.push_back(false).unwrap();
                 self.handle_ref(children[0], self.prefix.len())?;
                 self.prefix.set_last(true);
                 self.handle_ref(children[1], len)


### PR DESCRIPTION
Using generics for extend implementation may be cool but it made the
code overly complex.  Simplify the bits::concat::Concat trait to
handle concatenation with creation of a new Owned object, replace
Owned::extend method by implementation which takes slice as suffix
parameter and add Owned::push_back for the case of appending a single
bit to the Owned slice.
