### PR TITLE
solana-allocator: add support for global state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4387,6 +4387,7 @@ dependencies = [
 name = "solana-allocator"
 version = "0.0.0"
 dependencies = [
+ "bytemuck",
  "solana-program",
 ]
 

--- a/solana/allocator/Cargo.toml
+++ b/solana/allocator/Cargo.toml
@@ -5,4 +5,8 @@ version = "0.0.0"
 edition = "2021"
 
 [target.'cfg(target_os = "solana")'.dependencies]
+bytemuck.workspace = true
 solana-program.workspace = true
+
+[dev-dependencies]
+bytemuck.workspace = true

--- a/solana/allocator/src/lib.rs
+++ b/solana/allocator/src/lib.rs
@@ -56,7 +56,9 @@ impl<G: bytemuck::Zeroable> BumpAllocator<G> {
     /// allocator is present leads to undefined behaviour since the allocator
     /// needs to take ownership of the heap provided by Solana runtime.
     #[cfg(not(test))]
-    pub const unsafe fn new() -> Self { Self { _ph: Default::default() } }
+    pub const unsafe fn new() -> Self {
+        Self { _ph: core::marker::PhantomData }
+    }
 
     /// Returns range of addresses that are guaranteed to be valid and within
     /// the heap owned by us.

--- a/solana/allocator/src/tests.rs
+++ b/solana/allocator/src/tests.rs
@@ -11,7 +11,7 @@ impl<G: bytemuck::Zeroable> BumpAllocator<G> {
                 .unwrap();
         let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
         let ptr = core::ptr::NonNull::new(ptr).unwrap();
-        Self { ptr, layout, _ph: Default::default() }
+        Self { ptr, layout, _ph: core::marker::PhantomData }
     }
 
     /// Returns amount of used memory in bytes excluding space used for end
@@ -142,14 +142,13 @@ fn test_global() {
     let layout = Layout::from_size_align(8, 1).unwrap();
     let ptr = allocator.check_alloc(layout).unwrap();
     assert_eq!(8, allocator.used());
-    let global_ptr: *const _ = global;
     assert_no_overlap(
-        global_ptr.cast(),
+        core::ptr::addr_of!(*global).cast(),
         core::mem::size_of_val(global),
         ptr,
         8,
     );
 
     // Global state doesn’t change location.
-    assert_eq!(global_ptr, allocator.global() as *const _);
+    assert!(core::ptr::eq(global, allocator.global()));
 }

--- a/solana/allocator/src/tests.rs
+++ b/solana/allocator/src/tests.rs
@@ -143,7 +143,12 @@ fn test_global() {
     let ptr = allocator.check_alloc(layout).unwrap();
     assert_eq!(8, allocator.used());
     let global_ptr: *const _ = global;
-    assert_no_overlap(global_ptr.cast(), core::mem::size_of_val(global), ptr, 8);
+    assert_no_overlap(
+        global_ptr.cast(),
+        core::mem::size_of_val(global),
+        ptr,
+        8,
+    );
 
     // Global state doesn’t change location.
     assert_eq!(global_ptr, allocator.global() as *const _);

--- a/solana/solana-ibc/programs/solana-ibc/src/allocator.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/allocator.rs
@@ -4,7 +4,7 @@
     not(feature = "no-entrypoint"),
 ))]
 #[global_allocator]
-static ALLOCATOR: solana_allocator::BumpAllocator = {
+static ALLOCATOR: solana_allocator::BumpAllocator<()> = {
     // SAFETY: We’re only instantiating the BumpAllocator once.
     unsafe { solana_allocator::BumpAllocator::new() }
 };


### PR DESCRIPTION
Add support to reserve global state in the allocator.  This is to work
around Solana’s limitation of not allowing mutable statics.

With this feature, user can declare `BumpAllocator<T>` as the global
allocator and later use `BumpAllocator::global()` to get access to
`T`.
