### PR TITLE
solana-ed25519: move ED25519 Solana verification code into a new crate

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,12 @@ jobs:
         id: install-rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          # Pin nightly to specific version to avoid ahash breakage.
+          # See https://github.com/tkaitchuck/aHash/issues/200
+          # TODO(mina86): Unpin once situation with ahash is resolved.
+          # Hopefully we won’t need to patch.
+          #toolchain: nightly
+          toolchain: nightly-2024-02-05
           components: clippy rustfmt miri
 
       - name: Install Protoc
@@ -112,7 +117,7 @@ jobs:
           cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
           avm install $ANCHOR_VERSION
           avm use $ANCHOR_VERSION
-       
+
       - name: Installing node modules
         run : yarn
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,6 +4477,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-ed25519"
+version = "0.0.0"
+dependencies = [
+ "base64 0.21.7",
+ "blockchain",
+ "borsh 0.10.3",
+ "bytemuck",
+ "derive_more",
+ "solana-program",
+]
+
+[[package]]
 name = "solana-frozen-abi"
 version = "1.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4541,6 +4553,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-allocator",
+ "solana-ed25519",
  "solana-trie",
  "spl-associated-token-account",
  "spl-token",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.11",
@@ -1837,7 +1837,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
 ]
 
 [[package]]
@@ -4493,7 +4493,7 @@ version = "1.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "174a53486f9e0774680c2b6a53568a15c11ccc5cef1263a7e7d42958bfd61792"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
  "blake3",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -4626,7 +4626,7 @@ version = "1.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7b58cc4a2f4f450361bc8c1a24a94383c659e6212a74e6080a410f7d87e05a6"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
  "bincode",
  "bv",
  "caps",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,6 @@ dependencies = [
 name = "restaking"
 version = "0.1.0"
 dependencies = [
- "ahash 0.8.6",
  "anchor-lang",
  "anchor-spl",
  "home",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.11",
@@ -1837,7 +1837,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.6",
 ]
 
 [[package]]
@@ -4493,7 +4493,7 @@ version = "1.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "174a53486f9e0774680c2b6a53568a15c11ccc5cef1263a7e7d42958bfd61792"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.6",
  "blake3",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -4626,7 +4626,7 @@ version = "1.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7b58cc4a2f4f450361bc8c1a24a94383c659e6212a74e6080a410f7d87e05a6"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.6",
  "bincode",
  "bv",
  "caps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.71.0"
 members = [
     "common/*",
     "solana/allocator",
+    "solana/ed25519",
     "solana/restaking/programs/*",
     "solana/solana-ibc/programs/*",
     "solana/trie",
@@ -32,8 +33,6 @@ anchor-spl = "0.29.0"
 ascii = "1.1.0"
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 borsh = { version = "0.10.3", default-features = false }
-prost = { version = "0.12.3", default-features = false }
-prost-build = { version = "0.12.3", default-features = false }
 bytemuck = { version = "1.14", default-features = false }
 derive_more = "0.99.17"
 hex-literal = "0.4.1"
@@ -53,6 +52,8 @@ insta = { version = "1.34.0" }
 linear-map = { git = "https://github.com/contain-rs/linear-map", rev = "57f1432e26ff902bc883b250a85e0b5716bd241c", default-features = false }
 pretty_assertions = "1.4.0"
 primitive-types = "0.12.2"
+prost = { version = "0.12.3", default-features = false }
+prost-build = { version = "0.12.3", default-features = false }
 rand = { version = "0.8.5" }
 serde = "1"
 serde_json = "1"
@@ -70,6 +71,7 @@ lib = { path = "common/lib" }
 memory = { path = "common/memory" }
 sealable-trie = { path = "common/sealable-trie" }
 solana-allocator = { path = "solana/allocator" }
+solana-ed25519 = { path = "solana/ed25519" }
 solana-ibc = { path = "solana/solana-ibc/programs/solana-ibc" }
 solana-trie = { path = "solana/trie" }
 stdx = { path = "common/stdx" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ incremental = false
 codegen-units = 1
 
 [workspace.dependencies]
-ahash = "0.8.6"
 anchor-lang = {version = "0.29.0", features = ["init-if-needed"]}
 anchor-spl = "0.29.0"
 ascii = "1.1.0"

--- a/common/blockchain/Cargo.toml
+++ b/common/blockchain/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 borsh.workspace = true
-bytemuck.workspace = true
+bytemuck = { workspace = true, features = ["must_cast"] }
 derive_more.workspace = true
 ibc-core-client-context.workspace = true
 ibc-core-commitment-types.workspace = true

--- a/solana/ed25519/Cargo.toml
+++ b/solana/ed25519/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "solana-ed25519"
+authors = ["Michal Nazarewicz <mina86@mina86.com>"]
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+base64.workspace = true
+borsh = { workspace = true, optional = true }
+bytemuck.workspace = true
+derive_more.workspace = true
+solana-program.workspace = true
+
+blockchain = { workspace = true, optional = true }
+
+[features]
+default = ["borsh", "guest"]
+guest = ["dep:blockchain"]

--- a/solana/ed25519/src/lib.rs
+++ b/solana/ed25519/src/lib.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 
 use solana_program::account_info::AccountInfo;
-use solana_program::{ed25519_program, sysvar};
 use solana_program::program_error::ProgramError;
+use solana_program::{ed25519_program, sysvar};
 
 /// An Ed25519 public key used by guest validators to sign guest blocks.
 #[derive(
@@ -15,7 +15,10 @@ use solana_program::program_error::ProgramError;
     derive_more::From,
     derive_more::Into,
 )]
-#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct PubKey([u8; 32]);
 
 impl PubKey {
@@ -58,7 +61,10 @@ impl blockchain::PubKey for PubKey {
     derive_more::From,
     derive_more::Into,
 )]
-#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct Signature([u8; 64]);
 
 impl Signature {
@@ -97,7 +103,12 @@ impl Verifier {
 
     /// Verifies that the signature exists in the instruction data.
     #[inline]
-    pub fn exists(&self, message: &[u8], pubkey: &PubKey, signature: &Signature) -> bool {
+    pub fn exists(
+        &self,
+        message: &[u8],
+        pubkey: &PubKey,
+        signature: &Signature,
+    ) -> bool {
         exists_impl(self.0.as_slice(), message, &pubkey.0, &signature.0)
     }
 }
@@ -215,7 +226,7 @@ macro_rules! fmt_impl {
                 base64_display(&self.0, fmtr)
             }
         }
-    }
+    };
 }
 
 fmt_impl!(impl Display for PubKey);

