### PR TITLE
blockchain: introduce helper impl_proto and any_convert macros

### DIFF
--- a/common/blockchain/build.rs
+++ b/common/blockchain/build.rs
@@ -1,11 +1,5 @@
-use std::io::Result;
-
-fn main() -> Result<()> {
-    let mut config = prost_build::Config::new();
-    if std::env::var_os("CARGO_FEATURE_std").is_none() {
-        config.btree_map(["."]);
-    }
-    config
+fn main() -> std::io::Result<()> {
+    prost_build::Config::new()
         .enable_type_names()
         .type_name_domain(["."], "composable.finance")
         .include_file("messages.rs")

--- a/common/blockchain/src/ibc_state.rs
+++ b/common/blockchain/src/ibc_state.rs
@@ -1,3 +1,5 @@
+use ibc_proto::google::protobuf::Any;
+
 mod consensus;
 pub mod proof;
 
@@ -21,3 +23,85 @@ pub fn digest_with_client_id(
 ) -> lib::hash::CryptoHash {
     lib::hash::CryptoHash::digestv(&[client_id.as_bytes(), b"\0", value])
 }
+
+
+/// Defines conversion implementation between `$Type` and Any message as well as
+/// `encode_to_vec` and `decode` methods.
+macro_rules! any_convert {
+    (
+        $Proto:ty,
+        $Type:ident $( <$T:ident: $bond:path = $concrete:path> )?,
+        obj: $obj:expr,
+        $(bad: $bad:expr,)*
+    ) => {
+        impl $(<$T: $bond>)* $Type $(<$T>)* {
+            /// Encodes the object into a vector as protocol buffer message.
+            pub fn encode_to_vec(&self) -> alloc::vec::Vec<u8> {
+                prost::Message::encode_to_vec(&$crate::proto::$Type::from(self))
+            }
+
+            /// Decodes the object from a protocol buffer message.
+            pub fn decode(
+                buf: &[u8],
+            ) -> Result<Self, $crate::proto::DecodeError> {
+                <$crate::proto::$Type as prost::Message>::decode(buf)?
+                    .try_into()
+                    .map_err(Into::into)
+            }
+        }
+
+        impl $(<$T: $bond>)* From<$Type $(<$T>)*> for $crate::ibc_state::Any {
+            fn from(obj: $Type $(<$T>)*) -> $crate::ibc_state::Any {
+                $crate::proto::$Type::from(obj).into()
+            }
+        }
+
+        impl $(<$T: $bond>)* From<&$Type $(<$T>)*> for $crate::ibc_state::Any {
+            fn from(obj: &$Type $(<$T>)*) -> $crate::ibc_state::Any {
+                $crate::proto::$Type::from(obj).into()
+            }
+        }
+
+        impl $(<$T: $bond>)* TryFrom<$crate::ibc_state::Any> for $Type $(<$T>)* {
+            type Error = $crate::proto::DecodeError;
+            fn try_from(
+                any: $crate::ibc_state::Any,
+            ) -> Result<Self, Self::Error> {
+                $crate::proto::$Type::try_from(any)
+                    .and_then(|msg| Ok(msg.try_into()?))
+            }
+        }
+
+        impl $(<$T: $bond>)* TryFrom<&$crate::ibc_state::Any> for $Type $(<$T>)*
+        {
+            type Error = $crate::proto::DecodeError;
+            fn try_from(
+                any: &$crate::ibc_state::Any,
+            ) -> Result<Self, Self::Error> {
+                $crate::proto::$Type::try_from(any)
+                    .and_then(|msg| Ok(msg.try_into()?))
+            }
+        }
+
+        impl $(<$T: $bond>)* ibc_primitives::proto::Protobuf<$Proto>
+            for $Type $(<$T>)* { }
+
+        #[test]
+        fn test_any_conversion() {
+            type Type = $Type $( ::<$concrete> )*;
+
+            // Check conversion to and from proto
+            let msg = proto::$Type::test();
+            let obj: Type = $obj;
+            assert_eq!(msg, proto::$Type::from(&obj));
+            assert_eq!(Ok(obj), $Type::try_from(&msg));
+
+            // Check failure on invalid proto
+            $(
+                assert_eq!(Err(proto::BadMessage), Type::try_from($bad));
+            )*
+        }
+    };
+}
+
+use any_convert;

--- a/common/blockchain/src/ibc_state/consensus.rs
+++ b/common/blockchain/src/ibc_state/consensus.rs
@@ -1,6 +1,5 @@
 use core::num::NonZeroU64;
 
-use ibc_primitives::proto::Any;
 use lib::hash::CryptoHash;
 use prost::Message as _;
 
@@ -20,11 +19,6 @@ impl ConsensusState {
     pub fn new(block_hash: &CryptoHash, timestamp_ns: NonZeroU64) -> Self {
         let block_hash = block_hash.as_array().to_vec().into();
         Self { block_hash, timestamp_ns }
-    }
-
-    /// Decodes the state from a protocol buffer message.
-    pub fn decode(buf: &[u8]) -> Result<Self, proto::DecodeError> {
-        Ok(Self::try_from(proto::ConsensusState::decode(buf)?)?)
     }
 }
 
@@ -67,71 +61,32 @@ impl From<&ConsensusState> for proto::ConsensusState {
 impl TryFrom<proto::ConsensusState> for ConsensusState {
     type Error = proto::BadMessage;
     fn try_from(msg: proto::ConsensusState) -> Result<Self, Self::Error> {
-        if msg.block_hash.as_slice().len() != CryptoHash::LENGTH {
-            return Err(proto::BadMessage);
-        }
+        <&CryptoHash>::try_from(msg.block_hash.as_slice())
+            .map_err(|_| proto::BadMessage)?;
         let timestamp_ns =
             NonZeroU64::new(msg.timestamp_ns).ok_or(proto::BadMessage)?;
-        let block_hash = msg.block_hash.into();
-        Ok(ConsensusState { block_hash, timestamp_ns })
+        Ok(ConsensusState { block_hash: msg.block_hash.into(), timestamp_ns })
     }
 }
 
 impl TryFrom<&proto::ConsensusState> for ConsensusState {
     type Error = proto::BadMessage;
     fn try_from(msg: &proto::ConsensusState) -> Result<Self, Self::Error> {
-        if msg.block_hash.as_slice().len() != CryptoHash::LENGTH {
-            return Err(proto::BadMessage);
-        }
+        let block_hash = <&CryptoHash>::try_from(msg.block_hash.as_slice())
+            .map_err(|_| proto::BadMessage)?
+            .to_vec();
         let timestamp_ns =
             NonZeroU64::new(msg.timestamp_ns).ok_or(proto::BadMessage)?;
-        let block_hash = msg.block_hash.clone().into();
-        Ok(ConsensusState { block_hash, timestamp_ns })
+        Ok(ConsensusState { block_hash: block_hash.into(), timestamp_ns })
     }
 }
 
-impl From<ConsensusState> for Any {
-    fn from(state: ConsensusState) -> Any {
-        proto::ConsensusState::from(state).into()
-    }
-}
-
-impl From<&ConsensusState> for Any {
-    fn from(state: &ConsensusState) -> Any {
-        proto::ConsensusState::from(state).into()
-    }
-}
-
-impl TryFrom<Any> for ConsensusState {
-    type Error = proto::DecodeError;
-    fn try_from(any: Any) -> Result<Self, Self::Error> {
-        proto::ConsensusState::try_from(any).and_then(|msg| Ok(msg.try_into()?))
-    }
-}
-
-impl TryFrom<&Any> for ConsensusState {
-    type Error = proto::DecodeError;
-    fn try_from(any: &Any) -> Result<Self, Self::Error> {
-        proto::ConsensusState::try_from(any).and_then(|msg| Ok(msg.try_into()?))
-    }
-}
-
-impl ibc_primitives::proto::Protobuf<crate::proto::ConsensusState>
-    for ConsensusState
-{
-}
-
-
-#[test]
-fn test_consensus_state() {
-    // Check conversion to and from proto
-    let proto = proto::ConsensusState::test();
-    let state = ConsensusState::new(&CryptoHash::test(42), NonZeroU64::MIN);
-    assert_eq!(proto, proto::ConsensusState::from(&state));
-    assert_eq!(Ok(state), ConsensusState::try_from(&proto));
-
-    // Check failure on invalid proto
-    let bad_state =
-        proto::ConsensusState { block_hash: [0; 32].to_vec(), timestamp_ns: 0 };
-    assert_eq!(Err(proto::BadMessage), ConsensusState::try_from(bad_state));
+super::any_convert! {
+    proto::ConsensusState,
+    ConsensusState,
+    obj: ConsensusState::new(&CryptoHash::test(42), NonZeroU64::MIN),
+    bad: proto::ConsensusState {
+        block_hash: [0; 32].to_vec(),
+        timestamp_ns: 0,
+    },
 }

--- a/common/lib/src/hash.rs
+++ b/common/lib/src/hash.rs
@@ -181,7 +181,7 @@ impl<'a> TryFrom<&'a [u8]> for CryptoHash {
 
     #[inline]
     fn try_from(hash: &'a [u8]) -> Result<Self, Self::Error> {
-        <&CryptoHash>::try_from(hash).map(Clone::clone)
+        <&CryptoHash>::try_from(hash).cloned()
     }
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/consensus_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/consensus_state.rs
@@ -46,7 +46,7 @@ impl AnyConsensusState {
     /// Protobuf type URL for Tendermint client state used in Any message.
     const TENDERMINT_TYPE: &'static str =
         crate::ibc::tm::TENDERMINT_CONSENSUS_STATE_TYPE_URL;
-    /// Protobuf type URL for Guest client state used in Any message.
+    /// Protobuf type URL for Guest consensus state used in Any message.
     const GUEST_TYPE: &'static str =
         blockchain::proto::ConsensusState::TYPE_URL;
     #[cfg(any(test, feature = "mocks"))]


### PR DESCRIPTION
Add proto::impl_proto macro which implements conversion from a raw
protocol buffer type to Any type and ibc_state::any_convert macro
which implements conversion between Rust message type and Any type.
For now, use them with ConsensusState.  In the future they will also
be used for ClientState.
