### PR TITLE
solana-ibc: end to end tests and remove redunadancies

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -125,8 +125,8 @@ pub mod solana_ibc {
     /// given in this call’s context before the body of the method is
     /// executed.
     #[allow(unused_variables)]
-    pub fn init_escrow<'a, 'info>(
-        ctx: Context<'a, 'a, 'a, 'info, InitEscrow<'info>>,
+    pub fn init_mint<'a, 'info>(
+        ctx: Context<'a, 'a, 'a, 'info, InitMint<'info>>,
         port_id: ibc::PortId,
         channel_id_on_b: ibc::ChannelId,
         hashed_base_denom: CryptoHash,
@@ -352,7 +352,7 @@ pub struct ChainWithVerifier<'info> {
 
 #[derive(Accounts)]
 #[instruction(port_id: ibc::PortId, channel_id_on_b: ibc::ChannelId, hashed_base_denom: CryptoHash)]
-pub struct InitEscrow<'info> {
+pub struct InitMint<'info> {
     #[account(mut)]
     sender: Signer<'info>,
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -146,29 +146,11 @@ pub mod solana_ibc {
             .map_err(move |err| error!((&err)))
     }
 
-    /// Called to set up escrow and mint accounts for given channel and denom.
-    /// Panics if called without `mocks` feature.
-    pub fn mock_init_escrow<'a, 'info>(
-        ctx: Context<'a, 'a, 'a, 'info, MockInitEscrow<'info>>,
-        port_id: ibc::PortId,
-        channel_id_on_b: ibc::ChannelId,
-        hashed_base_denom: CryptoHash,
-    ) -> Result<()> {
-        mocks::mock_init_escrow(
-            ctx,
-            port_id,
-            channel_id_on_b,
-            hashed_base_denom,
-        )
-    }
-
     /// Called to set up a connection, channel and store the next
     /// sequence.  Will panic if called without `mocks` feature.
     pub fn mock_deliver<'a, 'info>(
         ctx: Context<'a, 'a, 'a, 'info, MockDeliver<'info>>,
         port_id: ibc::PortId,
-        channel_id_on_b: ibc::ChannelId,
-        hashed_base_denom: CryptoHash,
         commitment_prefix: ibc::CommitmentPrefix,
         client_id: ibc::ClientId,
         counterparty_client_id: ibc::ClientId,
@@ -176,8 +158,6 @@ pub mod solana_ibc {
         mocks::mock_deliver(
             ctx,
             port_id,
-            channel_id_on_b,
-            hashed_base_denom,
             commitment_prefix,
             client_id,
             counterparty_client_id,
@@ -385,11 +365,6 @@ pub struct InitEscrow<'info> {
               bump, mint::decimals = 6, mint::authority = mint_authority)]
     token_mint: Account<'info, Mint>,
 
-    #[account(init_if_needed, payer = sender, seeds = [
-        port_id.as_bytes(), channel_id_on_b.as_bytes(), hashed_base_denom.as_ref()
-    ], bump, token::mint = token_mint, token::authority = mint_authority)]
-    escrow_account: Box<Account<'info, TokenAccount>>,
-
     associated_token_program: Program<'info, AssociatedToken>,
     token_program: Program<'info, Token>,
     system_program: Program<'info, System>,
@@ -421,7 +396,7 @@ pub struct Deliver<'info> {
     #[account(mut, seeds = [MINT_ESCROW_SEED], bump)]
     /// CHECK:
     mint_authority: Option<UncheckedAccount<'info>>,
-    #[account(mut, mint::decimals = 6, mint::authority = mint_authority)]
+    #[account(mut)]
     token_mint: Option<Box<Account<'info, Mint>>>,
     #[account(mut, token::mint = token_mint, token::authority = mint_authority)]
     escrow_account: Option<Box<Account<'info, TokenAccount>>>,
@@ -436,37 +411,9 @@ pub struct Deliver<'info> {
 }
 
 #[derive(Accounts)]
-#[instruction(port_id: ibc::PortId, channel_id_on_b: ibc::ChannelId, hashed_base_denom: CryptoHash)]
-pub struct MockInitEscrow<'info> {
-    #[account(mut)]
-    sender: Signer<'info>,
-
-    /// CHECK:
-    #[account(init_if_needed, payer = sender, seeds = [MINT_ESCROW_SEED],
-              bump, space = 100)]
-    mint_authority: UncheckedAccount<'info>,
-
-    #[account(init_if_needed, payer = sender, seeds = [hashed_base_denom.as_ref()],
-              bump, mint::decimals = 6, mint::authority = mint_authority)]
-    token_mint: Account<'info, Mint>,
-
-    #[account(init_if_needed, payer = sender, seeds = [
-        port_id.as_bytes(), channel_id_on_b.as_bytes(),hashed_base_denom.as_ref()
-    ], bump, token::mint = token_mint, token::authority = mint_authority)]
-    escrow_account: Box<Account<'info, TokenAccount>>,
-
-    associated_token_program: Program<'info, AssociatedToken>,
-    token_program: Program<'info, Token>,
-    system_program: Program<'info, System>,
-}
-#[derive(Accounts)]
-#[instruction(port_id: ibc::PortId, channel_id_on_b: ibc::ChannelId, hashed_base_denom: CryptoHash)]
 pub struct MockDeliver<'info> {
     #[account(mut)]
     sender: Signer<'info>,
