### PR TITLE
added validation for transfer methods

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -363,8 +363,7 @@ pub fn get_provable_from<'a, 'info>(
 pub struct TransferAccounts<'a> {
     pub sender: Option<AccountInfo<'a>>,
     pub receiver: Option<AccountInfo<'a>>,
-    pub sender_token_account: Option<AccountInfo<'a>>,
-    pub receiver_token_account: Option<AccountInfo<'a>>,
+    pub token_account: Option<AccountInfo<'a>>,
     pub token_mint: Option<AccountInfo<'a>>,
     pub escrow_account: Option<AccountInfo<'a>>,
     pub mint_authority: Option<AccountInfo<'a>>,
@@ -446,8 +445,7 @@ macro_rules! from_ctx {
                 .receiver
                 .as_ref()
                 .map(ToAccountInfo::to_account_info),
-            sender_token_account: None,
-            receiver_token_account: accounts
+            token_account: accounts
                 .receiver_token_account
                 .as_deref()
                 .map(ToAccountInfo::to_account_info),

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -326,8 +326,8 @@ impl TokenTransferValidationContext for IbcStorage<'_, '_> {
         {
             return Err(TokenTransferError::ParseAccountFailure);
         }
-        let escrow_account = &accounts.escrow_account.clone().unwrap(); // we check before if it exists so the unwrap is infallible
-        let token_account = &accounts.token_account.clone().unwrap(); // we check before if it exists so the unwrap is infallible
+        let escrow_account = &accounts.escrow_account.as_ref().ok_or(TokenTransferError::ParseAccountFailure)?;
+        let token_account = &accounts.token_account.as_ref().ok_or(TokenTransferError::ParseAccountFailure)?;
         if matches!(from_account, AccountId::Escrow(_)) {
             let from = from_account
                 .get_escrow_account(coin.denom.base_denom.as_str())
@@ -379,7 +379,7 @@ impl TokenTransferValidationContext for IbcStorage<'_, '_> {
             return Err(TokenTransferError::ParseAccountFailure);
         }
         let account: Pubkey = account.try_into().unwrap();
-        let token_account = accounts.token_account.clone().unwrap();
+        let token_account = accounts.token_account.as_ref().ok_or(TokenTransferError::ParseAccountFailure)?;
         if !account.eq(token_account.key) {
             return Err(TokenTransferError::ParseAccountFailure);
         }
@@ -408,7 +408,7 @@ impl TokenTransferValidationContext for IbcStorage<'_, '_> {
             return Err(TokenTransferError::ParseAccountFailure);
         }
         let account: Pubkey = account.try_into().unwrap();
-        let token_account = accounts.token_account.clone().unwrap();
+        let token_account = accounts.token_account.as_ref().ok_or(TokenTransferError::ParseAccountFailure)?;
         if !account.eq(token_account.key) {
             return Err(TokenTransferError::ParseAccountFailure);
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -319,9 +319,7 @@ impl TokenTransferValidationContext for IbcStorage<'_, '_> {
         */
         let store = self.borrow();
         let accounts = &store.accounts;
-        if accounts.token_program.is_none() ||
-            accounts.token_mint.is_none()
-        {
+        if accounts.token_program.is_none() || accounts.token_mint.is_none() {
             return Err(TokenTransferError::ParseAccountFailure);
         }
         let escrow_account = accounts

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -320,9 +320,7 @@ impl TokenTransferValidationContext for IbcStorage<'_, '_> {
         let store = self.borrow();
         let accounts = &store.accounts;
         if accounts.token_program.is_none() ||
-            accounts.token_mint.is_none() ||
-            accounts.escrow_account.is_none() ||
-            accounts.token_account.is_none()
+            accounts.token_mint.is_none()
         {
             return Err(TokenTransferError::ParseAccountFailure);
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -324,11 +324,11 @@ impl TokenTransferValidationContext for IbcStorage<'_, '_> {
         {
             return Err(TokenTransferError::ParseAccountFailure);
         }
-        let escrow_account = &accounts
+        let escrow_account = accounts
             .escrow_account
             .as_ref()
             .ok_or(TokenTransferError::ParseAccountFailure)?;
-        let token_account = &accounts
+        let token_account = accounts
             .token_account
             .as_ref()
             .ok_or(TokenTransferError::ParseAccountFailure)?;

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -373,8 +373,7 @@ impl TokenTransferValidationContext for IbcStorage<'_, '_> {
         let accounts = &store.accounts;
         if accounts.token_program.is_none() ||
             accounts.token_mint.is_none() ||
-            accounts.mint_authority.is_none() ||
-            accounts.token_account.is_none()
+            accounts.mint_authority.is_none()
         {
             return Err(TokenTransferError::ParseAccountFailure);
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -405,8 +405,7 @@ impl TokenTransferValidationContext for IbcStorage<'_, '_> {
         let accounts = &store.accounts;
         if accounts.token_program.is_none() ||
             accounts.token_mint.is_none() ||
-            accounts.mint_authority.is_none() ||
-            accounts.token_account.is_none()
+            accounts.mint_authority.is_none()
         {
             return Err(TokenTransferError::ParseAccountFailure);
         }


### PR DESCRIPTION
Since we are sending a struct of accounts with optional fields, there might be chances of not sending some accounts which are important. And also we check if the accounts which are PDAs are derived with right seed or not.