### PR TITLE
solana-ibc: remove unneccesary Ok in validation and execution context

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -58,8 +58,7 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
 
         let trie_key =
             trie_ids::TrieKey::for_consensus_state(client.index, height);
-        store.provable.set(&trie_key, &hash).map_err(error)?;
-        Ok(())
+        store.provable.set(&trie_key, &hash).map_err(error)
     }
 
     fn delete_consensus_state(
@@ -73,8 +72,7 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
         let mut client = store.private.client_mut(&path.client_id, false)?;
         client.consensus_states.remove(&height);
         let key = trie_ids::TrieKey::for_consensus_state(client.index, height);
-        store.provable.del(&key).map_err(error)?;
-        Ok(())
+        store.provable.del(&key).map(|_| ()).map_err(error)
     }
 
     /// Does nothing in the current implementation.
@@ -165,9 +163,7 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_> {
         store
             .provable
             .set(&trie_ids::TrieKey::for_connection(connection), &hash)
-            .map_err(error)?;
-
-        Ok(())
+            .map_err(error)
     }
 
     /// Does nothing in the current implementation.
@@ -256,8 +252,7 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_> {
             .or_default()
             .set_channel_end(&channel_end)
             .map_err(error)?;
-        store.provable.set(&trie_key, &digest).map_err(error)?;
-        Ok(())
+        store.provable.set(&trie_key, &digest).map_err(error)
     }
 
     fn store_next_sequence_send(

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -110,11 +110,10 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
         client_state_of_host_on_counterparty: ibc::Any,
     ) -> Result {
         Self::AnyClientState::try_from(client_state_of_host_on_counterparty)
-            .map_err(|err| ibc::ClientError::Other {
-                description: err.to_string(),
-            })?;
-        // todo: validate that the AnyClientState is Solomachine (for Solana protocol)
-        Ok(())
+            .map(|_| ())
+            .map_err(|err| {
+                ibc::ClientError::Other { description: err.to_string() }.into()
+            })
     }
 
     fn commitment_prefix(&self) -> ibc::CommitmentPrefix {


### PR DESCRIPTION
Replacing explicit `Ok(())` with the `Result` provided by the methods.