### PR TITLE
solana-ibc: use vector-backed maps rather than BTreeMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "linear-map"
+version = "1.2.0"
+source = "git+https://github.com/contain-rs/linear-map?rev=57f1432e26ff902bc883b250a85e0b5716bd241c#57f1432e26ff902bc883b250a85e0b5716bd241c"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4364,6 +4369,7 @@ dependencies = [
  "ibc-testkit",
  "insta",
  "lib",
+ "linear-map",
  "memory",
  "primitive-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ ibc-core-host-types = { version = "0.48.2", default-features = false }
 ibc-proto = { version = "0.39.1", default-features = false }
 ibc-testkit = { version = "0.48.2", default-features = false }
 insta = { version = "1.34.0" }
+# https://github.com/contain-rs/linear-map/pull/38 adds no_std support
+linear-map = { git = "https://github.com/contain-rs/linear-map", rev = "57f1432e26ff902bc883b250a85e0b5716bd241c", default-features = false }
 pretty_assertions = "1.4.0"
 primitive-types = "0.12.2"
 rand = { version = "0.8.5" }

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -23,6 +23,7 @@ bytemuck = { workspace = true, features = ["must_cast"] }
 derive_more.workspace = true
 ibc-testkit = { workspace = true, optional = true }
 ibc.workspace = true
+linear-map.workspace = true
 primitive-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -249,7 +249,7 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_> {
             .private
             .port_channel
             .entry(port_channel)
-            .or_default()
+            .or_insert_with(Default::default)
             .set_channel_end(&channel_end)
             .map_err(error)?;
         store.provable.set(&trie_key, &digest).map_err(error)
@@ -334,7 +334,7 @@ impl storage::IbcStorage<'_, '_> {
                 .private
                 .port_channel
                 .entry(key)
-                .or_default()
+                .or_insert_with(Default::default)
                 .next_sequence;
             triple.set(index, seq);
             triple.to_hash()

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -1,4 +1,3 @@
-use alloc::collections::BTreeMap;
 use alloc::rc::Rc;
 use core::cell::{RefCell, RefMut};
 use core::num::NonZeroU64;
@@ -12,6 +11,8 @@ type Result<T, E = anchor_lang::error::Error> = core::result::Result<T, E>;
 use crate::client_state::AnyClientState;
 use crate::consensus_state::AnyConsensusState;
 use crate::ibc;
+
+pub mod map;
 
 /// A triple of send, receive and acknowledge sequences.
 ///
@@ -62,7 +63,7 @@ impl SequenceTriple {
 pub struct ClientStore {
     pub client_id: ibc::ClientId,
     pub client_state: Serialised<AnyClientState>,
-    pub consensus_states: BTreeMap<ibc::Height, ClientConsensusState>,
+    pub consensus_states: map::Map<ibc::Height, ClientConsensusState>,
 }
 
 impl ClientStore {
@@ -253,7 +254,7 @@ pub struct PrivateStorage {
     pub connections: Vec<Serialised<ibc::ConnectionEnd>>,
 
     /// Information about a each `(part, channel)` endpoint.
-    pub port_channel: BTreeMap<trie_ids::PortChannelPK, PortChannelStore>,
+    pub port_channel: map::Map<trie_ids::PortChannelPK, PortChannelStore>,
 
     pub channel_counter: u32,
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/storage/map.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/map.rs
@@ -1,0 +1,51 @@
+use core::fmt;
+
+use anchor_lang::prelude::borsh;
+use anchor_lang::prelude::borsh::maybestd::io;
+
+/// A mapping using an unsorted vector as backing storage.
+///
+/// Lookup operations on the map take linear time but for small maps that might
+/// actually be faster than hash maps or B trees.
+#[derive(Clone, derive_more::Deref, derive_more::DerefMut)]
+pub struct Map<K: Eq, V>(linear_map::LinearMap<K, V>);
+
+impl<K: Eq, V> Default for Map<K, V> {
+    fn default() -> Self { Self(Default::default()) }
+}
+
+impl<K: Eq + fmt::Debug, V: fmt::Debug> fmt::Debug for Map<K, V> {
+    fn fmt(&self, fmtr: &mut fmt::Formatter) -> fmt::Result {
+        fmtr.debug_map().entries(&self.0).finish()
+    }
+}
+
+impl<K: Eq, V> borsh::BorshSerialize for Map<K, V>
+where
+    K: borsh::BorshSerialize,
+    V: borsh::BorshSerialize,
+{
+    fn serialize<W: io::Write>(&self, wr: &mut W) -> io::Result<()> {
+        // LinearMap doesn’t offer as_slice function so we need to encode it by
+        // ourselves.
+        u32::try_from(self.len()).unwrap().serialize(wr)?;
+        for pair in self.iter() {
+            pair.serialize(wr)?;
+        }
+        Ok(())
+    }
+}
+
+impl<K: Eq, V> borsh::BorshDeserialize for Map<K, V>
+where
+    K: borsh::BorshDeserialize,
+    V: borsh::BorshDeserialize,
+{
+    /// Deserialises the map from a vector of `(K, V)` pairs.
+    ///
+    /// **Note**: No checking for duplicates is performed.  Malicious value may
+    /// lead to a map with duplicate keys.
+    fn deserialize_reader<R: io::Read>(rd: &mut R) -> io::Result<Self> {
+        Vec::<(K, V)>::deserialize_reader(rd).map(|vec| Self(vec.into()))
+    }
+}


### PR DESCRIPTION
In attempt to reduce memory usage and cost of serialising and
deserialising accounts, replace usage of BTreeMap with LinearMap which
is a vector-backed map.

Operations on the map have linear complexity, but since we’re not
doing many of them per instruction, chances are that time saved by not
having to build a tree structure when deserialising will make up for
that.

In fact, for small maps—which is what we’re having—it may be faster
regardless.  In anchor_test_deliver some of the instructions spend
fewer compute units while others use more so this would need further
investigation.
