### PR TITLE
solana-ibc: signature verification for update client using ed25519 program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,7 @@ dependencies = [
  "serde",
  "tendermint",
  "tendermint-light-client-verifier",
- "tendermint-proto",
+ "tendermint-proto 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2458,7 +2458,7 @@ dependencies = [
  "prost",
  "serde",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5381,7 +5381,7 @@ dependencies = [
  "signature 2.2.0",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.34.0 (git+https://github.com/dhruvja/tendermint-rs?branch=skip-sig-verification)",
  "time",
  "zeroize",
 ]
@@ -5396,6 +5396,24 @@ dependencies = [
  "flex-error",
  "serde",
  "tendermint",
+ "time",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cc728a4f9e891d71adf66af6ecaece146f9c7a11312288a3107b3e1d6979aaf"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive 0.3.3",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,7 @@ dependencies = [
  "serde",
  "tendermint",
  "tendermint-light-client-verifier",
- "tendermint-proto 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendermint-proto",
 ]
 
 [[package]]
@@ -2458,7 +2458,7 @@ dependencies = [
  "prost",
  "serde",
  "subtle-encoding",
- "tendermint-proto 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendermint-proto",
 ]
 
 [[package]]
@@ -5381,7 +5381,7 @@ dependencies = [
  "signature 2.2.0",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.34.0 (git+https://github.com/dhruvja/tendermint-rs?branch=skip-sig-verification)",
+ "tendermint-proto",
  "time",
  "zeroize",
 ]
@@ -5396,24 +5396,6 @@ dependencies = [
  "flex-error",
  "serde",
  "tendermint",
- "time",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc728a4f9e891d71adf66af6ecaece146f9c7a11312288a3107b3e1d6979aaf"
-dependencies = [
- "bytes",
- "flex-error",
- "num-derive 0.3.3",
- "num-traits",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "subtle-encoding",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,21 @@ dependencies = [
 
 [[package]]
 name = "ed25519-consensus"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758e2a0cd8a6cdf483e1d369e7d081647e00b88d8953e34d8f2cbba05ae28368"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.9.9",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-consensus"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
@@ -2889,7 +2904,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba8ee05284d79b367ae8966d558e1a305a781fc80c9df51f37775169117ba64f"
 dependencies = [
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "num-derive 0.3.3",
  "num-traits",
  "solana-program",
@@ -4361,6 +4376,7 @@ dependencies = [
  "blockchain",
  "bytemuck",
  "derive_more",
+ "ed25519-consensus 1.2.1",
  "hex-literal",
  "ibc",
  "ibc-testkit",
@@ -5345,12 +5361,12 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.34.0"
-source = "git+https://github.com/informalsystems/tendermint-rs?rev=37822e540e272d2ca9e763769ad20c581203ff9a#37822e540e272d2ca9e763769ad20c581203ff9a"
+source = "git+https://github.com/dhruvja/tendermint-rs?branch=skip-sig-verification#ff66d6fa8402aaa113b4f1fa639e112720cfee2d"
 dependencies = [
  "bytes",
  "digest 0.10.7",
  "ed25519 2.2.3",
- "ed25519-consensus",
+ "ed25519-consensus 2.1.0",
  "flex-error",
  "futures",
  "num-traits",
@@ -5386,7 +5402,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.34.0"
-source = "git+https://github.com/informalsystems/tendermint-rs?rev=37822e540e272d2ca9e763769ad20c581203ff9a#37822e540e272d2ca9e763769ad20c581203ff9a"
+source = "git+https://github.com/dhruvja/tendermint-rs?branch=skip-sig-verification#ff66d6fa8402aaa113b4f1fa639e112720cfee2d"
 dependencies = [
  "bytes",
  "flex-error",
@@ -5406,7 +5422,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19d4f02b7e38ce790da973fdc9edc71a0e35340ac57737bf278c8379037c1f5"
 dependencies = [
- "ed25519-consensus",
+ "ed25519-consensus 2.1.0",
  "gumdrop",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ prost = { version = "0.12.3", default-features = false }
 prost-build = { version = "0.12.3", default-features = false }
 bytemuck = { version = "1.14", default-features = false }
 derive_more = "0.99.17"
+ed25519-consensus = "1"
 hex-literal = "0.4.1"
 ibc = { version = "0.49.1", default-features = false, features = ["borsh", "serde"] }
 ibc-core-channel-types = { version = "0.49.1", default-features = false }
@@ -90,9 +91,7 @@ anyhow = "1.0.32"
 aes-gcm-siv = { git = "https://github.com/RustCrypto/AEADs", rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef" }
 curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "8274d5cbb6fc3f38cdc742b4798173895cd2a290" }
 
-# eyre has a mutable global variable which is something Solana
-# programs cannot have.  tendermint 0.34 enables eyre unconditionally;
-# version which doesn’t do that hasn’t been released yet so we need to
-# refer to a commit on master.
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
-tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
+# Skips signature verification since solana programs dont have
+# compute budget to verify ed25519 signatures.
+tendermint = { git = "https://github.com/dhruvja/tendermint-rs", branch = "skip-sig-verification" }
+tendermint-proto = { git = "https://github.com/dhruvja/tendermint-rs", branch = "skip-sig-verification" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,4 @@ curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dal
 # Skips signature verification since solana programs dont have
 # compute budget to verify ed25519 signatures.
 tendermint = { git = "https://github.com/dhruvja/tendermint-rs", branch = "skip-sig-verification" }
+tendermint-proto = { git = "https://github.com/dhruvja/tendermint-rs", branch = "skip-sig-verification" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,3 @@ curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dal
 # Skips signature verification since solana programs dont have
 # compute budget to verify ed25519 signatures.
 tendermint = { git = "https://github.com/dhruvja/tendermint-rs", branch = "skip-sig-verification" }
-tendermint-proto = { git = "https://github.com/dhruvja/tendermint-rs", branch = "skip-sig-verification" }

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -12,7 +12,7 @@ name = "solana_ibc"
 default = ["custom-heap"]
 cpi = ["no-entrypoint"]
 custom-heap = []
-mocks = ["ibc-testkit"]
+mocks = ["ibc-testkit", "ed25519-consensus"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
@@ -23,6 +23,7 @@ anchor-spl.workspace = true
 base64.workspace = true
 bytemuck = { workspace = true, features = ["must_cast"] }
 derive_more.workspace = true
+ed25519-consensus = { workspace = true, optional = true }
 ibc-testkit = { workspace = true, optional = true }
 ibc.workspace = true
 linear-map.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -12,7 +12,7 @@ name = "solana_ibc"
 default = ["custom-heap"]
 cpi = ["no-entrypoint"]
 custom-heap = []
-mocks = ["ibc-testkit", "ed25519-consensus"]
+mocks = ["ibc-testkit"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
@@ -23,7 +23,7 @@ anchor-spl.workspace = true
 base64.workspace = true
 bytemuck = { workspace = true, features = ["must_cast"] }
 derive_more.workspace = true
-ed25519-consensus = { workspace = true, optional = true }
+ed25519-consensus.workspace = true
 ibc-testkit = { workspace = true, optional = true }
 ibc.workspace = true
 linear-map.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/ed25519.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ed25519.rs
@@ -86,8 +86,8 @@ impl Verifier {
     /// Returns error if `ix_sysver` is not `AccountInfo` for the Instruction
     /// sysvar, there was no instruction prior to the current on or the previous
     /// instruction was not a call to the Ed25519 native program.
-    pub fn new(ix_sysvar: &AccountInfo<'_>) -> anchor_lang::Result<Self> {
-        let ix = sysvar::instructions::get_instruction_relative(-1, ix_sysvar)?;
+    pub fn new(ix_sysvar: &AccountInfo<'_>, relative_index: i64) -> anchor_lang::Result<Self> {
+        let ix = sysvar::instructions::get_instruction_relative(relative_index, ix_sysvar)?;
         if ed25519_program::check_id(&ix.program_id) {
             Ok(Self(ix.data))
         } else {
@@ -159,22 +159,22 @@ fn verify_impl(
 /// <https://github.com/solana-labs/solana/blob/master/sdk/src/ed25519_instruction.rs>.
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-struct SignatureOffsets {
+pub struct SignatureOffsets {
     /// Offset to ed25519 signature of 64 bytes.
-    signature_offset: u16,
+    pub signature_offset: u16,
     /// Instruction index to find signature.  We support `u16::MAX` only.
-    signature_instruction_index: u16,
+    pub signature_instruction_index: u16,
     /// Offset to public key of 32 bytes.
-    public_key_offset: u16,
+    pub public_key_offset: u16,
     /// Instruction index to find public key.  We support `u16::MAX` only.
-    public_key_instruction_index: u16,
+    pub public_key_instruction_index: u16,
     /// Offset to start of message data
-    message_data_offset: u16,
-    /// Size of message data.
-    message_data_size: u16,
+    pub message_data_offset: u16,
+    /// Size of message data.   
+    pub message_data_size: u16,
     /// Index of instruction data to get message data.  We support `u16::MAX`
     /// only.
-    message_instruction_index: u16,
+    pub message_instruction_index: u16,
 }
 
 impl SignatureOffsets {

--- a/solana/solana-ibc/programs/solana-ibc/src/ed25519.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ed25519.rs
@@ -86,8 +86,14 @@ impl Verifier {
     /// Returns error if `ix_sysver` is not `AccountInfo` for the Instruction
     /// sysvar, there was no instruction prior to the current on or the previous
     /// instruction was not a call to the Ed25519 native program.
-    pub fn new(ix_sysvar: &AccountInfo<'_>, relative_index: i64) -> anchor_lang::Result<Self> {
-        let ix = sysvar::instructions::get_instruction_relative(relative_index, ix_sysvar)?;
+    pub fn new(
+        ix_sysvar: &AccountInfo<'_>,
+        relative_index: i64,
+    ) -> anchor_lang::Result<Self> {
+        let ix = sysvar::instructions::get_instruction_relative(
+            relative_index,
+            ix_sysvar,
+        )?;
         if ed25519_program::check_id(&ix.program_id) {
             Ok(Self(ix.data))
         } else {

--- a/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
@@ -19,7 +19,6 @@ pub use ibc::core::client::context::client_state::{
 };
 pub use ibc::core::client::context::consensus_state::ConsensusState;
 pub use ibc::core::client::context::types::error::ClientError;
-#[cfg(test)]
 pub use ibc::core::client::context::types::msgs::{ClientMsg, MsgCreateClient};
 pub use ibc::core::client::context::{
     ClientExecutionContext, ClientValidationContext,

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -10,8 +10,8 @@ use anchor_lang::solana_program;
 use anchor_lang::solana_program::sysvar::instructions as tx_instructions;
 use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
-use borsh::BorshDeserialize;
 use blockchain::Verifier;
+use borsh::BorshDeserialize;
 use lib::hash::CryptoHash;
 use storage::TransferAccounts;
 use trie_ids::PortChannelPK;
@@ -169,13 +169,13 @@ pub mod solana_ibc {
     }
 
     /// Method to verify ed25519 signatures and send update client message.
-    /// 
+    ///
     /// Since we cannot use ed25519 signature verification due to compute budget limit,
-    /// we have to call ed25519 program and pass the message, pubkey and signatures in 
+    /// we have to call ed25519 program and pass the message, pubkey and signatures in
     /// the same transaction in which the below method would be called. We then verify
-    /// the signatures comparing to the data in the previous instructions. If they 
+    /// the signatures comparing to the data in the previous instructions. If they
     /// signature verification is success, we send the `UpdateClient` msg. This method
-    /// can only be called to send `UpdateClient` message. Calling otherwise would 
+    /// can only be called to send `UpdateClient` message. Calling otherwise would
     /// panic.
     pub fn send_update_client(
         ctx: Context<SendUpdateClient>,
@@ -197,8 +197,12 @@ pub mod solana_ibc {
             msg!("This is the result {}", result);
             if !result {
                 return Err(error::Error::ContextError(
-                    ibc::ClientError::HeaderVerificationFailure { reason: "Signature Verification Failed".to_string() }.into(),
-                ).into());
+                    ibc::ClientError::HeaderVerificationFailure {
+                        reason: "Signature Verification Failed".to_string(),
+                    }
+                    .into(),
+                )
+                .into());
             }
             index += 1;
         }
@@ -206,7 +210,9 @@ pub mod solana_ibc {
             match update_client_msg.clone() {
                 ibc::MsgEnvelope::Client(msg) => match msg {
                     ibc::ClientMsg::UpdateClient(_) => (),
-                    _ => panic!("Invalid instruction, expected MsgUpdateClient"),
+                    _ => {
+                        panic!("Invalid instruction, expected MsgUpdateClient")
+                    }
                 },
                 _ => panic!("Invalid instruction, expected MsgUpdateClient"),
             }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -183,11 +183,11 @@ pub mod solana_ibc {
         signatures_data: Vec<SignatureData>,
     ) -> Result<()> {
         let length = signatures_data.len() as i64;
-        let mut index = 0;
-        for signature_data in signatures_data {
+        // let mut index = 0;
+        for (index, signature_data) in signatures_data.into_iter().enumerate() {
             let verifier = ed25519::Verifier::new(
                 &ctx.accounts.ix_sysvar,
-                index - length,
+                index as i64 - length,
             )?;
             let result = verifier.verify(
                 &signature_data.message,
@@ -204,7 +204,7 @@ pub mod solana_ibc {
                 )
                 .into());
             }
-            index += 1;
+            // index += 1;
         }
         if cfg!(not(feature = "mocks")) {
             match update_client_msg.clone() {

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -161,6 +161,16 @@ pub mod solana_ibc {
         ctx: Context<'a, 'a, 'a, 'info, Deliver<'info>>,
         message: ibc::MsgEnvelope,
     ) -> Result<()> {
+        match message.clone() {
+            ibc::MsgEnvelope::Client(msg) => match msg {
+                ibc::ClientMsg::UpdateClient(_) => panic!(
+                    "Invalid message, Update Client message cannot be passed \
+                     here. Call send_update_client instead."
+                ),
+                _ => (),
+            },
+            _ => (),
+        }
         let mut store = storage::from_ctx!(ctx, with accounts);
         let mut router = store.clone();
         ::ibc::core::entrypoint::dispatch(&mut store, &mut router, message)

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -161,15 +161,14 @@ pub mod solana_ibc {
         ctx: Context<'a, 'a, 'a, 'info, Deliver<'info>>,
         message: ibc::MsgEnvelope,
     ) -> Result<()> {
-        match message.clone() {
-            ibc::MsgEnvelope::Client(msg) => match msg {
-                ibc::ClientMsg::UpdateClient(_) => panic!(
-                    "Invalid message, Update Client message cannot be passed \
-                     here. Call send_update_client instead."
-                ),
-                _ => (),
-            },
-            _ => (),
+        if matches!(
+            message,
+            ibc::MsgEnvelope::Client(ibc::ClientMsg::UpdateClient(_))
+        ) {
+            panic!(
+                "Invalid message, Update Client message cannot be passed \
+                 here. Call send_update_client instead."
+            );
         }
         let mut store = storage::from_ctx!(ctx, with accounts);
         let mut router = store.clone();
@@ -193,7 +192,6 @@ pub mod solana_ibc {
         signatures_data: Vec<SignatureData>,
     ) -> Result<()> {
         let length = signatures_data.len() as i64;
-        // let mut index = 0;
         for (index, signature_data) in signatures_data.into_iter().enumerate() {
             let verifier = ed25519::Verifier::new(
                 &ctx.accounts.ix_sysvar,
@@ -214,17 +212,13 @@ pub mod solana_ibc {
                 )
                 .into());
             }
-            // index += 1;
         }
         if cfg!(not(feature = "mocks")) {
-            match update_client_msg.clone() {
-                ibc::MsgEnvelope::Client(msg) => match msg {
-                    ibc::ClientMsg::UpdateClient(_) => (),
-                    _ => {
-                        panic!("Invalid instruction, expected MsgUpdateClient")
-                    }
-                },
-                _ => panic!("Invalid instruction, expected MsgUpdateClient"),
+            if !matches!(
+                update_client_msg,
+                ibc::MsgEnvelope::Client(ibc::ClientMsg::UpdateClient(_))
+            ) {
+                panic!("Invalid message, Expect MsgUpdateClient");
             }
             let mut store = storage::from_ctx!(ctx);
             let mut router = store.clone();

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -20,6 +20,7 @@ use anchor_lang::solana_program::system_instruction::create_account;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
 use bytemuck::bytes_of;
+use ed25519_consensus::SigningKey;
 use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
 use spl_token::instruction::initialize_mint2;
 
@@ -197,10 +198,10 @@ fn anchor_test_deliver() -> Result<()> {
     let msg1 = b"Hello";
     let private = authority.secret();
     let sig1 =
-        ed25519_consensus::SigningKey::from(private.to_bytes()).sign(msg1);
+        SigningKey::from(private.to_bytes()).sign(msg1);
     let msg2 = b"bye";
     let sig2 =
-        ed25519_consensus::SigningKey::from(private.to_bytes()).sign(msg2);
+        SigningKey::from(private.to_bytes()).sign(msg2);
 
     let signature_data1 = crate::SignatureData {
         message: msg1.to_vec(),

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -197,11 +197,9 @@ fn anchor_test_deliver() -> Result<()> {
 
     let msg1 = b"Hello";
     let private = authority.secret();
-    let sig1 =
-        SigningKey::from(private.to_bytes()).sign(msg1);
+    let sig1 = SigningKey::from(private.to_bytes()).sign(msg1);
     let msg2 = b"bye";
-    let sig2 =
-        SigningKey::from(private.to_bytes()).sign(msg2);
+    let sig2 = SigningKey::from(private.to_bytes()).sign(msg2);
 
     let signature_data1 = crate::SignatureData {
         message: msg1.to_vec(),

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -9,12 +9,15 @@ use anchor_client::solana_client::rpc_client::RpcClient;
 use anchor_client::solana_client::rpc_config::RpcSendTransactionConfig;
 use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::compute_budget::ComputeBudgetInstruction;
+use anchor_client::solana_sdk::ed25519_instruction::{PUBKEY_SERIALIZED_SIZE, SIGNATURE_SERIALIZED_SIZE, DATA_START};
 use anchor_client::solana_sdk::pubkey::Pubkey;
 use anchor_client::solana_sdk::signature::{Keypair, Signature, Signer};
-use anchor_client::{Client, Cluster};
+use anchor_client::{Client, Cluster, solana_sdk};
+use anchor_lang::solana_program::instruction::Instruction;
 use anchor_lang::solana_program::system_instruction::create_account;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
+use bytemuck::bytes_of;
 use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
 use spl_token::instruction::initialize_mint2;
 
@@ -167,7 +170,7 @@ fn anchor_test_deliver() -> Result<()> {
             associated_token_program: None,
             token_program: None,
         })
-        .args(instruction::Deliver { message })
+        .args(instruction::Deliver { message: message.clone() })
         .payer(authority.clone())
         .signer(&*authority)
         .send_with_spinner_and_config(RpcSendTransactionConfig {
@@ -184,6 +187,53 @@ fn anchor_test_deliver() -> Result<()> {
         "  This is solana storage account {:?}",
         solana_ibc_storage_account
     );
+
+    /*
+     * Verify signatures for update client 
+     */
+
+     let msg1 = b"Hello";
+     let private = authority.secret();
+     let sig1 =
+         ed25519_consensus::SigningKey::from(private.to_bytes()).sign(msg1);
+     let msg2 = b"bye";
+     let sig2 =
+         ed25519_consensus::SigningKey::from(private.to_bytes()).sign(msg2);
+ 
+     let signature_data1 = crate::SignatureData {
+        message: msg1.to_vec(),
+        pubkey: authority.pubkey(),
+        signature: sig1.into(),
+     };
+
+     let signature_data2 = crate::SignatureData {
+        message: msg2.to_vec(),
+        pubkey: authority.pubkey(),
+        signature: sig2.into(),
+     };
+     let signatures_data = vec![signature_data1, signature_data2];
+ 
+     let sig = program
+         .request()
+         .instruction(new_ed25519_instruction_with_signature(&authority.pubkey().to_bytes(),  &sig1.to_bytes(), msg1))
+         .instruction(new_ed25519_instruction_with_signature(&authority.pubkey().to_bytes(), &sig2.to_bytes(), msg2))
+         .accounts(accounts::SendUpdateClient { 
+            sender: authority.pubkey(), 
+            storage,
+            trie,
+            chain,
+            ix_sysvar: anchor_lang::solana_program::sysvar::instructions::id()})
+         .args(instruction::SendUpdateClient {
+            signatures_data,
+            update_client_msg: message, 
+         })
+         .payer(authority.clone())
+         .signer(&*authority)
+         .send_with_spinner_and_config(RpcSendTransactionConfig {
+             skip_preflight: true,
+             ..RpcSendTransactionConfig::default()
+         })?;
+     println!("  Signature for Signature verification : {sig}");
 
     /*
      * Create New Mock Connection Open Init
@@ -802,5 +852,60 @@ fn construct_transfer_packet_from_denom(
         packet_data,
         timeout_height_on_b: ibc::TimeoutHeight::Never,
         timeout_timestamp_on_b: ibc::Timestamp::none(),
+    }
+}
+
+/// Solana sdk only accepts a keypair to form ed25519 instruction. 
+/// Until they implement a method which accepts a pubkey and signature instead of keypair 
+/// we have to use the below method instead.
+/// 
+/// Reference: https://github.com/solana-labs/solana/pull/32806
+pub fn new_ed25519_instruction_with_signature(pubkey: &[u8], signature: &[u8], message: &[u8]) -> Instruction {
+    assert_eq!(pubkey.len(), PUBKEY_SERIALIZED_SIZE);
+    assert_eq!(signature.len(), SIGNATURE_SERIALIZED_SIZE);
+
+    let mut instruction_data = Vec::with_capacity(
+        DATA_START
+            .saturating_add(SIGNATURE_SERIALIZED_SIZE)
+            .saturating_add(PUBKEY_SERIALIZED_SIZE)
+            .saturating_add(message.len()),
+    );
+
+    let num_signatures: u8 = 1;
+    let public_key_offset = DATA_START;
+    let signature_offset = public_key_offset.saturating_add(PUBKEY_SERIALIZED_SIZE);
+    let message_data_offset = signature_offset.saturating_add(SIGNATURE_SERIALIZED_SIZE);
+
+    // add padding byte so that offset structure is aligned
+    instruction_data.extend_from_slice(bytes_of(&[num_signatures, 0]));
+
+    let offsets = crate::ed25519::SignatureOffsets {
+        signature_offset: signature_offset as u16,
+        signature_instruction_index: u16::MAX,
+        public_key_offset: public_key_offset as u16,
+        public_key_instruction_index: u16::MAX,
+        message_data_offset: message_data_offset as u16,
+        message_data_size: message.len() as u16,
+        message_instruction_index: u16::MAX,
+    };
+
+    instruction_data.extend_from_slice(bytes_of(&offsets));
+
+    debug_assert_eq!(instruction_data.len(), public_key_offset);
+
+    instruction_data.extend_from_slice(pubkey);
+
+    debug_assert_eq!(instruction_data.len(), signature_offset);
+
+    instruction_data.extend_from_slice(signature);
+
+    debug_assert_eq!(instruction_data.len(), message_data_offset);
+
+    instruction_data.extend_from_slice(message);
+
+    Instruction {
+        program_id: solana_sdk::ed25519_program::id(),
+        accounts: vec![],
+        data: instruction_data,
     }
 }


### PR DESCRIPTION
Solana programs have a compute budget limit which doesnt allow us to verify ed25519 signatures. So we have to call the `ed22519` program on solana and pass the `message`, `signature` and `pubkey` in the same transaction in which we call the `send_update_client` method on our contract. 

In the `send_update_client` method, we take signature data and compare it with the instruction data which was performed before and verify. If the verification fails we return the error else we execute the `UpdateClient` message. The signature verification wont be done now, since it has already been done before.

**Note:** the `send_update_client` can only be called to execute `UpdateClient` message.