### PR TITLE
added generic argument in split_at method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5094,6 +5094,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-write-account"
+version = "0.0.0"
+dependencies = [
+ "solana-program",
+ "stdx",
+]
+
+[[package]]
 name = "solana-zk-token-sdk"
 version = "1.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/common/blockchain/src/ibc_state/proof.rs
+++ b/common/blockchain/src/ibc_state/proof.rs
@@ -188,8 +188,8 @@ pub fn verify(
             // Proof is followed by two more sequence numbers this time in
             // big-endian.  We’re keeping sequence numbers together and we
             // need all of them to figure out the hash kept in the trie.
-            let (head, tail) =
-                stdx::split_at::<16, u8>(proof_bytes).ok_or_else(|| {
+            let (head, tail) = stdx::split_at::<16, u8>(proof_bytes)
+                .ok_or_else(|| {
                     VerifyError::ProofDecodingFailure(
                         "Missing sequences".into(),
                     )

--- a/common/blockchain/src/ibc_state/proof.rs
+++ b/common/blockchain/src/ibc_state/proof.rs
@@ -189,7 +189,7 @@ pub fn verify(
             // big-endian.  We’re keeping sequence numbers together and we
             // need all of them to figure out the hash kept in the trie.
             let (head, tail) =
-                stdx::split_at::<16>(proof_bytes).ok_or_else(|| {
+                stdx::split_at::<16, u8>(proof_bytes).ok_or_else(|| {
                     VerifyError::ProofDecodingFailure(
                         "Missing sequences".into(),
                     )


### PR DESCRIPTION
The `stdx::split_at` method has been changed in commit 8c74a55:
‘write-account: add Solana program for writing data into an account’
by adding type generic argument.  Update call site to reflect that.

This fixes a build failure which wasn’t caught because CI on the
offending commit wasn’t rerun between when the pull request was
initially made and when it was merged much later.