-
-    /// CHECK:
-    receiver: AccountInfo<'info>,
 
     /// The account holding private IBC storage.
     #[account(mut, seeds = [SOLANA_IBC_STORAGE_SEED],bump)]
@@ -483,28 +430,6 @@ pub struct MockDeliver<'info> {
     #[account(mut, seeds = [CHAIN_SEED], bump)]
     chain: Account<'info, chain::ChainData>,
 
-    /// The below accounts are being created for testing purposes only.  In
-    /// real, we would run conditionally create an escrow account when the
-    /// channel is created.  And we could have another method that can create
-    /// a mint given the denom.
-    #[account(mut, seeds = [MINT_ESCROW_SEED], bump)]
-    /// CHECK:
-    mint_authority: UncheckedAccount<'info>,
-    #[account(mut, seeds = [hashed_base_denom.as_ref()],
-              bump, mint::decimals = 6, mint::authority = mint_authority)]
-    token_mint: Box<Account<'info, Mint>>,
-    #[account(mut, seeds = [
-        port_id.as_bytes(), channel_id_on_b.as_bytes(),hashed_base_denom.as_ref()
-    ], bump, token::mint = token_mint, token::authority = mint_authority)]
-    escrow_account: Box<Account<'info, TokenAccount>>,
-
-    #[account(init_if_needed, payer = sender,
-              associated_token::mint = token_mint,
-              associated_token::authority = receiver)]
-    receiver_token_account: Box<Account<'info, TokenAccount>>,
-
-    associated_token_program: Program<'info, AssociatedToken>,
-    token_program: Program<'info, Token>,
     system_program: Program<'info, System>,
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/mocks.rs
@@ -1,26 +1,12 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::MintTo;
 
 use crate::ibc::ExecutionContext;
-use crate::{
-    ibc, storage, CryptoHash, MockDeliver, MockInitEscrow, MINT_ESCROW_SEED,
-};
+use crate::{ibc, storage, MockDeliver};
 
