### PR TITLE
solana-allocator: simplify pointer arithmetic functions

### DIFF
--- a/solana/allocator/src/ptr.rs
+++ b/solana/allocator/src/ptr.rs
@@ -1,19 +1,10 @@
-//! Mostly polyfill pointer operations which are currently nightly.
+//! Helper functions for pointer arithmetic.
 
 /// Creates a new pointer with the given address.
 // TODO(mina86): Use ptr.with_addr once strict_provenance stabilises.
 #[inline]
 pub(super) fn with_addr(ptr: *mut u8, addr: usize) -> *mut u8 {
-    let self_addr = ptr as usize as isize;
-    let dest_addr = addr as isize;
-    ptr.wrapping_offset(dest_addr.wrapping_sub(self_addr))
-}
-
-/// Creates a new pointer by mapping `self`’s address to a new one.
-// TODO(mina86): Use ptr.map_addr once strict_provenance stabilises.
-#[inline]
-fn map_addr(ptr: *mut u8, f: impl FnOnce(usize) -> usize) -> *mut u8 {
-    with_addr(ptr, f(ptr as usize))
+    ptr.wrapping_add(addr.wrapping_sub(ptr as usize))
 }
 
 /// Aligns pointer to given alignment which must be a power of two.
@@ -23,23 +14,18 @@ fn map_addr(ptr: *mut u8, f: impl FnOnce(usize) -> usize) -> *mut u8 {
 pub(super) fn align(ptr: *mut u8, align: usize) -> *mut u8 {
     let mask = align - 1;
     debug_assert!(align != 0 && align & mask == 0);
-    map_addr(ptr, |addr| (addr + mask) & !mask)
-}
-
-/// Returns pointer past object of given size at given pointer.
-#[inline]
-pub(super) fn end_addr(ptr: *mut u8, size: usize) -> *mut u8 {
-    map_addr(ptr, |addr| addr + size)
+    // TODO(mina86): Use ptr.map_addr once strict_provenance stabilises.
+    with_addr(ptr, ptr.wrapping_add(mask) as usize & !mask)
 }
 
 /// Returns end address of given object.
 #[inline]
 pub(super) fn end_addr_of_val<T: Sized>(obj: &T) -> usize {
-    obj as *const T as usize + core::mem::size_of_val(obj)
+    (obj as *const T).wrapping_add(1) as usize
 }
 
 /// Returns a range of pointers of given size.
 #[inline]
 pub(super) fn range(start: *mut u8, size: usize) -> core::ops::Range<*mut u8> {
-    start..map_addr(start, |addr| addr + size)
+    start..start.wrapping_add(size)
 }

--- a/solana/allocator/src/tests.rs
+++ b/solana/allocator/src/tests.rs
@@ -1,8 +1,7 @@
 use alloc::alloc::{GlobalAlloc, Layout};
 
 use crate::ptr::end_addr_of_val;
-use crate::BumpAllocator;
-use crate::ptr;
+use crate::{ptr, BumpAllocator};
 
 impl BumpAllocator {
     /// Creates a new allocator with given amount of available memory.

--- a/solana/allocator/src/tests.rs
+++ b/solana/allocator/src/tests.rs
@@ -2,6 +2,7 @@ use alloc::alloc::{GlobalAlloc, Layout};
 
 use crate::ptr::end_addr_of_val;
 use crate::BumpAllocator;
+use crate::ptr;
 
 impl BumpAllocator {
     /// Creates a new allocator with given amount of available memory.
@@ -37,7 +38,7 @@ impl BumpAllocator {
 
 #[track_caller]
 fn assert_no_overlap(a: *mut u8, a_size: usize, b: *mut u8, b_size: usize) {
-    let (a, b) = unsafe { (a..a.add(a_size), b..b.add(b_size)) };
+    let (a, b) = (ptr::range(a, a_size), ptr::range(b, b_size));
     assert!(
         !a.contains(&b.start) && !a.contains(&b.end),
         "{a:?} and {b:?} overlap",


### PR DESCRIPTION
This should have been part of previous commit really.  Sorry about the noise.