### PR TITLE
solana-ibc: use ConsensusState derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,8 +698,9 @@ dependencies = [
  "borsh 0.10.3",
  "bytemuck",
  "derive_more",
+ "ibc-core-client-context",
  "ibc-core-commitment-types",
- "ibc-proto 0.39.1",
+ "ibc-primitives",
  "insta",
  "lib",
  "prost",
@@ -2056,7 +2057,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-core",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "primitive-types",
  "serde",
  "uint",
@@ -2102,7 +2103,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost",
  "serde",
  "tendermint",
@@ -2166,7 +2167,7 @@ dependencies = [
  "ibc-core-connection-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost",
  "serde",
  "sha2 0.10.8",
@@ -2220,7 +2221,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost",
  "serde",
  "subtle-encoding",
@@ -2237,7 +2238,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "ics23",
  "prost",
  "serde",
@@ -2271,7 +2272,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost",
  "serde",
  "subtle-encoding",
@@ -2310,7 +2311,7 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost",
  "serde",
  "subtle-encoding",
@@ -2355,7 +2356,7 @@ dependencies = [
  "ibc-core-handler-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost",
  "serde",
  "sha2 0.10.8",
@@ -2403,7 +2404,7 @@ dependencies = [
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "ics23",
  "prost",
  "serde",
@@ -2432,7 +2433,7 @@ dependencies = [
  "borsh 0.10.3",
  "derive_more",
  "displaydoc",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost",
  "serde",
  "tendermint",
@@ -2457,21 +2458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ibc-proto"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a8b1356652b9f160f5a010dd6b084675b8a28e163bf2b41ca5abecf27d9701"
-dependencies = [
- "base64 0.21.5",
- "bytes",
- "flex-error",
- "ics23",
- "prost",
- "subtle-encoding",
- "tendermint-proto",
-]
-
-[[package]]
 name = "ibc-testkit"
 version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,7 +2467,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "parking_lot",
  "primitive-types",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,13 @@ derive_more = "0.99.17"
 hex-literal = "0.4.1"
 ibc = { version = "0.48.2", default-features = false, features = ["borsh", "serde"] }
 ibc-core-channel-types = { version = "0.48.2", default-features = false }
+ibc-core-client-context = { version = "0.48.2", default-features = false }
 ibc-core-client-types = { version = "0.48.2", default-features = false }
 ibc-core-commitment-types = { version = "0.48.2", default-features = false }
 ibc-core-connection-types = { version = "0.48.2", default-features = false }
 ibc-core-host-types = { version = "0.48.2", default-features = false }
-ibc-proto = { version = "0.39.1", default-features = false }
+ibc-primitives = { version = "0.48.2", default-features = false }
+ibc-proto = { version = "0.39.2", default-features = false }
 ibc-testkit = { version = "0.48.2", default-features = false }
 insta = { version = "1.34.0" }
 pretty_assertions = "1.4.0"

--- a/common/blockchain/Cargo.toml
+++ b/common/blockchain/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2021"
 borsh.workspace = true
 bytemuck.workspace = true
 derive_more.workspace = true
+ibc-core-client-context.workspace = true
 ibc-core-commitment-types.workspace = true
-ibc-proto.workspace = true
+ibc-primitives.workspace = true
 prost = { workspace = true, features = ["prost-derive"] }
 strum.workspace = true
 

--- a/common/blockchain/src/proto.rs
+++ b/common/blockchain/src/proto.rs
@@ -1,4 +1,4 @@
-use ibc_proto::google::protobuf::Any;
+use ibc_primitives::proto::Any;
 use prost::Message as _;
 
 mod pb {


### PR DESCRIPTION
Rather than manually implementing ConsensusState for AnyConsensusState
(which is just boilerplate dispatch code) use a derive to do that for
us.  Unfortunately, we cannot do the same with ClientState because of
<https://github.com/cosmos/ibc-rs/issues/910>.