-
-pub(crate) fn mock_init_escrow<'a, 'info>(
-    _ctx: Context<'a, 'a, 'a, 'info, MockInitEscrow<'info>>,
-    _port_id: ibc::PortId,
-    _channel_id: ibc::ChannelId,
-    _hashed_base_denom: CryptoHash,
-) -> Result<()> {
-    Ok(())
-}
 
 pub(crate) fn mock_deliver<'a, 'info>(
     ctx: Context<'a, 'a, 'a, 'info, MockDeliver<'info>>,
     port_id: ibc::PortId,
-    _channel_id: ibc::ChannelId,
-    _hashed_base_denom: CryptoHash,
     commitment_prefix: ibc::CommitmentPrefix,
     client_id: ibc::ClientId,
     counterparty_client_id: ibc::ClientId,
@@ -148,23 +134,5 @@ pub(crate) fn mock_deliver<'a, 'info>(
         )
         .unwrap();
 
-    // Minting some tokens to the escrow so that he can do the transfer
-    let bump = ctx.bumps.mint_authority;
-    let seeds = [MINT_ESCROW_SEED, core::slice::from_ref(&bump)];
-    let seeds = seeds.as_ref();
-    let seeds = core::slice::from_ref(&seeds);
-
-    // Mint some tokens to escrow account
-    let mint_instruction = MintTo {
-        mint: ctx.accounts.token_mint.to_account_info(),
-        to: ctx.accounts.escrow_account.to_account_info(),
-        authority: ctx.accounts.mint_authority.to_account_info(),
-    };
-    let cpi_ctx = CpiContext::new_with_signer(
-        ctx.accounts.token_program.to_account_info(),
-        mint_instruction,
-        seeds, //signer PDA
-    );
-    anchor_spl::token::mint_to(cpi_ctx, 10000000)?;
     Ok(())
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/no-mocks.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/no-mocks.rs
@@ -2,22 +2,11 @@
 
 use anchor_lang::prelude::*;
 
-use crate::{ibc, CryptoHash, MockDeliver, MockInitEscrow};
-
-pub(crate) fn mock_init_escrow<'a, 'info>(
-    ctx: Context<'a, 'a, 'a, 'info, MockInitEscrow<'info>>,
-    port_id: ibc::PortId,
-    channel_id: ibc::ChannelId,
-    hashed_base_denom: CryptoHash,
-) -> Result<()> {
-    panic!("This instruction is only available in mocks build")
-}
+use crate::{ibc, CryptoHash, MockDeliver};
 
 pub(crate) fn mock_deliver<'a, 'info>(
     ctx: Context<'a, 'a, 'a, 'info, MockDeliver<'info>>,
     port_id: ibc::PortId,
-    channel_id: ibc::ChannelId,
-    hashed_base_denom: CryptoHash,
     commitment_prefix: ibc::CommitmentPrefix,
     client_id: ibc::ClientId,
     counterparty_client_id: ibc::ClientId,

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -302,7 +302,7 @@ fn anchor_test_deliver() -> Result<()> {
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
             1_000_000u32,
         ))
-        .accounts(accounts::InitEscrow {
+        .accounts(accounts::InitMint {
             sender: authority.pubkey(),
             mint_authority: mint_authority_key,
             // escrow_account: escrow_account_key,
@@ -311,7 +311,7 @@ fn anchor_test_deliver() -> Result<()> {
             associated_token_program: anchor_spl::associated_token::ID,
             token_program: anchor_spl::token::ID,
         })
-        .args(instruction::InitEscrow {
+        .args(instruction::InitMint {
             port_id: port_id.clone(),
             channel_id_on_b: channel_id_on_a.clone(),
             hashed_base_denom: hashed_denom.clone(),

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -451,9 +451,9 @@ fn anchor_test_deliver() -> Result<()> {
      */
 
     println!("\nRecving on destination chain");
-    let account_balance_before =
-        sol_rpc_client.get_token_account_balance(&receiver_token_address);
-    // .unwrap();
+    let account_balance_before = sol_rpc_client
+        .get_token_account_balance(&receiver_token_address)
+        .map_or(0f64, |balance| balance.ui_amount.unwrap());
 
     let packet = construct_packet_from_denom(
         &base_denom,
@@ -513,12 +513,8 @@ fn anchor_test_deliver() -> Result<()> {
     let account_balance_after = sol_rpc_client
         .get_token_account_balance(&receiver_token_address)
         .unwrap();
-    let previous_balance = match account_balance_before {
-        Ok(balance) => balance.ui_amount.unwrap(),
-        Err(_) => 0f64,
-    };
     assert_eq!(
-        ((account_balance_after.ui_amount.unwrap() - previous_balance) *
+        ((account_balance_after.ui_amount.unwrap() - account_balance_before) *
             10_f64.powf(mint_info.decimals.into()))
         .round() as u64,
         TRANSFER_AMOUNT
@@ -633,7 +629,8 @@ fn anchor_test_deliver() -> Result<()> {
     let escrow_account_balance_before =
         sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
     let receiver_account_balance_before = sol_rpc_client
-        .get_token_account_balance(&receiver_native_token_address);
+        .get_token_account_balance(&receiver_native_token_address)
+        .map_or(0f64, |balance| balance.ui_amount.unwrap());
 
     let sig = program
         .request()
@@ -675,13 +672,9 @@ fn anchor_test_deliver() -> Result<()> {
         .round() as u64,
         TRANSFER_AMOUNT
     );
-    let previous_receiver_balance = match receiver_account_balance_before {
-        Ok(balance) => balance.ui_amount.unwrap(),
-        Err(_) => 0f64,
-    };
     assert_eq!(
         ((receiver_account_balance_after.ui_amount.unwrap() -
-            previous_receiver_balance) *
+            receiver_account_balance_before) *
             10_f64.powf(mint_info.decimals.into()))
         .round() as u64,
         TRANSFER_AMOUNT

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -23,7 +23,7 @@ use crate::storage::PrivateStorage;
 use crate::{accounts, chain, ibc, instruction, CryptoHash, MINT_ESCROW_SEED};
 
 const IBC_TRIE_PREFIX: &[u8] = b"ibc/";
-const BASE_DENOM: &str = "PICA";
+// const BASE_DENOM: &str = "PICA";
 
 const TRANSFER_AMOUNT: u64 = 1000000;
 
@@ -86,7 +86,11 @@ fn anchor_test_deliver() -> Result<()> {
     let trie = Pubkey::find_program_address(&[crate::TRIE_SEED], &crate::ID).0;
     let chain =
         Pubkey::find_program_address(&[crate::CHAIN_SEED], &crate::ID).0;
-    let hashed_denom = CryptoHash::digest(BASE_DENOM.as_bytes());
+
+    let mint_keypair = Keypair::new();
+    let native_token_mint_key = mint_keypair.pubkey();
+    let base_denom = native_token_mint_key.to_string();
+    let hashed_denom = CryptoHash::digest(base_denom.as_bytes());
 
     /*
      * Initialise chain
@@ -231,50 +235,18 @@ fn anchor_test_deliver() -> Result<()> {
         })?;
     println!("  Signature: {sig}");
 
-    /*
-     * Setup mock escrow.
-     */
-
-    println!("\nCreating mint and escrow accounts");
     let port_id = ibc::PortId::transfer();
     let channel_id_on_a = ibc::ChannelId::new(0);
     let channel_id_on_b = ibc::ChannelId::new(1);
 
     let seeds =
-        [port_id.as_bytes(), channel_id_on_b.as_bytes(), hashed_denom.as_ref()];
+        [port_id.as_bytes(), channel_id_on_a.as_bytes(), hashed_denom.as_ref()];
     let (escrow_account_key, _bump) =
         Pubkey::find_program_address(&seeds, &crate::ID);
     let (token_mint_key, _bump) =
         Pubkey::find_program_address(&[hashed_denom.as_ref()], &crate::ID);
     let (mint_authority_key, _bump) =
         Pubkey::find_program_address(&[MINT_ESCROW_SEED], &crate::ID);
-
-    let sig = program
-        .request()
-        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            1_000_000u32,
-        ))
-        .accounts(accounts::MockInitEscrow {
-            sender: authority.pubkey(),
-            mint_authority: mint_authority_key,
-            escrow_account: escrow_account_key,
-            token_mint: token_mint_key,
-            system_program: system_program::ID,
-            associated_token_program: anchor_spl::associated_token::ID,
-            token_program: anchor_spl::token::ID,
-        })
-        .args(instruction::MockInitEscrow {
-            port_id: port_id.clone(),
-            channel_id_on_b: channel_id_on_b.clone(),
-            hashed_base_denom: hashed_denom.clone(),
-        })
-        .payer(authority.clone())
-        .signer(&*authority)
-        .send_with_spinner_and_config(RpcSendTransactionConfig {
-            skip_preflight: true,
-            ..RpcSendTransactionConfig::default()
-        })?;
-    println!("  Signature: {sig}");
 
     /*
      * Setup mock connection and channel
@@ -287,16 +259,6 @@ fn anchor_test_deliver() -> Result<()> {
     println!("\nSetting up mock connection and channel");
     let receiver = Keypair::new();
 
-    let binding = hashed_denom.clone();
-    let seeds =
-        [port_id.as_bytes(), channel_id_on_b.as_bytes(), binding.as_ref()];
-    let (escrow_account_key, _bump) =
-        Pubkey::find_program_address(&seeds, &crate::ID);
-
-    let (token_mint_key, _bump) =
-        Pubkey::find_program_address(&[hashed_denom.as_ref()], &crate::ID);
-    let (mint_authority_key, _bump) =
-        Pubkey::find_program_address(&[MINT_ESCROW_SEED], &crate::ID);
     let sender_token_address =
         get_associated_token_address(&authority.pubkey(), &token_mint_key);
     let receiver_token_address =
@@ -309,22 +271,13 @@ fn anchor_test_deliver() -> Result<()> {
         ))
         .accounts(accounts::MockDeliver {
             sender: authority.pubkey(),
-            receiver: receiver.pubkey(),
-            receiver_token_account: receiver_token_address,
             storage,
             trie,
             chain,
-            mint_authority: mint_authority_key,
-            escrow_account: escrow_account_key,
-            token_mint: token_mint_key,
             system_program: system_program::ID,
-            associated_token_program: anchor_spl::associated_token::ID,
-            token_program: anchor_spl::token::ID,
         })
         .args(instruction::MockDeliver {
             port_id: port_id.clone(),
-            channel_id_on_b: channel_id_on_b.clone(),
-            hashed_base_denom: hashed_denom.clone(),
             commitment_prefix,
             client_id: client_id.clone(),
             counterparty_client_id: counter_party_client_id,
@@ -336,10 +289,6 @@ fn anchor_test_deliver() -> Result<()> {
             ..RpcSendTransactionConfig::default()
         })?;
     println!("  Signature: {sig}");
-
-    let mint_info = sol_rpc_client.get_token_supply(&token_mint_key).unwrap();
-
-    println!("  This is the mint information {:?}", mint_info);
 
     // Make sure all the accounts needed for transfer are ready ( mint, escrow etc.)
     // Pass the instruction for transfer
@@ -356,7 +305,7 @@ fn anchor_test_deliver() -> Result<()> {
         .accounts(accounts::InitEscrow {
             sender: authority.pubkey(),
             mint_authority: mint_authority_key,
-            escrow_account: escrow_account_key,
+            // escrow_account: escrow_account_key,
             token_mint: token_mint_key,
             system_program: system_program::ID,
             associated_token_program: anchor_spl::associated_token::ID,
@@ -364,7 +313,7 @@ fn anchor_test_deliver() -> Result<()> {
         })
         .args(instruction::InitEscrow {
             port_id: port_id.clone(),
-            channel_id_on_b: channel_id_on_b.clone(),
+            channel_id_on_b: channel_id_on_a.clone(),
             hashed_base_denom: hashed_denom.clone(),
         })
         .payer(authority.clone())
@@ -375,45 +324,81 @@ fn anchor_test_deliver() -> Result<()> {
         })?;
     println!("  Signature: {sig}");
 
+    let mint_info = sol_rpc_client.get_token_supply(&token_mint_key).unwrap();
+
+    println!("  This is the mint information {:?}", mint_info);
+
     /*
-     * On Source chain
+     * Creating Token Mint
      */
 
-    println!("\nRecving on source chain");
-    let packet = construct_packet_from_denom(
+    println!("\nCreating a token mint");
+
+    let create_account_ix = create_account(
+        &authority.pubkey(),
+        &native_token_mint_key,
+        sol_rpc_client.get_minimum_balance_for_rent_exemption(82).unwrap(),
+        82,
+        &anchor_spl::token::ID,
+    );
+
+    let create_mint_ix = initialize_mint2(
+        &anchor_spl::token::ID,
+        &native_token_mint_key,
+        &authority.pubkey(),
+        Some(&authority.pubkey()),
+        6,
+    )
+    .expect("invalid mint instruction");
+
+    let create_token_acc_ix = spl_associated_token_account::instruction::create_associated_token_account(&authority.pubkey(), &authority.pubkey(), &native_token_mint_key, &anchor_spl::token::ID);
+    let associated_token_addr = get_associated_token_address(
+        &authority.pubkey(),
+        &native_token_mint_key,
+    );
+    let mint_ix = spl_token::instruction::mint_to(
+        &anchor_spl::token::ID,
+        &native_token_mint_key,
+        &associated_token_addr,
+        &authority.pubkey(),
+        &[&authority.pubkey()],
+        1000000000,
+    )
+    .unwrap();
+
+    let tx = program
+        .request()
+        .instruction(create_account_ix)
+        .instruction(create_mint_ix)
+        .instruction(create_token_acc_ix)
+        .instruction(mint_ix)
+        .payer(authority.clone())
+        .signer(&*authority)
+        .signer(&mint_keypair)
+        .send_with_spinner_and_config(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        })?;
+
+    println!("  Signature: {}", tx);
+
+    /*
+     * Sending transfer on source chain
+     */
+
+    println!("\nSend Transfer On Source Chain");
+
+    let msg_transfer = construct_transfer_packet_from_denom(
+        &base_denom,
         port_id.clone(),
-        channel_id_on_a.clone(),
-        channel_id_on_a.clone(),
         channel_id_on_b.clone(),
-        1,
-        sender_token_address,
+        channel_id_on_a.clone(),
+        associated_token_addr,
         receiver_token_address,
-        String::from("Tx from Source chain"),
     );
 
-    let proof_height_on_a = mock_client_state.header.height;
-
-    let message = make_message!(
-        ibc::MsgRecvPacket {
-            packet: packet.clone(),
-            proof_commitment_on_a: ibc::CommitmentProofBytes::try_from(
-                packet.data
-            )
-            .unwrap(),
-            proof_height_on_a,
-            signer: ibc::Signer::from(authority.pubkey().to_string())
-        },
-        ibc::PacketMsg::Recv,
-        ibc::MsgEnvelope::Packet,
-    );
-
-    println!("  This is trie {:?}", trie);
-    println!("  This is storage {:?}", storage);
-
-    let escrow_account_balance_before =
-        sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
-    let receiver_account_balance_before = sol_rpc_client
-        .get_token_account_balance(&receiver_token_address)
+    let account_balance_before = sol_rpc_client
+        .get_token_account_balance(&associated_token_addr)
         .unwrap();
 
     let sig = program
@@ -421,7 +406,7 @@ fn anchor_test_deliver() -> Result<()> {
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
             1_000_000u32,
         ))
-        .accounts(accounts::Deliver {
+        .accounts(accounts::SendTransfer {
             sender: authority.pubkey(),
             receiver: Some(receiver.pubkey()),
             storage,
@@ -429,13 +414,18 @@ fn anchor_test_deliver() -> Result<()> {
             chain,
             system_program: system_program::ID,
             mint_authority: Some(mint_authority_key),
-            token_mint: Some(token_mint_key),
+            token_mint: Some(native_token_mint_key),
             escrow_account: Some(escrow_account_key),
-            receiver_token_account: Some(receiver_token_address),
+            receiver_token_account: Some(associated_token_addr),
             associated_token_program: Some(anchor_spl::associated_token::ID),
             token_program: Some(anchor_spl::token::ID),
         })
-        .args(instruction::Deliver { message })
+        .args(instruction::SendTransfer {
+            port_id: port_id.clone(),
+            channel_id: channel_id_on_a.clone(),
+            hashed_base_denom: hashed_denom.clone(),
+            msg: msg_transfer,
+        })
         .payer(authority.clone())
         .signer(&*authority)
         .send_with_spinner_and_config(RpcSendTransactionConfig {
@@ -444,21 +434,13 @@ fn anchor_test_deliver() -> Result<()> {
         })?;
     println!("  Signature: {sig}");
 
-    let escrow_account_balance_after =
-        sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
-    let receiver_account_balance_after = sol_rpc_client
-        .get_token_account_balance(&receiver_token_address)
+    let account_balance_after = sol_rpc_client
+        .get_token_account_balance(&associated_token_addr)
         .unwrap();
+
     assert_eq!(
-        ((escrow_account_balance_before.ui_amount.unwrap() -
-            escrow_account_balance_after.ui_amount.unwrap()) *
-            10_f64.powf(mint_info.decimals.into()))
-        .round() as u64,
-        TRANSFER_AMOUNT
-    );
-    assert_eq!(
-        ((receiver_account_balance_after.ui_amount.unwrap() -
-            receiver_account_balance_before.ui_amount.unwrap()) *
+        ((account_balance_before.ui_amount.unwrap() -
+            account_balance_after.ui_amount.unwrap()) *
             10_f64.powf(mint_info.decimals.into()))
         .round() as u64,
         TRANSFER_AMOUNT
@@ -469,11 +451,12 @@ fn anchor_test_deliver() -> Result<()> {
      */
 
     println!("\nRecving on destination chain");
-    let account_balance_before = sol_rpc_client
-        .get_token_account_balance(&receiver_token_address)
-        .unwrap();
+    let account_balance_before =
+        sol_rpc_client.get_token_account_balance(&receiver_token_address);
+    // .unwrap();
 
     let packet = construct_packet_from_denom(
+        &base_denom,
         port_id.clone(),
         channel_id_on_b.clone(),
         channel_id_on_a.clone(),
@@ -513,7 +496,7 @@ fn anchor_test_deliver() -> Result<()> {
             system_program: system_program::ID,
             mint_authority: Some(mint_authority_key),
             token_mint: Some(token_mint_key),
-            escrow_account: Some(escrow_account_key),
+            escrow_account: None,
             receiver_token_account: Some(receiver_token_address),
             associated_token_program: Some(anchor_spl::associated_token::ID),
             token_program: Some(anchor_spl::token::ID),
@@ -530,9 +513,175 @@ fn anchor_test_deliver() -> Result<()> {
     let account_balance_after = sol_rpc_client
         .get_token_account_balance(&receiver_token_address)
         .unwrap();
+    let previous_balance = match account_balance_before {
+        Ok(balance) => balance.ui_amount.unwrap(),
+        Err(_) => 0f64,
+    };
     assert_eq!(
-        ((account_balance_after.ui_amount.unwrap() -
-            account_balance_before.ui_amount.unwrap()) *
+        ((account_balance_after.ui_amount.unwrap() - previous_balance) *
+            10_f64.powf(mint_info.decimals.into()))
+        .round() as u64,
+        TRANSFER_AMOUNT
+    );
+
+    /*
+     * Sending transfer on destination chain
+     */
+
+    println!("\nSend Transfer On Destination Chain");
+
+    let msg_transfer = construct_transfer_packet_from_denom(
+        &base_denom,
+        port_id.clone(),
+        channel_id_on_a.clone(),
+        channel_id_on_a.clone(),
+        associated_token_addr,
+        receiver_token_address,
+    );
+
+    let account_balance_before = sol_rpc_client
+        .get_token_account_balance(&associated_token_addr)
+        .unwrap();
+
+    let sig = program
+        .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            1_000_000u32,
+        ))
+        .accounts(accounts::SendTransfer {
+            sender: authority.pubkey(),
+            receiver: Some(receiver.pubkey()),
+            storage,
+            trie,
+            chain,
+            system_program: system_program::ID,
+            mint_authority: Some(mint_authority_key),
+            token_mint: Some(native_token_mint_key),
+            escrow_account: Some(escrow_account_key),
+            receiver_token_account: Some(associated_token_addr),
+            associated_token_program: Some(anchor_spl::associated_token::ID),
+            token_program: Some(anchor_spl::token::ID),
+        })
+        .args(instruction::SendTransfer {
+            port_id: port_id.clone(),
+            channel_id: channel_id_on_a.clone(),
+            hashed_base_denom: hashed_denom,
+            msg: msg_transfer,
+        })
+        .payer(authority.clone())
+        .signer(&*authority)
+        .send_with_spinner_and_config(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        })?;
+    println!("  Signature: {sig}");
+
+    let account_balance_after = sol_rpc_client
+        .get_token_account_balance(&associated_token_addr)
+        .unwrap();
+
+    assert_eq!(
+        ((account_balance_before.ui_amount.unwrap() -
+            account_balance_after.ui_amount.unwrap()) *
+            10_f64.powf(mint_info.decimals.into()))
+        .round() as u64,
+        TRANSFER_AMOUNT
+    );
+
+    /*
+     * On Source chain
+     */
+
+    println!("\nRecving on source chain");
+
+    let receiver_native_token_address = get_associated_token_address(
+        &receiver.pubkey(),
+        &native_token_mint_key,
+    );
+
+    let packet = construct_packet_from_denom(
+        &base_denom,
+        port_id.clone(),
+        channel_id_on_b.clone(),
+        channel_id_on_b.clone(),
+        channel_id_on_a.clone(),
+        3,
+        sender_token_address,
+        receiver_native_token_address,
+        String::from("Tx from Source chain"),
+    );
+
+    let proof_height_on_a = mock_client_state.header.height;
+
+    let message = make_message!(
+        ibc::MsgRecvPacket {
+            packet: packet.clone(),
+            proof_commitment_on_a: ibc::CommitmentProofBytes::try_from(
+                packet.data
+            )
+            .unwrap(),
+            proof_height_on_a,
+            signer: ibc::Signer::from(authority.pubkey().to_string())
+        },
+        ibc::PacketMsg::Recv,
+        ibc::MsgEnvelope::Packet,
+    );
+
+    // println!("  This is trie {:?}", trie);
+    // println!("  This is storage {:?}", storage);
+
+    let escrow_account_balance_before =
+        sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
+    let receiver_account_balance_before = sol_rpc_client
+        .get_token_account_balance(&receiver_native_token_address);
+
+    let sig = program
+        .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            1_000_000u32,
+        ))
+        .accounts(accounts::Deliver {
+            sender: authority.pubkey(),
+            receiver: Some(receiver.pubkey()),
+            storage,
+            trie,
+            chain,
+            system_program: system_program::ID,
+            mint_authority: Some(mint_authority_key),
+            token_mint: Some(native_token_mint_key),
+            escrow_account: Some(escrow_account_key),
+            receiver_token_account: Some(receiver_native_token_address),
+            associated_token_program: Some(anchor_spl::associated_token::ID),
+            token_program: Some(anchor_spl::token::ID),
+        })
+        .args(instruction::Deliver { message })
+        .payer(authority.clone())
+        .signer(&*authority)
+        .send_with_spinner_and_config(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        })?;
+    println!("  Signature: {sig}");
+
+    let escrow_account_balance_after =
+        sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
+    let receiver_account_balance_after = sol_rpc_client
+        .get_token_account_balance(&receiver_native_token_address)
+        .unwrap();
+    assert_eq!(
+        ((escrow_account_balance_before.ui_amount.unwrap() -
+            escrow_account_balance_after.ui_amount.unwrap()) *
+            10_f64.powf(mint_info.decimals.into()))
+        .round() as u64,
+        TRANSFER_AMOUNT
+    );
+    let previous_receiver_balance = match receiver_account_balance_before {
+        Ok(balance) => balance.ui_amount.unwrap(),
+        Err(_) => 0f64,
+    };
+    assert_eq!(
+        ((receiver_account_balance_after.ui_amount.unwrap() -
+            previous_receiver_balance) *
             10_f64.powf(mint_info.decimals.into()))
         .round() as u64,
         TRANSFER_AMOUNT
@@ -544,6 +693,7 @@ fn anchor_test_deliver() -> Result<()> {
 
     println!("\nSend packet");
     let packet = construct_packet_from_denom(
+        &base_denom,
         port_id.clone(),
         channel_id_on_a.clone(),
         channel_id_on_a.clone(),
@@ -578,151 +728,11 @@ fn anchor_test_deliver() -> Result<()> {
         })?;
     println!("  Signature: {sig}");
 
-    /*
-     * Creating Token Mint
-     */
-
-    println!("\nCreating a token mint");
-    let mint_keypair = Keypair::new();
-
-    let create_account_ix = create_account(
-        &authority.pubkey(),
-        &mint_keypair.pubkey(),
-        sol_rpc_client.get_minimum_balance_for_rent_exemption(82).unwrap(),
-        82,
-        &anchor_spl::token::ID,
-    );
-
-    let create_mint_ix = initialize_mint2(
-        &anchor_spl::token::ID,
-        &mint_keypair.pubkey(),
-        &authority.pubkey(),
-        Some(&authority.pubkey()),
-        6,
-    )
-    .expect("invalid mint instruction");
-
-    let create_token_acc_ix = spl_associated_token_account::instruction::create_associated_token_account(&authority.pubkey(), &authority.pubkey(), &mint_keypair.pubkey(), &anchor_spl::token::ID);
-    let associated_token_addr = get_associated_token_address(
-        &authority.pubkey(),
-        &mint_keypair.pubkey(),
-    );
-    let mint_ix = spl_token::instruction::mint_to(
-        &anchor_spl::token::ID,
-        &mint_keypair.pubkey(),
-        &associated_token_addr,
-        &authority.pubkey(),
-        &[&authority.pubkey()],
-        1000000000,
-    )
-    .unwrap();
-
-    let tx = program
-        .request()
-        .instruction(create_account_ix)
-        .instruction(create_mint_ix)
-        .instruction(create_token_acc_ix)
-        .instruction(mint_ix)
-        .payer(authority.clone())
-        .signer(&*authority)
-        .signer(&mint_keypair)
-        .send_with_spinner_and_config(RpcSendTransactionConfig {
-            skip_preflight: true,
-            ..RpcSendTransactionConfig::default()
-        })?;
-
-    println!("  Signature: {}", tx);
-
-    /*
-     * Creating Token Mint
-     */
-
-    println!("\nSend Transfer On Source Chain");
-
-    let send_denom = mint_keypair.pubkey().to_string();
-
-    let denom = format!("{port_id}/{channel_id_on_b}/{send_denom}");
-    let hashed_denom = CryptoHash::digest(send_denom.as_bytes());
-    let denom =
-        ibc::apps::transfer::types::PrefixedDenom::from_str(&denom).unwrap();
-    let token = ibc::apps::transfer::types::Coin {
-        denom,
-        amount: TRANSFER_AMOUNT.into(),
-    };
-
-    let packet_data = ibc::apps::transfer::types::packet::PacketData {
-        token: token.into(),
-        sender: ibc::Signer::from(associated_token_addr.to_string()), // Should be a token account
-        receiver: ibc::Signer::from(receiver_token_address.to_string()), // Should be a token account
-        memo: String::from("Sending a transfer").into(),
-    };
-
-    let msg_transfer = MsgTransfer {
-        port_id_on_a: port_id.clone(),
-        chan_id_on_a: channel_id_on_a.clone(),
-        packet_data,
-        timeout_height_on_b: ibc::TimeoutHeight::Never,
-        timeout_timestamp_on_b: ibc::Timestamp::none(),
-    };
-
-    let seeds =
-        [port_id.as_bytes(), channel_id_on_a.as_bytes(), hashed_denom.as_ref()];
-    let (escrow_account_key, _bump) =
-        Pubkey::find_program_address(&seeds, &crate::ID);
-
-    let account_balance_before = sol_rpc_client
-        .get_token_account_balance(&associated_token_addr)
-        .unwrap();
-
-    let sig = program
-        .request()
-        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            1_000_000u32,
-        ))
-        .accounts(accounts::SendTransfer {
-            sender: authority.pubkey(),
-            receiver: Some(receiver.pubkey()),
-            storage,
-            trie,
-            chain,
-            system_program: system_program::ID,
-            mint_authority: Some(mint_authority_key),
-            token_mint: Some(mint_keypair.pubkey()),
-            escrow_account: Some(escrow_account_key),
-            receiver_token_account: Some(associated_token_addr),
-            associated_token_program: Some(anchor_spl::associated_token::ID),
-            token_program: Some(anchor_spl::token::ID),
-        })
-        .args(instruction::SendTransfer {
-            port_id: port_id.clone(),
-            channel_id: channel_id_on_a.clone(),
-            hashed_base_denom: hashed_denom,
-            msg: msg_transfer,
-        })
-        .payer(authority.clone())
-        .signer(&*authority)
-        .send_with_spinner_and_config(RpcSendTransactionConfig {
-            skip_preflight: true,
-            ..RpcSendTransactionConfig::default()
-        })?;
-    println!("  Signature: {sig}");
-
-    let account_balance_after = sol_rpc_client
-        .get_token_account_balance(&associated_token_addr)
-        .unwrap();
-
-    assert_eq!(
-        ((account_balance_before.ui_amount.unwrap() -
-            account_balance_after.ui_amount.unwrap()) *
-            10_f64.powf(mint_info.decimals.into()))
-        .round() as u64,
-        TRANSFER_AMOUNT
-    );
-
     Ok(())
 }
 
 fn construct_packet_from_denom(
+    base_denom: &str,
     port_id: ibc::PortId,
     // Channel id used to define if its source chain or destination chain (in
     // denom).
@@ -734,7 +744,7 @@ fn construct_packet_from_denom(
     receiver_token_address: Pubkey,
     memo: String,
 ) -> ibc::Packet {
-    let denom = format!("{port_id}/{denom_channel_id}/{BASE_DENOM}");
+    let denom = format!("{port_id}/{denom_channel_id}/{base_denom}");
     let denom =
         ibc::apps::transfer::types::PrefixedDenom::from_str(&denom).unwrap();
     let token = ibc::apps::transfer::types::Coin {
@@ -763,4 +773,38 @@ fn construct_packet_from_denom(
     };
 
     packet
+}
+
+fn construct_transfer_packet_from_denom(
+    base_denom: &str,
+    port_id: ibc::PortId,
+    // Channel id used to define if its source chain or destination chain (in
+    // denom).
+    denom_channel_id: ibc::ChannelId,
+    channel_id_on_a: ibc::ChannelId,
+    sender_address: Pubkey,
+    receiver_address: Pubkey,
+) -> MsgTransfer {
+    let denom = format!("{port_id}/{denom_channel_id}/{base_denom}");
+    let denom =
+        ibc::apps::transfer::types::PrefixedDenom::from_str(&denom).unwrap();
+    let token = ibc::apps::transfer::types::Coin {
+        denom,
+        amount: TRANSFER_AMOUNT.into(),
+    };
+
+    let packet_data = ibc::apps::transfer::types::packet::PacketData {
+        token: token.into(),
+        sender: ibc::Signer::from(sender_address.to_string()), // Should be a token account
+        receiver: ibc::Signer::from(receiver_address.to_string()), // Should be a token account
+        memo: String::from("Sending a transfer").into(),
+    };
+
+    MsgTransfer {
+        port_id_on_a: port_id.clone(),
+        chan_id_on_a: channel_id_on_a.clone(),
+        packet_data,
+        timeout_height_on_b: ibc::TimeoutHeight::Never,
+        timeout_timestamp_on_b: ibc::Timestamp::none(),
+    }
 }


### PR DESCRIPTION
We were having a `init` methods where we were creating escrow accounts, but those escrow accounts were being created for wrapped tokens which were wrong. Since only native tokens are escrowed, they should be created for native token mint which will happen in the `send_transfer` method. Made the tests end to end where we escrow, mint, burn and then unescrow the same tokens.

### Changes:
Removed `mock_init_escrow` method and removed `escrow_account` from the init methods as well.
Renamed `init_escrow` to `init_mint`, since it would be called for initializing the wrapped token mint.
Shuffled the tests cases so that they are in proper order.

### Doubt
I observed that ibc uses `channel_id_on_b` for deriving escrow accounts when receiving packet and `channel_id_on_a` when sending a packet. So this would mean that whenever we receive a packet on source chain, the `channel_id_on_a` should be of destination ( i think this would be handled by the relayer ). 