### PR TITLE
solana-allocator: use strict pointer provenance

### DIFF
--- a/solana/allocator/src/lib.rs
+++ b/solana/allocator/src/lib.rs
@@ -126,7 +126,7 @@ unsafe impl GlobalAlloc for BumpAllocator {
             // On first call, end_pos is null.  Start allocating past the
             // end_pos.
             ptr = ptr::with_addr(
-                self.ptr.as_ptr(),
+                self.heap_range().start,
                 ptr::end_addr_of_val(end_pos),
             );
         };

--- a/solana/allocator/src/lib.rs
+++ b/solana/allocator/src/lib.rs
@@ -11,6 +11,10 @@ extern crate alloc;
 use alloc::alloc::{GlobalAlloc, Layout};
 use core::cell::Cell;
 
+mod ptr;
+#[cfg(test)]
+mod tests;
+
 /// Custom bump allocator for on-chain operations.
 ///
 /// The default allocator is also a bump one, but grows from a fixed
@@ -21,9 +25,9 @@ use core::cell::Cell;
 /// a segfault once out of available heap memory.
 pub struct BumpAllocator {
     #[cfg(test)]
-    start: core::ptr::NonNull<Cell<usize>>,
+    ptr: core::ptr::NonNull<u8>,
     #[cfg(test)]
-    size: usize,
+    layout: Layout,
 
     /// Prevents clients from being able to construct the type with struct
     /// literal syntax.
@@ -47,20 +51,35 @@ impl BumpAllocator {
     #[cfg(not(test))]
     pub const unsafe fn new() -> Self { Self { _private: () } }
 
+    /// Returns range of addresses that are guaranteed to be valid and within
+    /// the heap owned by us.
+    #[inline]
+    fn heap_range(&self) -> core::ops::Range<*mut u8> {
+        #[cfg(test)]
+        let (start, size) = (self.ptr.as_ptr(), self.layout.size());
+        #[cfg(not(test))]
+        // Solana heap is guaranteed to be at least 32 KiB.
+        let (start, size) = (
+            solana_program::entrypoint::HEAP_START_ADDRESS as *mut u8,
+            32 * 1024,
+        );
+        ptr::range(start, size)
+    }
+
     /// Returns reference to the end position address stored at the front of the
     /// heap.
     #[inline]
-    fn end_pos(&self) -> &Cell<usize> {
-        #[cfg(not(test))]
-        let ptr = solana_program::entrypoint::HEAP_START_ADDRESS;
-        #[cfg(test)]
-        let ptr = self.start.as_ptr();
-        // SAFETY: In not(test) case, we are running in a single-threaded
-        // environment where memory at HEAP_START_ADDRESS is guaranteed to
-        // always exist.  In test case, the type is single-threaded and memory
-        // pointed by self.start is guaranteed to be alive so long as self is
-        // alive.
-        unsafe { &*(ptr as *const _) }
+    fn end_pos(&self) -> &Cell<*mut u8> {
+        let range = self.heap_range();
+        // In release build on Solana, all of those numbers are known at compile
+        // time so all this maths should be compiled out.
+        let ptr = ptr::align(range.start, core::mem::align_of::<*mut u8>());
+        let end = ptr::end_addr(ptr, core::mem::size_of::<*mut u8>());
+        assert!(end <= range.end);
+        // SAFETY: 1. `ptr` is properly aligned and points to region within heap
+        // owned by us.  2. The heap has been zero-initialised and Cell<*mut u8>
+        // is Zeroable.
+        unsafe { &*ptr.cast() }
     }
 
     /// Checks whether given slice falls within available heap space and updates
@@ -73,24 +92,28 @@ impl BumpAllocator {
     /// If check passes, returns `start` cast to `*mut u8`.  Otherwise returns
     /// a NULL pointer.
     #[inline]
-    unsafe fn update_end_pos(&self, start: usize, size: usize) -> *mut u8 {
-        if let Some(end) = start.checked_add(size) {
+    fn update_end_pos(&self, ptr: *mut u8, size: usize) -> *mut u8 {
+        let end = match (ptr as usize).checked_add(size) {
+            None => return core::ptr::null_mut(),
+            Some(addr) => ptr::with_addr(ptr, addr),
+        };
+        let ok = if cfg!(test) {
+            let range = self.heap_range();
+            assert!(range.contains(&ptr));
+            end <= range.end
+        } else {
             // SAFETY: This is unsound but it will only execute on Solana where
             // accessing memory beyond heap results in segfault which is what we
             // want.
-            #[cfg(not(test))]
-            let ok = unsafe {
-                ((end - 1) as *mut u8).read_volatile();
-                true
-            };
-            #[cfg(test)]
-            let ok = end <= self.start.as_ptr() as usize + self.size;
-            if ok {
-                self.end_pos().set(end);
-                return start as *mut u8;
-            }
+            let _ = unsafe { end.sub(1).read_volatile() };
+            true
+        };
+        if ok {
+            self.end_pos().set(end);
+            ptr
+        } else {
+            core::ptr::null_mut()
         }
-        core::ptr::null_mut()
     }
 }
 
@@ -98,24 +121,24 @@ unsafe impl GlobalAlloc for BumpAllocator {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let end_pos = self.end_pos();
-        // On first call, pos is zero.  Need to initialise it with address past
-        // the position pointer we’re storing.
-        let start = match end_pos.get() {
-            0 => end_pos as *const _ as usize + core::mem::size_of_val(end_pos),
-            n => n,
+        let mut ptr = end_pos.get();
+        if ptr.is_null() {
+            // On first call, end_pos is null.  Start allocating past the
+            // end_pos.
+            ptr = ptr::with_addr(
+                self.ptr.as_ptr(),
+                ptr::end_addr_of_val(end_pos),
+            );
         };
-        // Note: layout.align() is guaranteed to be a power of two.
-        let mask = layout.align() - 1;
-        let start = (start + mask) & !mask;
-        self.update_end_pos(start, layout.size())
+        self.update_end_pos(ptr::align(ptr, layout.align()), layout.size())
     }
 
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         // If this is the last allocation, free it.  Otherwise this is bump
         // allocator and we leak memory.
-        if ptr as usize + layout.size() == self.end_pos().get() {
-            self.end_pos().set(ptr as usize);
+        if ptr::end_addr(ptr, layout.size()) == self.end_pos().get() {
+            self.end_pos().set(ptr);
         }
     }
 
@@ -126,9 +149,9 @@ unsafe impl GlobalAlloc for BumpAllocator {
         layout: Layout,
         new_size: usize,
     ) -> *mut u8 {
-        if ptr as usize + layout.size() == self.end_pos().get() {
+        if ptr::end_addr(ptr, layout.size()) == self.end_pos().get() {
             // If this is the last allocation, resize.
-            self.update_end_pos(ptr as usize, new_size)
+            self.update_end_pos(ptr, new_size)
         } else if new_size <= layout.size() {
             // If user wants to shrink size, do nothing.  We’re leaking memory
             // here but we’re bump allocator so that’s what we do.
@@ -144,11 +167,9 @@ unsafe impl GlobalAlloc for BumpAllocator {
             };
             if !new_ptr.is_null() {
                 // SAFETY: The previously allocated block cannot overlap the
-                // newly allocated block.  The safety contract for `dealloc`
-                // must be upheld by the caller.
+                // newly allocated block.  Note that layout.size() < new_size.
                 unsafe {
                     core::ptr::copy_nonoverlapping(ptr, new_ptr, layout.size());
-                    self.dealloc(ptr, layout);
                 }
             }
             new_ptr
@@ -156,129 +177,10 @@ unsafe impl GlobalAlloc for BumpAllocator {
     }
 }
 
-
-#[cfg(test)]
-impl BumpAllocator {
-    /// Creates a new allocator with given amount of available memory.
-    fn new(size: usize) -> Self {
-        let layout = Self::layout_for_size(size);
-        // SAFETY: layout.size() >= size_of(usize) > 0
-        let ptr = unsafe { std::alloc::alloc_zeroed(layout) }.cast();
-        let start = core::ptr::NonNull::new(ptr).unwrap();
-        Self { start, size: layout.size(), _private: () }
-    }
-
-    /// Returns layout of the underlying heap for given heap size.
-    fn layout_for_size(size: usize) -> Layout {
-        let size = size.max(core::mem::size_of::<Cell<usize>>());
-        Layout::from_size_align(size, core::mem::align_of::<Cell<usize>>())
-            .unwrap()
-    }
-
-    /// Returns amount of used memory in bytes excluding space used for end
-    /// position address stored at the start of the heap.
-    fn used(&self) -> usize {
-        match self.end_pos().get() {
-            0 => 0,
-            n => {
-                n - core::mem::size_of::<Cell<usize>>() -
-                    self.start.as_ptr() as usize
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 impl core::ops::Drop for BumpAllocator {
     fn drop(&mut self) {
-        let layout = Self::layout_for_size(self.size);
         // SAFETY: ptr and layout are the same as when we’ve allocated.
-        unsafe { alloc::alloc::dealloc(self.start.as_ptr().cast(), layout) }
-    }
-}
-
-#[test]
-fn test_alloc() {
-    let allocator = BumpAllocator::new(64);
-    assert_eq!(0, allocator.used());
-
-    let layout_large = Layout::from_size_align(64, 1).unwrap();
-    assert_eq!(core::ptr::null_mut(), unsafe { allocator.alloc(layout_large) });
-
-    let layout_1 = Layout::from_size_align(9, 1).unwrap();
-    let layout_4 = Layout::from_size_align(8, 4).unwrap();
-
-    let first = unsafe { allocator.alloc(layout_1) };
-    assert_eq!(9, allocator.used());
-    for i in 0..9 {
-        assert_eq!(0, unsafe { first.add(i).read() });
-    }
-
-    let second = unsafe { allocator.alloc(layout_4) };
-    assert_eq!(0, second as usize & 3);
-    assert!(second as usize > first as usize + 9);
-    assert_eq!(20, allocator.used());
-
-    unsafe { allocator.dealloc(second, layout_4) };
-    assert_eq!(12, allocator.used());
-}
-
-#[test]
-fn test_dealloc() {
-    let allocator = BumpAllocator::new(64);
-    assert_eq!(0, allocator.used());
-
-    let layout = Layout::array::<u8>(10).unwrap();
-
-    let first = unsafe { allocator.alloc(layout) };
-    assert_eq!(10, allocator.used());
-
-    let second = unsafe { allocator.alloc(layout) };
-    assert_eq!(20, allocator.used());
-    assert_eq!(unsafe { first.add(10) }, second);
-
-    unsafe { allocator.dealloc(second, layout) };
-    assert_eq!(10, allocator.used());
-
-    let third = unsafe { allocator.alloc(layout) };
-    assert_eq!(second, third);
-
-    unsafe {
-        allocator.dealloc(third, layout);
-        allocator.dealloc(first, layout);
-    }
-    assert_eq!(0, allocator.used());
-}
-
-#[test]
-fn test_realloc() {
-    let allocator = BumpAllocator::new(64);
-    assert_eq!(0, allocator.used());
-
-    let layout_5 = Layout::array::<u8>(5).unwrap();
-    let layout_10 = Layout::array::<u8>(10).unwrap();
-    let layout_15 = Layout::array::<u8>(15).unwrap();
-
-    let first = unsafe { allocator.alloc(layout_10) };
-    let second = unsafe { allocator.alloc(layout_10) };
-
-    // Resizing last allocation always works.
-    assert_eq!(second, unsafe { allocator.realloc(second, layout_10, 15) });
-    assert_eq!(25, allocator.used());
-    assert_eq!(second, unsafe { allocator.realloc(second, layout_15, 5) });
-    assert_eq!(15, allocator.used());
-
-    // Shrinking always works.
-    assert_eq!(first, unsafe { allocator.realloc(first, layout_10, 5) });
-    assert_eq!(15, allocator.used());
-
-    // Growing region in the middle requires copying.
-    for i in 0..5 {
-        unsafe { first.add(i).write(0x42) }
-    }
-    let third = unsafe { allocator.realloc(first, layout_5, 10) };
-    assert_ne!(first, third);
-    for i in 0..5 {
-        assert_eq!(0x42, unsafe { third.add(i).read() });
+        unsafe { alloc::alloc::dealloc(self.ptr.as_ptr(), self.layout) }
     }
 }

--- a/solana/allocator/src/ptr.rs
+++ b/solana/allocator/src/ptr.rs
@@ -1,20 +1,18 @@
 //! Mostly polyfill pointer operations which are currently nightly.
-// TODO(mina86): Switch to using methods on pointer once they stabilise.
 
+/// Creates a new pointer with the given address.
+// TODO(mina86): Use ptr.with_addr once strict_provenance stabilises.
 #[inline]
 pub(super) fn with_addr(ptr: *mut u8, addr: usize) -> *mut u8 {
     let self_addr = ptr as usize as isize;
     let dest_addr = addr as isize;
-    let offset = dest_addr.wrapping_sub(self_addr);
-    // This is the canonical desugaring of this operation
-    ptr.wrapping_byte_offset(offset)
+    ptr.wrapping_offset(dest_addr.wrapping_sub(self_addr))
 }
 
+/// Creates a new pointer by mapping `self`’s address to a new one.
+// TODO(mina86): Use ptr.map_addr once strict_provenance stabilises.
 #[inline]
-pub(super) fn map_addr(
-    ptr: *mut u8,
-    f: impl FnOnce(usize) -> usize,
-) -> *mut u8 {
+fn map_addr(ptr: *mut u8, f: impl FnOnce(usize) -> usize) -> *mut u8 {
     with_addr(ptr, f(ptr as usize))
 }
 
@@ -24,7 +22,7 @@ pub(super) fn map_addr(
 #[inline]
 pub(super) fn align(ptr: *mut u8, align: usize) -> *mut u8 {
     let mask = align - 1;
-    debug_assert!(align != 0 && 0 == align & mask);
+    debug_assert!(align != 0 && align & mask == 0);
     map_addr(ptr, |addr| (addr + mask) & !mask)
 }
 

--- a/solana/allocator/src/ptr.rs
+++ b/solana/allocator/src/ptr.rs
@@ -1,0 +1,47 @@
+//! Mostly polyfill pointer operations which are currently nightly.
+// TODO(mina86): Switch to using methods on pointer once they stabilise.
+
+#[inline]
+pub(super) fn with_addr(ptr: *mut u8, addr: usize) -> *mut u8 {
+    let self_addr = ptr as usize as isize;
+    let dest_addr = addr as isize;
+    let offset = dest_addr.wrapping_sub(self_addr);
+    // This is the canonical desugaring of this operation
+    ptr.wrapping_byte_offset(offset)
+}
+
+#[inline]
+pub(super) fn map_addr(
+    ptr: *mut u8,
+    f: impl FnOnce(usize) -> usize,
+) -> *mut u8 {
+    with_addr(ptr, f(ptr as usize))
+}
+
+/// Aligns pointer to given alignment which must be a power of two.
+///
+/// If `align` isn’t a power of two, result is unspecified.
+#[inline]
+pub(super) fn align(ptr: *mut u8, align: usize) -> *mut u8 {
+    let mask = align - 1;
+    debug_assert!(align != 0 && 0 == align & mask);
+    map_addr(ptr, |addr| (addr + mask) & !mask)
+}
+
+/// Returns pointer past object of given size at given pointer.
+#[inline]
+pub(super) fn end_addr(ptr: *mut u8, size: usize) -> *mut u8 {
+    map_addr(ptr, |addr| addr + size)
+}
+
+/// Returns end address of given object.
+#[inline]
+pub(super) fn end_addr_of_val<T: Sized>(obj: &T) -> usize {
+    obj as *const T as usize + core::mem::size_of_val(obj)
+}
+
+/// Returns a range of pointers of given size.
+#[inline]
+pub(super) fn range(start: *mut u8, size: usize) -> core::ops::Range<*mut u8> {
+    start..map_addr(start, |addr| addr + size)
+}

--- a/solana/allocator/src/tests.rs
+++ b/solana/allocator/src/tests.rs
@@ -1,0 +1,125 @@
+use alloc::alloc::{GlobalAlloc, Layout};
+
+use crate::ptr::end_addr_of_val;
+use crate::BumpAllocator;
+
+impl BumpAllocator {
+    /// Creates a new allocator with given amount of available memory.
+    fn new(size: usize) -> Self {
+        let layout = Layout::from_size_align(
+            size,
+            core::mem::align_of::<core::cell::Cell<usize>>(),
+        )
+        .unwrap();
+        let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+        let ptr = core::ptr::NonNull::new(ptr).unwrap();
+        Self { ptr, layout, _private: () }
+    }
+
+    /// Returns amount of used memory in bytes excluding space used for end
+    /// position address stored at the start of the heap.
+    fn used(&self) -> usize {
+        let end_pos = self.end_pos();
+        (end_pos.get() as usize).saturating_sub(end_addr_of_val(end_pos))
+    }
+
+    /// Allocates region of memory and returns it as a slice; checks returned
+    /// alignment and whether region is all-zero.
+    fn check_alloc(&self, layout: Layout) -> Option<*mut u8> {
+        core::ptr::NonNull::new(unsafe { self.alloc(layout) }).map(|ptr| {
+            let ptr = ptr.as_ptr();
+            let mask = layout.align() - 1;
+            assert_eq!(0, ptr as usize & mask, "{ptr:?} is misaligned");
+            ptr
+        })
+    }
+}
+
+#[track_caller]
+fn assert_no_overlap(a: *mut u8, a_size: usize, b: *mut u8, b_size: usize) {
+    let (a, b) = unsafe { (a..a.add(a_size), b..b.add(b_size)) };
+    assert!(
+        !a.contains(&b.start) && !a.contains(&b.end),
+        "{a:?} and {b:?} overlap",
+    )
+}
+
+#[test]
+fn test_alloc() {
+    let allocator = BumpAllocator::new(64);
+    assert_eq!(0, allocator.used());
+
+    // Large allocation fails.
+    let large = Layout::from_size_align(64 - 7, 1).unwrap();
+    assert_eq!(None, allocator.check_alloc(large));
+
+    // Two successful allocations.  Cannot overlap.
+    let layout_align_1 = Layout::from_size_align(9, 1).unwrap();
+    let layout_align_4 = Layout::from_size_align(8, 4).unwrap();
+
+    let first = allocator.check_alloc(layout_align_1).unwrap();
+    assert_eq!(9, allocator.used());
+
+    let second = allocator.check_alloc(layout_align_4).unwrap();
+    assert_eq!(20, allocator.used());
+    assert_no_overlap(first, 9, second, 8);
+}
+
+#[test]
+fn test_dealloc() {
+    let allocator = BumpAllocator::new(64);
+    assert_eq!(0, allocator.used());
+
+    let layout = Layout::array::<u8>(10).unwrap();
+
+    let first = allocator.check_alloc(layout).unwrap();
+    assert_eq!(10, allocator.used());
+
+    let second = allocator.check_alloc(layout).unwrap();
+    assert_eq!(20, allocator.used());
+    assert_no_overlap(first, 10, second, 10);
+
+    // Freeing last allocation recovers the memory.
+    unsafe { allocator.dealloc(second, layout) };
+    assert_eq!(10, allocator.used());
+
+    let third = unsafe { allocator.alloc(layout) };
+    assert_eq!(second, third);
+
+    // Freeing from the middle wastes memory.
+    unsafe {
+        allocator.dealloc(first, layout);
+        allocator.dealloc(third, layout);
+    }
+    assert_eq!(10, allocator.used());
+}
+
+#[test]
+fn test_realloc() {
+    let allocator = BumpAllocator::new(64);
+    assert_eq!(0, allocator.used());
+
+    let layout_5 = Layout::array::<u8>(5).unwrap();
+    let layout_10 = Layout::array::<u8>(10).unwrap();
+    let layout_15 = Layout::array::<u8>(15).unwrap();
+
+    let first = allocator.check_alloc(layout_10).unwrap();
+    let second = allocator.check_alloc(layout_10).unwrap();
+
+    // Resizing last allocation always works (so long there’s free memory).
+    assert_eq!(second, unsafe { allocator.realloc(second, layout_10, 15) });
+    assert_eq!(25, allocator.used());
+    assert_eq!(second, unsafe { allocator.realloc(second, layout_15, 5) });
+    assert_eq!(15, allocator.used());
+
+    // Shrinking always works but the memory is wasted.
+    assert_eq!(first, unsafe { allocator.realloc(first, layout_10, 5) });
+    assert_eq!(15, allocator.used());
+
+    // Growing region in the middle requires copying.
+    unsafe { core::slice::from_raw_parts_mut(first, 5) }.fill(42);
+    let third = unsafe { allocator.realloc(first, layout_5, 10) };
+    assert_ne!(first, third);
+    let slice = unsafe { core::slice::from_raw_parts_mut(first, 10) };
+    assert_eq!([42, 42, 42, 42, 42, 0, 0, 0, 0, 0], slice);
+}


### PR DESCRIPTION
Use pointer arithmetic with strict provenance to make Miri happy and
better test the allocator.  Strict provenance pointer methods are
unstable so copy what we need.
