### PR TITLE
converting timestamp into nanoseconds while conversion in `host_timestamp`

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -60,9 +60,11 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
     fn host_timestamp(&self) -> Result<ibc::Timestamp> {
         let timestamp = self.borrow().chain.head()?.host_timestamp.get();
         // Since timestamp is in seconds, converting it into nanoseconds.
-        ibc::Timestamp::from_nanoseconds(timestamp * 10_u64.pow(9)).map_err(|err| {
-            ibc::ClientError::Other { description: err.to_string() }.into()
-        })
+        ibc::Timestamp::from_nanoseconds(timestamp * 10_u64.pow(9)).map_err(
+            |err| {
+                ibc::ClientError::Other { description: err.to_string() }.into()
+            },
+        )
     }
 
     fn host_consensus_state(

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -59,7 +59,8 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
 
     fn host_timestamp(&self) -> Result<ibc::Timestamp> {
         let timestamp = self.borrow().chain.head()?.host_timestamp.get();
-        ibc::Timestamp::from_nanoseconds(timestamp).map_err(|err| {
+        // Since timestamp is in seconds, converting it into nanoseconds.
+        ibc::Timestamp::from_nanoseconds(timestamp * 10_u64.pow(9)).map_err(|err| {
             ibc::ClientError::Other { description: err.to_string() }.into()
         })
     }


### PR DESCRIPTION
The timestamp which we get from the `chain` head is in seconds but while converting it to ibc timestamp, we have to convert it into nanoseconds. So multiplying the timestamp by 10^9 to get it in nanoseconds.