--- a/solana/ed25519/src/lib.rs
+++ b/solana/ed25519/src/lib.rs
@@ -1,7 +1,8 @@
-use anchor_lang::prelude::{borsh, err};
-use anchor_lang::solana_program;
+use core::fmt;
+
 use solana_program::account_info::AccountInfo;
 use solana_program::{ed25519_program, sysvar};
+use solana_program::program_error::ProgramError;
 
 /// An Ed25519 public key used by guest validators to sign guest blocks.
 #[derive(
@@ -11,11 +12,10 @@ use solana_program::{ed25519_program, sysvar};
     PartialOrd,
     Ord,
     Hash,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
     derive_more::From,
     derive_more::Into,
 )]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct PubKey([u8; 32]);
 
 impl PubKey {
@@ -42,6 +42,7 @@ impl PartialEq<PubKey> for solana_program::pubkey::Pubkey {
     fn eq(&self, other: &PubKey) -> bool { self.as_ref() == &other.0[..] }
 }
 
+#[cfg(feature = "guest")]
 impl blockchain::PubKey for PubKey {
     type Signature = Signature;
 }
@@ -54,11 +55,10 @@ impl blockchain::PubKey for PubKey {
     PartialOrd,
     Ord,
     Hash,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
     derive_more::From,
     derive_more::Into,
 )]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct Signature([u8; 64]);
 
 impl Signature {
@@ -86,16 +86,23 @@ impl Verifier {
     /// Returns error if `ix_sysver` is not `AccountInfo` for the Instruction
     /// sysvar, there was no instruction prior to the current on or the previous
     /// instruction was not a call to the Ed25519 native program.
-    pub fn new(ix_sysvar: &AccountInfo<'_>) -> anchor_lang::Result<Self> {
+    pub fn new(ix_sysvar: &AccountInfo<'_>) -> Result<Self, ProgramError> {
         let ix = sysvar::instructions::get_instruction_relative(-1, ix_sysvar)?;
         if ed25519_program::check_id(&ix.program_id) {
             Ok(Self(ix.data))
         } else {
-            err!(anchor_lang::error::ErrorCode::InstructionMissing)
+            Err(ProgramError::IncorrectProgramId)
         }
+    }
+
+    /// Verifies that the signature exists in the instruction data.
+    #[inline]
+    pub fn exists(&self, message: &[u8], pubkey: &PubKey, signature: &Signature) -> bool {
+        exists_impl(self.0.as_slice(), message, &pubkey.0, &signature.0)
     }
 }
 
+#[cfg(feature = "guest")]
 impl blockchain::Verifier<PubKey> for Verifier {
     #[inline]
     fn verify(
@@ -104,7 +111,7 @@ impl blockchain::Verifier<PubKey> for Verifier {
         pubkey: &PubKey,
         signature: &Signature,
     ) -> bool {
-        verify_impl(self.0.as_slice(), message, &pubkey.0, &signature.0)
+        self.exists(message, pubkey, signature)
     }
 }
 
@@ -113,7 +120,7 @@ impl blockchain::Verifier<PubKey> for Verifier {
 ///
 /// `data` must be aligned to two bytes.  This is in practice guaranteed if data
 /// comes from a vector or in general points at a beginning of an allocation.
-fn verify_impl(
+fn exists_impl(
     data: &[u8],
     message: &[u8],
     pubkey: &[u8; PubKey::LENGTH],
@@ -200,46 +207,38 @@ impl SignatureOffsets {
     }
 }
 
-impl core::fmt::Display for PubKey {
-    #[inline]
-    fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> core::fmt::Result {
-        <&lib::hash::CryptoHash>::from(&self.0).fmt(fmtr)
+macro_rules! fmt_impl {
+    (impl $trait:ident for $ty:ident) => {
+        impl fmt::$trait for $ty {
+            #[inline]
+            fn fmt(&self, fmtr: &mut fmt::Formatter) -> fmt::Result {
+                base64_display(&self.0, fmtr)
+            }
+        }
     }
 }
 
-impl core::fmt::Debug for PubKey {
-    #[inline]
-    fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(self, fmtr)
-    }
+fmt_impl!(impl Display for PubKey);
+fmt_impl!(impl Debug for PubKey);
+fmt_impl!(impl Display for Signature);
+fmt_impl!(impl Debug for Signature);
+
+/// Displays slice using base64 encoding.  Slice must be at most 64 bytes
+/// (i.e. length of a signature).
+fn base64_display(bytes: &[u8], fmtr: &mut fmt::Formatter) -> fmt::Result {
+    use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
+    use base64::Engine;
+
+    let mut buf = [0u8; (64 + 2) / 3 * 4];
+    let len = BASE64_ENGINE.encode_slice(bytes, &mut buf[..]).unwrap();
+    // SAFETY: base64 fills the buffer with ASCII characters only.
+    fmtr.write_str(unsafe { core::str::from_utf8_unchecked(&buf[..len]) })
 }
 
-impl core::fmt::Display for Signature {
-    fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> core::fmt::Result {
-        use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
-        use base64::Engine;
 
-        const ENCODED_LENGTH: usize = (Signature::LENGTH + 2) / 3 * 4;
-        let mut buf = [0u8; ENCODED_LENGTH];
-        let len = BASE64_ENGINE
-            .encode_slice(self.0.as_slice(), &mut buf[..])
-            .unwrap();
-        // SAFETY: base64 fills the buffer with ASCII characters only.
-        fmtr.write_str(unsafe { core::str::from_utf8_unchecked(&buf[..len]) })
-    }
-}
-
-impl core::fmt::Debug for Signature {
-    #[inline]
-    fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(self, fmtr)
-    }
-}
 
 #[test]
 fn test_verify() {
-    use blockchain::Verifier;
-
     // Construct signatures.
     let pk = PubKey([128; 32]);
     let msg1 = &b"hello, world"[..];
@@ -280,10 +279,10 @@ fn test_verify() {
 
     // Test verification
     let verifier = Verifier(data);
-    assert!(verifier.verify(msg1, &pk, &sig1));
-    assert!(verifier.verify(msg2, &pk, &sig2));
+    assert!(verifier.exists(msg1, &pk, &sig1));
+    assert!(verifier.exists(msg2, &pk, &sig2));
     // Wrong signature
-    assert!(!verifier.verify(msg1, &pk, &sig2));
+    assert!(!verifier.exists(msg1, &pk, &sig2));
     // Wrong public key
-    assert!(!verifier.verify(msg1, &PubKey([129; 32]), &sig1));
+    assert!(!verifier.exists(msg1, &PubKey([129; 32]), &sig1));
 }

--- a/solana/restaking/programs/restaking/Cargo.toml
+++ b/solana/restaking/programs/restaking/Cargo.toml
@@ -18,7 +18,6 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-ahash.workspace = true
 anchor-lang = { workspace = true, features = ["init-if-needed"] }
 anchor-spl = { workspace = true, features = ["metadata"] }
 solana-ibc = { workspace = true, features = ["cpi"] }

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -31,7 +31,6 @@ serde.workspace = true
 serde_json.workspace = true
 spl-associated-token-account.workspace = true
 spl-token.workspace = true
-
 strum.workspace = true
 uint.workspace = true
 
@@ -39,6 +38,7 @@ blockchain.workspace = true
 lib.workspace = true
 memory.workspace = true
 solana-allocator = { workspace = true, optional = true }
+solana-ed25519 = { workspace = true, features = ["borsh", "guest"] }
 solana-trie.workspace = true
 stdx.workspace = true
 trie-ids = { workspace = true, features = ["borsh"] }

--- a/solana/solana-ibc/programs/solana-ibc/src/chain.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/chain.rs
@@ -3,6 +3,7 @@ use core::num::NonZeroU64;
 use anchor_lang::prelude::*;
 pub use blockchain::Config;
 use lib::hash::CryptoHash;
+pub use solana_ed25519::{PubKey, Signature, Verifier};
 
 use crate::error::Error;
 use crate::{events, ibc, storage};
@@ -14,7 +15,6 @@ pub type Block = blockchain::Block<PubKey>;
 pub type BlockHeader = blockchain::BlockHeader;
 pub type Manager = blockchain::ChainManager<PubKey>;
 pub type Validator = blockchain::Validator<PubKey>;
-pub use crate::ed25519::{PubKey, Signature, Verifier};
 
 /// Guest blockchain data held in Solana account.
 #[account]

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -29,7 +29,6 @@ mod allocator;
 pub mod chain;
 pub mod client_state;
 pub mod consensus_state;
-mod ed25519;
 mod error;
 pub mod events;
 mod execution_context;
@@ -97,7 +96,7 @@ pub mod solana_ibc {
         signature: [u8; 64],
     ) -> Result<()> {
         let provable = storage::get_provable_from(&ctx.accounts.trie)?;
-        let verifier = ed25519::Verifier::new(&ctx.accounts.ix_sysvar)?;
+        let verifier = solana_ed25519::Verifier::new(&ctx.accounts.ix_sysvar)?;
         if ctx.accounts.chain.sign_block(
             (*ctx.accounts.sender.key).into(),
             &signature.into(),


### PR DESCRIPTION
This is mostly because we are going to be patching ibc-rs to support
Solana signature verefication and to avoid circular dependencies we
need the ED25519 code in a separate crate that solana-ibc and ibc-rs
can both depend on.
