### PR TITLE
restaking: depositing before guest chain is initialized and fix vulnerabilites

### DIFF
--- a/solana/restaking/README.md
+++ b/solana/restaking/README.md
@@ -26,8 +26,9 @@ The high level flow of the program is given in the image below.
 ## Instructions
 
 When the contract is deployed, the `initialize` method is called where
-the bounding period, whitelisted tokens, admin key and the rewards
-token mint is set. Any update to the staking paramters can only be
+the whitelisted tokens, admin key and the rewards
+token mint is set. Initially the `guest_chain_initialization` is set to
+false. Any update to the staking paramters can only be
 done by the admin key. A token account is also created for the
 rewards token mint which would distribute the rewards. Since the
 authority is PDA, any debit from the account will happen only through
@@ -50,6 +51,11 @@ can start staking.
   stake. They would have to have to own the non fungible receipt
   token to be eligible for claiming rewards.
 
+- `Update Guest chain Initialization`: The admin would call this method
+  when the bridge is up and running. This would make `is_guest_chain_initialized`
+  as true which would allow to make CPI calls during deposit and set stake to 
+  validator. 
+
 - `Update token Whitelist`: The admin can update the token whitelist.
   Only callable by admin set during `initialize` method.
 
@@ -64,4 +70,10 @@ can start staking.
 
 - Oracle interface is yet to be added to fetch the current price of 
   staked tokens as well as the governance token in the `Guest Blockchain`.
+
+- Users who have deposited before the `guest chain` is initialized can choose
+  the validator in one of three ways(Yet to be implemented):
+  - Choose a validator randomly
+  - Choose a validator from the list of top 10 validators chosen by us
+  - Choose a particular validator.
   

--- a/solana/restaking/README.md
+++ b/solana/restaking/README.md
@@ -51,10 +51,16 @@ can start staking.
   stake. They would have to have to own the non fungible receipt
   token to be eligible for claiming rewards.
 
+- `Set Service`: Once the bridge is live, users who had deposited before
+  can call this method to delegate their stake to the validator. Users
+  cannot withdraw or claim any rewards until they delegate their stake
+  to the validator. But this method wont be needed after the bridge is
+  live and would panic if called otherwise.
+
 - `Update Guest chain Initialization`: The admin would call this method
-  when the bridge is up and running. This would make `is_guest_chain_initialized`
-  as true which would allow to make CPI calls during deposit and set stake to 
-  validator. 
+  when the bridge is up and running. This would set `guest_chain_program_id`
+  with the specified program ID which would allow to make CPI calls during 
+  deposit and set stake to validator. 
 
 - `Update token Whitelist`: The admin can update the token whitelist.
   Only callable by admin set during `initialize` method.

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -8,8 +8,8 @@ use solana_ibc::program::SolanaIbc;
 use solana_ibc::CHAIN_SEED;
 
 pub mod constants;
-mod validation;
 mod token;
