### PR TITLE
added instructions for verifying bytecode of restaking contract

### DIFF
--- a/solana/restaking/README.md
+++ b/solana/restaking/README.md
@@ -71,45 +71,47 @@ can start staking.
 
 ## Verifying the code
 
-First, compile the programs code from the `emulated-light-client` Github repository to get its bytecode.
-```
-git clone https://github.com/ComposableFi/emulated-light-client.git
-```
+First, compile the programs code from the `emulated-light-client` Github
+repository to get its bytecode.
 
-```
-anchor build
-```
-Now, install the [Ellipsis Labs verifiable build](https://crates.io/crates/solana-verify) crate.
-```
-cargo install solana-verify
-```
-Get the executable hash of the bytecode from the Restaking program that was compiled
-```
-solana-verify get-executable-hash target/deploy/restaking.so
-```
-Get the hash from the bytecode of the on-chain restaking program that you want to verify
-```
-solana-verify get-program-hash -u <cluster url> 8n3FHwYxFgQCQc2FNFkwDUf9mcqupxXcCvgfHbApMLv3
-```
-**Note for multisig members:** If you want to verify the upgrade program buffer, then you need to get the bytecode from the buffer account using the below command. You can get the buffer account address from the squads.
-```
-solana-verify get-buffer-hash -u <cluster url> <buffer address> 
-```
+    git clone https://github.com/ComposableFi/emulated-light-client.git
+    anchor build
 
-If the hash outputs of those two commands match, the code in the repository matches the on-chain programs code.
+Now, install the [Ellipsis Labs verifiable
+build](https://crates.io/crates/solana-verify) crate.
 
+    cargo install solana-verify
+
+Get the executable hash of the bytecode from the Restaking program that was
+compiled
+
+    solana-verify get-executable-hash target/deploy/restaking.so
+
+Get the hash from the bytecode of the on-chain restaking program that you want
+to verify
+
+    solana-verify get-program-hash -u <cluster url> \
+        8n3FHwYxFgQCQc2FNFkwDUf9mcqupxXcCvgfHbApMLv3
+
+**Note for multisig members:** If you want to verify the upgrade program buffer,
+then you need to get the bytecode from the buffer account using the below
+command. You can get the buffer account address from the squads.
+
+    solana-verify get-buffer-hash -u <cluster url> <buffer address>
+
+If the hash outputs of those two commands match, the code in the
+repository matches the on-chain programs code.
 
 ## Note
 
-- Since the rewards are not implemented yet on the `Guest Blockchain`,
-  a nil value is returned for now.
+- Since the rewards are not implemented yet on the Guest Chain, a nil value is
+  returned for now.
 
-- Oracle interface is yet to be added to fetch the current price of 
-  staked tokens as well as the governance token in the `Guest Blockchain`.
+- Oracle interface is yet to be added to fetch the current price of staked
+  tokens as well as the governance token in the Guest Chain.
 
-- Users who have deposited before the `guest chain` is initialized can choose
-  the validator in one of three ways(Yet to be implemented):
-  - Choose a validator randomly
-  - Choose a validator from the list of top 10 validators chosen by us
-  - Choose a particular validator.
-  
+- Users who have deposited before the Guest Chain is initialized can choose the
+  validator in one of three ways(Yet to be implemented):
+  - choose a validator randomly,
+  - choose a validator from the list of top 10 validators chosen by us or
+  - choose a particular validator.


### PR DESCRIPTION
Instructions on how the restaking contract bytecode can be verified using [Ellipsis Labs verifiable build](https://crates.io/crates/solana-verify) crate. This can be used by multisig members to verify the bytecode of the new upgrade before they approve the transaction.