### PR TITLE
Restaking audit issues

### DIFF
--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -459,6 +459,7 @@ pub struct Deposit<'info> {
     pub system_program: Program<'info, System>,
     pub rent: Sysvar<'info, Rent>,
 
+    #[account(address = solana_program::sysvar::instructions::ID)]
     ///CHECK:   
     pub instruction: AccountInfo<'info>,
 
@@ -618,6 +619,7 @@ pub struct SetService<'info> {
     pub stake_mint: Account<'info, Mint>,
 
     ///CHECK:   
+    #[account(address = solana_program::sysvar::instructions::ID)]
     pub instruction: AccountInfo<'info>,
 
     pub system_program: Program<'info, System>,

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -52,7 +52,7 @@ pub mod restaking {
     /// - Guest blockchain program ID
     pub fn deposit<'a, 'info>(
         ctx: Context<'a, 'a, 'a, 'info, Deposit<'info>>,
-        service: Option<Service>,
+        service: Service,
         amount: u64,
     ) -> Result<()> {
         let vault_params = &mut ctx.accounts.vault_params;
@@ -79,7 +79,7 @@ pub mod restaking {
         let guest_chain_program_id = staking_params.guest_chain_program_id;
 
         vault_params.service =
-            if guest_chain_program_id.is_some() { service } else { None };
+            if guest_chain_program_id.is_some() { Some(service) } else { None };
         vault_params.stake_timestamp_sec = current_time;
         vault_params.stake_amount = amount;
         vault_params.stake_mint = ctx.accounts.token_mint.key();

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -98,11 +98,6 @@ pub mod restaking {
                 ctx.remaining_accounts,
                 &guest_chain_program_id.unwrap(),
             )?;
-            let bump = ctx.bumps.staking_params;
-            let seeds =
-                [STAKING_PARAMS_SEED, TEST_SEED, core::slice::from_ref(&bump)];
-            let seeds = seeds.as_ref();
-            let seeds = core::slice::from_ref(&seeds);
             let cpi_accounts = SetStake {
                 sender: ctx.accounts.depositor.to_account_info(),
                 stake_mint: ctx.accounts.token_mint.to_account_info(),
@@ -113,7 +108,7 @@ pub mod restaking {
             };
             let cpi_program = ctx.remaining_accounts[2].clone();
             let cpi_ctx =
-                CpiContext::new_with_signer(cpi_program, cpi_accounts, seeds);
+                CpiContext::new(cpi_program, cpi_accounts);
             solana_ibc::cpi::set_stake(cpi_ctx, amount as u128)?;
         }
 

--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -330,6 +330,10 @@ pub mod restaking {
         if vault_params.service.is_some() {
             return Err(error!(ErrorCodes::ServiceAlreadySet));
         }
+        let token_account = &ctx.accounts.receipt_token_account;
+        if token_account.amount < 1 {
+            return Err(error!(ErrorCodes::InsufficientReceiptTokenBalance));
+        }
 
         vault_params.service = Some(service);
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -348,6 +348,7 @@ pub struct Chain<'info> {
 
     system_program: Program<'info, System>,
 
+    #[account(address = solana_program::sysvar::instructions::ID)]
     /// CHECK: Used for getting the caller program id to verify if the right
     /// program is calling the method.
     instruction: AccountInfo<'info>,
@@ -376,6 +377,7 @@ pub struct SetStake<'info> {
 
     system_program: Program<'info, System>,
 
+    #[account(address = solana_program::sysvar::instructions::ID)]
     /// CHECK: Used for getting the caller program id to verify if the right
     /// program is calling the method.
     instruction: AccountInfo<'info>,


### PR DESCRIPTION
Fixed the issues caught during the audit of the restaking contract.
- Changed the service parameter from `Option<Service>` to `Service` so that users choose the service once the guest chain is initialized. There is internal logic which keeps the service `None` if the guest chain is not initialized.
- Checking if `receipt_token_account` has balance in `set_service` method.
- removed signed invocation when calling `set_stake` method and using unsigned invocation instead.
- Added validation for `instruction` account in `deposit` and `set_service` method.