+mod validation;
 
 use constants::{
     REWARDS_SEED, STAKING_PARAMS_SEED, TEST_SEED, VAULT_PARAMS_SEED, VAULT_SEED,
@@ -77,8 +77,7 @@ pub mod restaking {
         }
 
         let current_time = Clock::get()?.unix_timestamp;
-        let guest_chain_program_id =
-            staking_params.guest_chain_program_id;
+        let guest_chain_program_id = staking_params.guest_chain_program_id;
 
         vault_params.service = service;
         vault_params.stake_timestamp_sec = current_time;
@@ -101,7 +100,10 @@ pub mod restaking {
 
         // Call Guest chain program to update the stake if the chain is initialized
         if guest_chain_program_id.is_some() {
-            validation::validate_remaining_accounts(ctx.remaining_accounts, &guest_chain_program_id.unwrap())?;
+            validation::validate_remaining_accounts(
+                ctx.remaining_accounts,
+                &guest_chain_program_id.unwrap(),
+            )?;
             let cpi_accounts = Chain {
                 sender: ctx.accounts.depositor.to_account_info(),
                 storage: ctx.remaining_accounts[0].clone(),
@@ -242,7 +244,7 @@ pub mod restaking {
     /// when the chain is initialized.
     pub fn update_guest_chain_initialization(
         ctx: Context<UpdateStakingParams>,
-        guest_chain_program_id: Pubkey, 
+        guest_chain_program_id: Pubkey,
     ) -> Result<()> {
         let staking_params = &mut ctx.accounts.staking_params;
         if staking_params.guest_chain_program_id.is_some() {
@@ -625,5 +627,5 @@ pub enum ErrorCodes {
     #[msg("Guest chain can only be initialized once")]
     GuestChainAlreadyInitialized,
     #[msg("Account validation for CPI call to the guest chain")]
-    AccountValidationFailedForCPI
+    AccountValidationFailedForCPI,
 }

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -493,7 +493,7 @@ pub struct Withdraw<'info> {
 
     #[account(mut, close = withdrawer, seeds = [VAULT_PARAMS_SEED, receipt_token_mint.key().as_ref()], bump)]
     pub vault_params: Box<Account<'info, Vault>>,
-    #[account(mut, seeds = [STAKING_PARAMS_SEED, TEST_SEED], bump)]
+    #[account(mut, seeds = [STAKING_PARAMS_SEED, TEST_SEED], bump, has_one = rewards_token_mint)]
     pub staking_params: Box<Account<'info, StakingParams>>,
 
     #[account(mut, seeds = [CHAIN_SEED], bump, seeds::program = guest_chain_program.key())]

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -87,16 +87,10 @@ pub mod restaking {
 
         // Transfer tokens to escrow
 
-        let bump = ctx.bumps.staking_params;
-        let seeds =
-            [STAKING_PARAMS_SEED, TEST_SEED, core::slice::from_ref(&bump)];
-        let seeds = seeds.as_ref();
-        let seeds = core::slice::from_ref(&seeds);
-
-        token::transfer(ctx.accounts.into(), seeds, amount)?;
+        token::transfer(ctx.accounts.into(), &[], amount)?;
 
         // Mint receipt tokens
-        token::mint_nft(ctx.accounts.into(), seeds)?;
+        token::mint_nft(ctx.accounts.into())?;
 
         // Call Guest chain program to update the stake if the chain is initialized
         if guest_chain_program_id.is_some() {
@@ -104,6 +98,11 @@ pub mod restaking {
                 ctx.remaining_accounts,
                 &guest_chain_program_id.unwrap(),
             )?;
+            let bump = ctx.bumps.staking_params;
+            let seeds =
+                [STAKING_PARAMS_SEED, TEST_SEED, core::slice::from_ref(&bump)];
+            let seeds = seeds.as_ref();
+            let seeds = core::slice::from_ref(&seeds);
             let cpi_accounts = Chain {
                 sender: ctx.accounts.depositor.to_account_info(),
                 storage: ctx.remaining_accounts[0].clone(),
@@ -186,7 +185,7 @@ pub mod restaking {
 
         // Burn receipt token
         burn_nft(
-            CpiContext::new_with_signer(
+            CpiContext::new(
                 ctx.accounts.metadata_program.to_account_info(),
                 BurnNft {
                     metadata: ctx.accounts.nft_metadata.to_account_info(),
@@ -199,12 +198,9 @@ pub mod restaking {
                         .master_edition_account
                         .to_account_info(),
                 },
-                seeds,
             ),
             None,
         )?;
-
-
 
         // Call Guest chain to update the stake
 

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -40,7 +40,7 @@ pub mod restaking {
     /// made to update the stake.
     ///
     /// We are sending the accounts needed for making CPI call to guest blockchain as [`remaining_accounts`]
-    /// since we were running out of stack memory. Note that these accounts dont need to be sent until the 
+    /// since we were running out of stack memory. Note that these accounts dont need to be sent until the
     /// guest chain is initialized since CPI calls wont be made during that period.
     /// Since remaining accounts are not named, they have to be
     /// sent in the same order as given below
@@ -69,7 +69,8 @@ pub mod restaking {
             .ok_or(error!(ErrorCodes::TokenNotWhitelisted))?;
 
         let current_time = Clock::get()?.unix_timestamp;
-        let is_guest_chain_initialized = staking_params.is_guest_chain_initialized;
+        let is_guest_chain_initialized =
+            staking_params.is_guest_chain_initialized;
 
         vault_params.service = service;
         vault_params.stake_timestamp_sec = current_time;
@@ -123,9 +124,12 @@ pub mod restaking {
         }
 
         let chain = &ctx.accounts.guest_chain;
-        let service = vault_params.service.as_ref().ok_or(error!(ErrorCodes::MissingService))?;
+        let service = vault_params
+            .service
+            .as_ref()
+            .ok_or(error!(ErrorCodes::MissingService))?;
         let validator_key = match service {
-            Service::GuestChain { validator } => validator
+            Service::GuestChain { validator } => validator,
         };
 
         /*
@@ -192,9 +196,9 @@ pub mod restaking {
     }
 
     /// Whitelists new tokens
-    /// 
+    ///
     /// This method checks if any of the new token mints which are to be whitelisted
-    /// are already whitelisted. If they are the method fails to update the 
+    /// are already whitelisted. If they are the method fails to update the
     /// whitelisted token list.
     pub fn update_token_whitelist(
         ctx: Context<UpdateAdminParams>,
@@ -218,7 +222,7 @@ pub mod restaking {
     }
 
     /// Sets guest chain initialization status to true.
-    /// 
+    ///
     /// After this method is called, CPI calls would be made to guest chain during deposit and stake would be
     /// set to the validators. Users can also claim rewards or withdraw their stake
     /// when the chain is initialized.
@@ -246,9 +250,12 @@ pub mod restaking {
         let vault_params = &mut ctx.accounts.vault_params;
         let chain = &ctx.accounts.guest_chain;
 
-        let service = vault_params.service.as_ref().ok_or(error!(ErrorCodes::MissingService))?;
+        let service = vault_params
+            .service
+            .as_ref()
+            .ok_or(error!(ErrorCodes::MissingService))?;
         let validator_key = match service {
-            Service::GuestChain { validator } => validator
+            Service::GuestChain { validator } => validator,
         };
         let stake_amount = vault_params.stake_amount;
         let last_received_rewards_height =
@@ -554,14 +561,19 @@ pub enum ErrorCodes {
     TokenAlreadyWhitelisted,
     #[msg("Can only stake whitelisted tokens")]
     TokenNotWhitelisted,
-    #[msg("This operation is not allowed until the guest chain is initialized")]
-    OperationNotAllowed, 
+    #[msg(
+        "This operation is not allowed until the guest chain is initialized"
+    )]
+    OperationNotAllowed,
     #[msg("Subtraction overflow")]
     SubtractionOverflow,
     #[msg("Invalid Token Mint")]
     InvalidTokenMint,
     #[msg("Insufficient receipt token balance, expected balance 1")]
     InsufficientReceiptTokenBalance,
-    #[msg("Service is missing. Make sure you have assigned your stake to a service")]
+    #[msg(
+        "Service is missing. Make sure you have assigned your stake to a \
+         service"
+    )]
     MissingService,
 }

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -354,11 +354,11 @@ pub struct Initialize<'info> {
     #[account(mut)]
     pub admin: Signer<'info>,
 
-    #[account(init_if_needed, payer = admin, seeds = [STAKING_PARAMS_SEED, TEST_SEED], bump, space = 1024)]
+    #[account(init, payer = admin, seeds = [STAKING_PARAMS_SEED, TEST_SEED], bump, space = 1024)]
     pub staking_params: Account<'info, StakingParams>,
 
     pub rewards_token_mint: Account<'info, Mint>,
-    #[account(init_if_needed, payer = admin, seeds = [REWARDS_SEED, TEST_SEED], bump, token::mint = rewards_token_mint, token::authority = staking_params)]
+    #[account(init, payer = admin, seeds = [REWARDS_SEED, TEST_SEED], bump, token::mint = rewards_token_mint, token::authority = staking_params)]
     pub rewards_token_account: Account<'info, TokenAccount>,
 
     token_program: Program<'info, Token>,

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -37,11 +37,11 @@ pub mod restaking {
         Ok(())
     }
 
-    /// Stakes the amount in the vault and if bounding time has elapsed, a CPI call to the service is being 
+    /// Stakes the amount in the vault and if bounding time has elapsed, a CPI call to the service is being
     /// made to update the stake.
-    /// 
+    ///
     /// We are sending the accounts needed for making CPI call to guest blockchain as [`remaining_accounts`]
-    /// since we were running out of stack memory. Note that these accounts dont need to be sent during 
+    /// since we were running out of stack memory. Note that these accounts dont need to be sent during
     /// bounding period since CPI calls wont be made during that period.
     /// Since remaining accounts are not named, they have to be
     /// sent in the same order as given below
@@ -131,7 +131,9 @@ pub mod restaking {
 
         let chain = &ctx.accounts.guest_chain;
         let validator_key = match vault_params.service {
-            Service::GuestChain { validator } => validator.ok_or(error!(ErrorCodes::MissingValidator))?,
+            Service::GuestChain { validator } => {
+                validator.ok_or(error!(ErrorCodes::MissingValidator))?
+            }
         };
 
         /*
@@ -211,17 +213,22 @@ pub mod restaking {
             return Err(error!(ErrorCodes::TokenAlreadyWhitelisted));
         }
 
-        staking_params.whitelisted_tokens.append(&mut new_token_mints.as_slice().to_vec());
+        staking_params
+            .whitelisted_tokens
+            .append(&mut new_token_mints.as_slice().to_vec());
 
         Ok(())
     }
 
-    pub fn update_bounding_period(ctx: Context<UpdateBoundingPeriod>, new_bounding_period: i64) -> Result<()> {
+    pub fn update_bounding_period(
+        ctx: Context<UpdateBoundingPeriod>,
+        new_bounding_period: i64,
+    ) -> Result<()> {
         let staking_params = &mut ctx.accounts.staking_params;
 
-        staking_params.bounding_timestamp_sec = new_bounding_period; 
+        staking_params.bounding_timestamp_sec = new_bounding_period;
 
-        Ok(()) 
+        Ok(())
     }
 
     pub fn claim_rewards(ctx: Context<Claim>) -> Result<()> {
@@ -234,7 +241,9 @@ pub mod restaking {
         let chain = &ctx.accounts.guest_chain;
 
         let validator = match vault_params.service {
-            Service::GuestChain { validator } => validator.ok_or(error!(ErrorCodes::MissingValidator))?,
+            Service::GuestChain { validator } => {
+                validator.ok_or(error!(ErrorCodes::MissingValidator))?
+            }
         };
         let stake_amount = vault_params.stake_amount;
         let last_received_rewards_height =

--- a/solana/restaking/programs/restaking/src/token.rs
+++ b/solana/restaking/programs/restaking/src/token.rs
@@ -10,9 +10,9 @@ use crate::constants::{TOKEN_NAME, TOKEN_SYMBOL, TOKEN_URI};
 use crate::{Claim, Deposit, Withdraw, WithdrawRewardFunds};
 
 /// Performs token transfer based on the given accounts and amount
-/// 
+///
 /// If the tokens are transferred from an account which is a signer,
-/// we dont need signed invocation. On the other hand, if 
+/// we dont need signed invocation. On the other hand, if
 /// the tokens are transferred from a PDA, then we need signed
 /// invocation
 pub fn transfer(
@@ -41,21 +41,16 @@ pub fn transfer(
 }
 
 /// Mints NFT using the metaplex standard
-/// 
+///
 /// Since the NFT is minted by the depositor who is a signer,
 /// we dont need signed invocation.
-pub fn mint_nft(
-    accounts: MintNftAccounts<'_>,
-) -> Result<()> {
+pub fn mint_nft(accounts: MintNftAccounts<'_>) -> Result<()> {
     mint_to(
-        CpiContext::new(
-            accounts.token_program.clone(),
-            MintTo {
-                authority: accounts.mint_authority.clone(),
-                to: accounts.to,
-                mint: accounts.token_mint.clone(),
-            },
-        ),
+        CpiContext::new(accounts.token_program.clone(), MintTo {
+            authority: accounts.mint_authority.clone(),
+            to: accounts.to,
+            mint: accounts.token_mint.clone(),
+        }),
         1, // 1 token
     )?;
 
@@ -89,20 +84,17 @@ pub fn mint_nft(
     msg!("Run create master edition v3");
 
     create_master_edition_v3(
-        CpiContext::new(
-            accounts.metadata_program,
-            CreateMasterEditionV3 {
-                edition: accounts.edition,
-                mint: accounts.token_mint,
-                update_authority: accounts.update_authority,
-                mint_authority: accounts.mint_authority,
-                payer: accounts.payer,
-                metadata: accounts.metadata,
-                token_program: accounts.token_program,
-                system_program: accounts.system_program,
-                rent: accounts.rent,
-            },
-        ),
+        CpiContext::new(accounts.metadata_program, CreateMasterEditionV3 {
+            edition: accounts.edition,
+            mint: accounts.token_mint,
+            update_authority: accounts.update_authority,
+            mint_authority: accounts.mint_authority,
+            payer: accounts.payer,
+            metadata: accounts.metadata,
+            token_program: accounts.token_program,
+            system_program: accounts.system_program,
+            rent: accounts.rent,
+        }),
         Some(1),
     )?;
     Ok(())

--- a/solana/restaking/programs/restaking/src/token.rs
+++ b/solana/restaking/programs/restaking/src/token.rs
@@ -9,6 +9,12 @@ use anchor_spl::token::{mint_to, MintTo, Transfer};
 use crate::constants::{TOKEN_NAME, TOKEN_SYMBOL, TOKEN_URI};
 use crate::{Claim, Deposit, Withdraw, WithdrawRewardFunds};
 
+/// Performs token transfer based on the given accounts and amount
+/// 
+/// If the tokens are transferred from an account which is a signer,
+/// we dont need signed invocation. On the other hand, if 
+/// the tokens are transferred from a PDA, then we need signed
+/// invocation
 pub fn transfer(
     accounts: TransferAccounts<'_>,
     seeds: &[&[&[u8]]],
@@ -20,35 +26,41 @@ pub fn transfer(
         authority: accounts.authority,
     };
 
-    let cpi_ctx = CpiContext::new_with_signer(
-        accounts.token_program,
-        transfer_instruction,
-        seeds, //signer PDA
-    );
+    let cpi_ctx = if seeds.is_empty() {
+        CpiContext::new(accounts.token_program, transfer_instruction)
+    } else {
+        CpiContext::new_with_signer(
+            accounts.token_program,
+            transfer_instruction,
+            seeds, //signer PDA
+        )
+    };
 
     anchor_spl::token::transfer(cpi_ctx, amount)?;
     Ok(())
 }
 
+/// Mints NFT using the metaplex standard
+/// 
+/// Since the NFT is minted by the depositor who is a signer,
+/// we dont need signed invocation.
 pub fn mint_nft(
     accounts: MintNftAccounts<'_>,
-    seeds: &[&[&[u8]]],
 ) -> Result<()> {
     mint_to(
-        CpiContext::new_with_signer(
+        CpiContext::new(
             accounts.token_program.clone(),
             MintTo {
                 authority: accounts.mint_authority.clone(),
                 to: accounts.to,
                 mint: accounts.token_mint.clone(),
             },
-            seeds,
         ),
         1, // 1 token
     )?;
 
     create_metadata_accounts_v3(
-        CpiContext::new_with_signer(
+        CpiContext::new(
             accounts.metadata_program.clone(),
             CreateMetadataAccountsV3 {
                 payer: accounts.payer.clone(),
@@ -59,7 +71,6 @@ pub fn mint_nft(
                 system_program: accounts.system_program.clone(),
                 rent: accounts.rent.clone(),
             },
-            seeds,
         ),
         DataV2 {
             name: TOKEN_NAME.to_string(),
@@ -78,7 +89,7 @@ pub fn mint_nft(
     msg!("Run create master edition v3");
 
     create_master_edition_v3(
-        CpiContext::new_with_signer(
+        CpiContext::new(
             accounts.metadata_program,
             CreateMasterEditionV3 {
                 edition: accounts.edition,
@@ -91,7 +102,6 @@ pub fn mint_nft(
                 system_program: accounts.system_program,
                 rent: accounts.rent,
             },
-            seeds,
         ),
         Some(1),
     )?;
@@ -162,7 +172,6 @@ impl<'a> From<&mut WithdrawRewardFunds<'a>> for TransferAccounts<'a> {
         }
     }
 }
-
 
 impl<'a> From<&mut Deposit<'a>> for MintNftAccounts<'a> {
     fn from(accounts: &mut Deposit<'a>) -> Self {

--- a/solana/restaking/programs/restaking/src/validation.rs
+++ b/solana/restaking/programs/restaking/src/validation.rs
@@ -1,0 +1,53 @@
+use anchor_lang::prelude::*;
+use anchor_spl::associated_token::get_associated_token_address_with_program_id;
+use solana_ibc::{CHAIN_SEED, SOLANA_IBC_STORAGE_SEED, TRIE_SEED};
+use crate::ErrorCodes;
+
+/// Validates accounts needed for CPI call to the guest chain.
+/// 
+/// Right now, this method would only validate accounts for calling `set_stake`
+/// method in the guest chain. Later when we expand to other services, we could
+/// extend this method below to do the validation for those accounts as well.
+/// 
+/// Accounts needed for calling `set_stake`
+/// - storage: PDA with seeds ["private"]
+/// - chain: PDA with seeds ["chain"]. Should be writable
+/// - trie: PDA with seeds ["trie"]
+/// - guest chain program ID: Should match the expected guest chain program ID
+/// 
+/// Note: The accounts should be sent in above order.
+pub fn validate_remaining_accounts<'a>(accounts: &[AccountInfo<'a>], expected_guest_chain_program_id: &Pubkey) -> Result<()> {
+
+  // Storage Account
+  let seeds = [SOLANA_IBC_STORAGE_SEED];
+  let seeds = seeds.as_ref();
+
+  let (storage_account, _bump) = Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+  if &storage_account != accounts[0].key {
+    return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
+  }
+
+  // Chain account
+  let seeds = [CHAIN_SEED];
+  let seeds = seeds.as_ref();
+
+  let (storage_account, _bump) = Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+  if &storage_account != accounts[1].key && accounts[1].is_writable {
+    return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
+  }
+  // Trie account
+  let seeds = [TRIE_SEED];
+  let seeds = seeds.as_ref();
+
+  let (storage_account, _bump) = Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+  if &storage_account != accounts[2].key && accounts[2].is_writable {
+    return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
+  } 
+
+  // Guest chain program ID
+  if expected_guest_chain_program_id != accounts[3].key {
+    return Err(error!(ErrorCodes::AccountValidationFailedForCPI)); 
+  }
+
+  Ok(())
+}

--- a/solana/restaking/programs/restaking/src/validation.rs
+++ b/solana/restaking/programs/restaking/src/validation.rs
@@ -1,5 +1,5 @@
 use anchor_lang::prelude::*;
-use solana_ibc::{CHAIN_SEED, SOLANA_IBC_STORAGE_SEED, TRIE_SEED};
+use solana_ibc::{CHAIN_SEED, TRIE_SEED};
 
 use crate::ErrorCodes;
 
@@ -10,7 +10,6 @@ use crate::ErrorCodes;
 /// extend this method below to do the validation for those accounts as well.
 ///
 /// Accounts needed for calling `set_stake`
-/// - storage: PDA with seeds ["private"]
 /// - chain: PDA with seeds ["chain"]. Should be writable
 /// - trie: PDA with seeds ["trie"]
 /// - guest chain program ID: Should match the expected guest chain program ID
@@ -20,23 +19,13 @@ pub fn validate_remaining_accounts(
     accounts: &[AccountInfo<'_>],
     expected_guest_chain_program_id: &Pubkey,
 ) -> Result<()> {
-    // Storage Account
-    let seeds = [SOLANA_IBC_STORAGE_SEED];
-    let seeds = seeds.as_ref();
-
-    let (storage_account, _bump) =
-        Pubkey::find_program_address(seeds, expected_guest_chain_program_id);
-    if &storage_account != accounts[0].key {
-        return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
-    }
-
     // Chain account
     let seeds = [CHAIN_SEED];
     let seeds = seeds.as_ref();
 
     let (storage_account, _bump) =
         Pubkey::find_program_address(seeds, expected_guest_chain_program_id);
-    if &storage_account != accounts[1].key && accounts[1].is_writable {
+    if &storage_account != accounts[0].key && accounts[0].is_writable {
         return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
     }
     // Trie account
@@ -45,12 +34,12 @@ pub fn validate_remaining_accounts(
 
     let (storage_account, _bump) =
         Pubkey::find_program_address(seeds, expected_guest_chain_program_id);
-    if &storage_account != accounts[2].key && accounts[2].is_writable {
+    if &storage_account != accounts[1].key && accounts[1].is_writable {
         return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
     }
 
     // Guest chain program ID
-    if expected_guest_chain_program_id != accounts[3].key {
+    if expected_guest_chain_program_id != accounts[2].key {
         return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
     }
 

--- a/solana/restaking/programs/restaking/src/validation.rs
+++ b/solana/restaking/programs/restaking/src/validation.rs
@@ -1,5 +1,4 @@
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::get_associated_token_address_with_program_id;
 use solana_ibc::{CHAIN_SEED, SOLANA_IBC_STORAGE_SEED, TRIE_SEED};
 
 use crate::ErrorCodes;
@@ -17,8 +16,8 @@ use crate::ErrorCodes;
 /// - guest chain program ID: Should match the expected guest chain program ID
 ///
 /// Note: The accounts should be sent in above order.
-pub fn validate_remaining_accounts<'a>(
-    accounts: &[AccountInfo<'a>],
+pub fn validate_remaining_accounts(
+    accounts: &[AccountInfo<'_>],
     expected_guest_chain_program_id: &Pubkey,
 ) -> Result<()> {
     // Storage Account
@@ -26,7 +25,7 @@ pub fn validate_remaining_accounts<'a>(
     let seeds = seeds.as_ref();
 
     let (storage_account, _bump) =
-        Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+        Pubkey::find_program_address(seeds, expected_guest_chain_program_id);
     if &storage_account != accounts[0].key {
         return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
     }
@@ -36,7 +35,7 @@ pub fn validate_remaining_accounts<'a>(
     let seeds = seeds.as_ref();
 
     let (storage_account, _bump) =
-        Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+        Pubkey::find_program_address(seeds, expected_guest_chain_program_id);
     if &storage_account != accounts[1].key && accounts[1].is_writable {
         return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
     }
@@ -45,7 +44,7 @@ pub fn validate_remaining_accounts<'a>(
     let seeds = seeds.as_ref();
 
     let (storage_account, _bump) =
-        Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+        Pubkey::find_program_address(seeds, expected_guest_chain_program_id);
     if &storage_account != accounts[2].key && accounts[2].is_writable {
         return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
     }

--- a/solana/restaking/programs/restaking/src/validation.rs
+++ b/solana/restaking/programs/restaking/src/validation.rs
@@ -1,53 +1,59 @@
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::get_associated_token_address_with_program_id;
 use solana_ibc::{CHAIN_SEED, SOLANA_IBC_STORAGE_SEED, TRIE_SEED};
+
 use crate::ErrorCodes;
 
 /// Validates accounts needed for CPI call to the guest chain.
-/// 
+///
 /// Right now, this method would only validate accounts for calling `set_stake`
 /// method in the guest chain. Later when we expand to other services, we could
 /// extend this method below to do the validation for those accounts as well.
-/// 
+///
 /// Accounts needed for calling `set_stake`
 /// - storage: PDA with seeds ["private"]
 /// - chain: PDA with seeds ["chain"]. Should be writable
 /// - trie: PDA with seeds ["trie"]
 /// - guest chain program ID: Should match the expected guest chain program ID
-/// 
+///
 /// Note: The accounts should be sent in above order.
-pub fn validate_remaining_accounts<'a>(accounts: &[AccountInfo<'a>], expected_guest_chain_program_id: &Pubkey) -> Result<()> {
+pub fn validate_remaining_accounts<'a>(
+    accounts: &[AccountInfo<'a>],
+    expected_guest_chain_program_id: &Pubkey,
+) -> Result<()> {
+    // Storage Account
+    let seeds = [SOLANA_IBC_STORAGE_SEED];
+    let seeds = seeds.as_ref();
 
-  // Storage Account
-  let seeds = [SOLANA_IBC_STORAGE_SEED];
-  let seeds = seeds.as_ref();
+    let (storage_account, _bump) =
+        Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+    if &storage_account != accounts[0].key {
+        return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
+    }
 
-  let (storage_account, _bump) = Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
-  if &storage_account != accounts[0].key {
-    return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
-  }
+    // Chain account
+    let seeds = [CHAIN_SEED];
+    let seeds = seeds.as_ref();
 
-  // Chain account
-  let seeds = [CHAIN_SEED];
-  let seeds = seeds.as_ref();
+    let (storage_account, _bump) =
+        Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+    if &storage_account != accounts[1].key && accounts[1].is_writable {
+        return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
+    }
+    // Trie account
+    let seeds = [TRIE_SEED];
+    let seeds = seeds.as_ref();
 
-  let (storage_account, _bump) = Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
-  if &storage_account != accounts[1].key && accounts[1].is_writable {
-    return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
-  }
-  // Trie account
-  let seeds = [TRIE_SEED];
-  let seeds = seeds.as_ref();
+    let (storage_account, _bump) =
+        Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
+    if &storage_account != accounts[2].key && accounts[2].is_writable {
+        return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
+    }
 
-  let (storage_account, _bump) = Pubkey::find_program_address(seeds, &expected_guest_chain_program_id);
-  if &storage_account != accounts[2].key && accounts[2].is_writable {
-    return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
-  } 
+    // Guest chain program ID
+    if expected_guest_chain_program_id != accounts[3].key {
+        return Err(error!(ErrorCodes::AccountValidationFailedForCPI));
+    }
 
-  // Guest chain program ID
-  if expected_guest_chain_program_id != accounts[3].key {
-    return Err(error!(ErrorCodes::AccountValidationFailedForCPI)); 
-  }
-
-  Ok(())
+    Ok(())
 }

--- a/solana/restaking/tests/helper.ts
+++ b/solana/restaking/tests/helper.ts
@@ -24,10 +24,10 @@ export const getRewardsTokenAccountPDA = () => {
   return { rewardsTokenAccountPDA, rewardsTokenAccountBump };
 };
 
-export const getVaultParamsPDA = (user_key: anchor.web3.PublicKey) => {
+export const getVaultParamsPDA = (receipt_mint: anchor.web3.PublicKey) => {
   const [vaultParamsPDA, vaultParamsBump] =
     anchor.web3.PublicKey.findProgramAddressSync(
-      [Buffer.from("vault_params"), user_key.toBuffer()],
+      [Buffer.from("vault_params"), receipt_mint.toBuffer()],
       restakingProgramID
     );
   return { vaultParamsPDA, vaultParamsBump };

--- a/solana/restaking/tests/restaking.ts
+++ b/solana/restaking/tests/restaking.ts
@@ -81,7 +81,7 @@ describe("restaking", () => {
         admin,
         admin.publicKey,
         null,
-        6
+        9,
       );
 
       rewardsTokenMint = await spl.createMint(
@@ -264,7 +264,6 @@ describe("restaking", () => {
           ),
         })
         .remainingAccounts([
-          { pubkey: ibcStoragePDA, isSigner: false, isWritable: true },
           { pubkey: guestChainPDA, isSigner: false, isWritable: true },
           { pubkey: triePDA, isSigner: false, isWritable: true },
           { pubkey: guestChainProgramId, isSigner: false, isWritable: true },
@@ -330,11 +329,11 @@ describe("restaking", () => {
           stakingParams: stakingParamsPDA,
           receiptTokenMint: tokenMint,
           receiptTokenAccount,
+          stakeMint: wSolMint,
           instruction: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
           systemProgram: anchor.web3.SystemProgram.programId,
         })
         .remainingAccounts([
-          { pubkey: ibcStoragePDA, isSigner: false, isWritable: true },
           { pubkey: guestChainPDA, isSigner: false, isWritable: true },
           { pubkey: triePDA, isSigner: false, isWritable: true },
           { pubkey: guestChainProgramId, isSigner: false, isWritable: true },

--- a/solana/restaking/tests/restaking.ts
+++ b/solana/restaking/tests/restaking.ts
@@ -194,11 +194,9 @@ describe("restaking", () => {
     const boundingTimestamp = Date.now() / 1000 + boundingPeriod;
     const { stakingParamsPDA } = getStakingParamsPDA();
     const { rewardsTokenAccountPDA } = getRewardsTokenAccountPDA();
-    // console.log("Staking params: ", stakingParamsPDA);
-    // console.log("Rewards token account: ", rewardsTokenAccountPDA);
     try {
       const tx = await program.methods
-        .initialize(whitelistedTokens, new anchor.BN(boundingTimestamp))
+        .initialize(whitelistedTokens)
         .accounts({
           admin: admin.publicKey,
           stakingParams: stakingParamsPDA,
@@ -215,6 +213,24 @@ describe("restaking", () => {
       // throw error;
     }
   });
+
+  it("Update guest chain initialization to true", async () => {
+    const { stakingParamsPDA } = getStakingParamsPDA();
+    try {
+      const tx = await program.methods
+        .updateGuestChainInitialization()
+        .accounts({
+          admin: admin.publicKey,
+          stakingParams: stakingParamsPDA,
+        })
+        .signers([admin])
+        .rpc();
+      console.log("  Signature for Updating Guest chain Initialization: ", tx);
+    } catch (error) {
+      console.log(error);
+      throw error;
+    }
+  })
 
   it("Deposit tokens", async () => {
     const { vaultParamsPDA } = getVaultParamsPDA(tokenMint);

--- a/solana/restaking/tests/restaking.ts
+++ b/solana/restaking/tests/restaking.ts
@@ -33,8 +33,8 @@ describe("restaking", () => {
   let depositorWSolTokenAccount: any; // depositor wSol token account
 
   let initialMintAmount = 100000000;
+  let stakingCap = 30000;
   const depositAmount = 4000;
-  const boundingPeriod = 5;
 
   const guestChainProgramId = new anchor.web3.PublicKey(
     "9fd7GDygnAmHhXDVWgzsfR6kSRvwkxVnsY8SaSpSH4SX"
@@ -191,12 +191,11 @@ describe("restaking", () => {
 
   it("Is Initialized", async () => {
     const whitelistedTokens = [wSolMint];
-    const boundingTimestamp = Date.now() / 1000 + boundingPeriod;
     const { stakingParamsPDA } = getStakingParamsPDA();
     const { rewardsTokenAccountPDA } = getRewardsTokenAccountPDA();
     try {
       const tx = await program.methods
-        .initialize(whitelistedTokens)
+        .initialize(whitelistedTokens, new anchor.BN(stakingCap))
         .accounts({
           admin: admin.publicKey,
           stakingParams: stakingParamsPDA,

--- a/solana/restaking/tests/restaking.ts
+++ b/solana/restaking/tests/restaking.ts
@@ -213,11 +213,11 @@ describe("restaking", () => {
     }
   });
 
-  it("Update guest chain initialization to true", async () => {
+  it("Update guest chain initialization with its program ID", async () => {
     const { stakingParamsPDA } = getStakingParamsPDA();
     try {
       const tx = await program.methods
-        .updateGuestChainInitialization()
+        .updateGuestChainInitialization(guestChainProgramId)
         .accounts({
           admin: admin.publicKey,
           stakingParams: stakingParamsPDA,

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -121,7 +121,7 @@ pub mod solana_ibc {
     ///
     /// Can only be called through CPI from our staking program whose
     /// id is stored in chain account.
-    pub fn set_stake(ctx: Context<Chain>, amount: u128) -> Result<()> {
+    pub fn set_stake(ctx: Context<SetStake>, amount: u128) -> Result<()> {
         let chain = &mut ctx.accounts.chain;
         let ixns = ctx.accounts.instruction.to_account_info();
         let current_index =
@@ -345,6 +345,34 @@ pub struct Chain<'info> {
     /// function.
     #[account(mut, seeds = [TRIE_SEED], bump)]
     trie: UncheckedAccount<'info>,
+
+    system_program: Program<'info, System>,
+
+    /// CHECK: Used for getting the caller program id to verify if the right
+    /// program is calling the method.
+    instruction: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SetStake<'info> {
+    #[account(mut)]
+    sender: Signer<'info>,
+
+    /// The guest blockchain data.
+    #[account(mut, seeds = [CHAIN_SEED], bump)]
+    chain: Account<'info, chain::ChainData>,
+
+    /// The account holding the trie which corresponds to guest blockchain’s
+    /// state root.
+    ///
+    /// CHECK: Account’s owner is checked by [`storage::get_provable_from`]
+    /// function.
+    #[account(mut, seeds = [TRIE_SEED], bump)]
+    trie: UncheckedAccount<'info>,
+
+    /// We would support only SOL as stake which has decimal of 9
+    #[account(mut, mint::decimals = 9)]
+    stake_mint: Account<'info, Mint>,
 
     system_program: Program<'info, System>,
 


### PR DESCRIPTION
Before the guest chain is initialized ( Bridge is launched ), users can stake their assets without choosing the validator since the validators don't exist yet. The staked tokens get locked in the vault and then when the bridge is launched, the users can set the stake on validator through the following options
- Choose a validator randomly
- Choose a validator from the list of top 10 validators chosen by us
- Choose a particular validator.

Also added `update_guest_chain_initialization` which would make the `is_guest_chain_initialized` as `true`.

The update methods are made seperate to isolate them such that one update doesn't fuck up the others.

Also fixed vulnerabilities from the audit.
1. The `Initialize` instruction can be called multiple times due to the use of `init_if_needed`, enabling anyone to alter staking parameters. So using `Init` instead.
2. The optional `service` parameter in the `deposit` instruction may result in fund lockup as it’s currently checked to be not `None` during `withdrawal`. Users can call `set_service` and set the validator if not set before. 
3. Validation checks for the `remaining_accounts` are missing in both the `deposit` instruction and the `solana_ibc::cpi::set_stake function`. The `guest_chain_program_id` is set when the chain is initialized. The `PDA` seeds along with program ID are verified.
4. In the `Deposit` instruction, the `solana_ibc::cpi::set_stake` function lacks parameters related to the mint of the staked amount. So the `stake_mint` account is sent which expects mint to be of `9` decimals.
5. Some `token::transfer` function calls doesn’t need seeds and signed invocation (for example, in deposit instruction). Introducing empty seeds and then checking `seeds.len() == 0` to switch to unsigned invocation when signed invocation is not necessary. Similarly, the burn_nft function call in the Withdraw instruction doesn’t have to be signed.
6. In the `Withdraw instruction`, ncluding `has_one = rewards_token_mint` for the `staking_params` account, aligning with the approach taken in the `Claim` instruction.