### PR TITLE
solana-ibc: use Solana ed25519 verifier for Tendermint client state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,8 +2048,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8057203ab04368297a31ecd5d059bec7108c069d636bcfc9ab20e82d89b480b8"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2062,8 +2061,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e931737b69129ae417598fe29eace3e41a9ce32b8649abe3937495973e5843f"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2073,8 +2071,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2019d3a6adf6b333c55630f52ca71ad8f61702ca1cf291aaf5ee40b7c6c27ba2"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "base64 0.21.7",
  "borsh 0.10.3",
@@ -2094,8 +2091,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2595e4cc14828a4141a28b86777040d8bfbabea43838a425137202cff0ee6329"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2105,8 +2101,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0106c87ddcc619a6a5eac05da2b77287e3958f89dddf951daf9a2dfc470cb5f4"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2121,8 +2116,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5738d8c842abce233f41d3be825d01e6ee075251b509c6947d05c75477eaeec"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2131,8 +2125,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ef4eefb4fd88167335fee4d212b1ff2fa4dd4e4ce87a58bda1798be1d128ac"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-client-tendermint-types",
  "ibc-core-client",
@@ -2148,8 +2141,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a224a98b193810e1ef86316e9a08e677eeff6f98b22b9eb9806bd993d3753a"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "displaydoc",
@@ -2159,6 +2151,7 @@ dependencies = [
  "ibc-primitives",
  "ibc-proto",
  "serde",
+ "solana-ed25519",
  "tendermint",
  "tendermint-light-client-verifier",
  "tendermint-proto",
@@ -2167,8 +2160,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1ea3be7ae201c99b6589c112a253f2fb3c9ae7322d8937a7303d1fbfe76d27"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2182,8 +2174,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fef481dd1ebe5ef69ee8e095c225cb3e51cd3895096ba2884b3f5b827a6ed6"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2192,8 +2183,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aedd421bae80115f44b198bec9af45f234e1c8ff81ee9d5e7f60444d526d2b6"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2209,8 +2199,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535048a8fe64101263e35a6a4503474811e379a115db72ee449df882b0f11b45"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2225,8 +2214,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d97396ccb1840f4ea6021bbf049a4a7e30a8f5b126f00023ec44b2a48d4dabc"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2249,8 +2237,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bcf0c59eaa935fa410497a56862f28c4df68317ea556724f0d0764b6c0307e"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2263,8 +2250,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d37d88be3dc7fd82d45418c257d826244a6b29b7902c76cf9e68fd61f1e9173"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2280,8 +2266,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb717b1296e6cda0990346ba5203fadd043d5159d7d7173b3765f72f263c29db"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2301,8 +2286,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10ff34bf57bf4bc668b55208dbfdf312d7907adc6a0e39da2377883f12efada"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2320,8 +2304,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de7f4f1e78e9ed5a63b09b1405f42713f3d076ba5e7889ec31a520cad4970344"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -2333,8 +2316,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230d7f547e121147d136c563ae71707a9e3477a9bc1bc6c1dc29051e1408a381"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2355,8 +2337,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60a2d072d8f7d8d64503bbf3fb69ffcd973b92667af053617a36682fadddea5"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2371,8 +2352,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fae38340bffa42a74563a12703c994515cca4bab755a0c83089c18c3c1e481a"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2396,8 +2376,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abaa0e2143855d12c19e814dab72a5e28daf5e31780afb1302e983614b248668"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2415,8 +2394,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3c792be21a340e42344e5bede1695c2d21d62abcc21bbfc7662b5950ffe8d4"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2440,8 +2418,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c25ce3082e036836d60aea3cc24f46dfb248d7718516a9a48e1feb466ce10c1"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2456,8 +2433,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c261fb7e9a7de7daafb6a38cb9abdce6e912230e30246eb2ef1bb5db32ba10f"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2471,8 +2447,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3b37bc4c11fdc60a328488f4be205106666edda20a4080484d599a8b0978d2"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2491,8 +2466,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de1e69ff9d7d6094b720a36bb26fc8078b5e1b0e216e2d0a92f602e6dc8016e"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2502,8 +2476,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5524046e645bdfbd96ef932c8ceab6bb2391dc31dee626e274d13e7ac25ec2"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2542,8 +2515,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3443c6ccc7551266dce6e842aa10c472bf73d7cc0c3140aafc55c942e85f530a"
+source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
 dependencies = [
  "derive_more",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,48 @@ curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dal
 # refer to a commit on master.
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
 tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
+
+# We need to patch ibc-client-tendermint to support custom verifier.
+# Unfortunately, because that crate refers to other ibc-rs crates by
+# path, we then need to patch all the other crates in ibc-rs as well.
+#cw-check = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-app-nft-transfer = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-app-nft-transfer-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-app-transfer = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-app-transfer-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-apps = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-client-tendermint = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-client-tendermint-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-client-wasm-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-clients = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-channel = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-channel-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-client = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-client-context = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-client-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-commitment-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-connection = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-connection-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-handler = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-handler-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-host = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-host-cosmos = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-host-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-router = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-core-router-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+#ibc-data-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-derive = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-primitives = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+#ibc-query = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+ibc-testkit = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+#no-std-check = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
+
+# We need to further instruct Crate to take solana-ed25519 from this
+# directory rather than from git when ibc-rs uses it.  Otherwise we
+# would end up with two versions of solana-ed25519: we would use ours
+# (from the checked out directory) and ibc-rs would use one from the
+# repository.
+[patch."https://github.com/ComposableFi/emulated-light-client/"]
+solana-ed25519 = { path = "solana/ed25519" }

--- a/solana/ed25519/src/lib.rs
+++ b/solana/ed25519/src/lib.rs
@@ -12,6 +12,7 @@ use solana_program::{ed25519_program, sysvar};
     PartialOrd,
     Ord,
     Hash,
+    bytemuck::TransparentWrapper,
     derive_more::From,
     derive_more::Into,
 )]
@@ -19,10 +20,19 @@ use solana_program::{ed25519_program, sysvar};
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[repr(transparent)]
 pub struct PubKey([u8; 32]);
 
 impl PubKey {
     pub const LENGTH: usize = 32;
+}
+
+impl<'a> TryFrom<&'a [u8]> for &'a PubKey {
+    type Error = core::array::TryFromSliceError;
+    fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+        <&[u8; PubKey::LENGTH]>::try_from(bytes)
+            .map(bytemuck::TransparentWrapper::wrap_ref)
+    }
 }
 
 impl From<solana_program::pubkey::Pubkey> for PubKey {
@@ -58,6 +68,7 @@ impl blockchain::PubKey for PubKey {
     PartialOrd,
     Ord,
     Hash,
+    bytemuck::TransparentWrapper,
     derive_more::From,
     derive_more::Into,
 )]
@@ -65,10 +76,19 @@ impl blockchain::PubKey for PubKey {
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[repr(transparent)]
 pub struct Signature([u8; 64]);
 
 impl Signature {
     pub const LENGTH: usize = 64;
+}
+
+impl<'a> TryFrom<&'a [u8]> for &'a Signature {
+    type Error = core::array::TryFromSliceError;
+    fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+        <&[u8; Signature::LENGTH]>::try_from(bytes)
+            .map(bytemuck::TransparentWrapper::wrap_ref)
+    }
 }
 
 /// Implementation for validating Ed25519 signatures.

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -21,7 +21,7 @@ no-log-ix-name = []
 anchor-lang.workspace = true
 anchor-spl.workspace = true
 base64.workspace = true
-bytemuck = { workspace = true, features = ["must_cast"] }
+bytemuck = { workspace = true, features = ["must_cast", "zeroable_atomics"] }
 derive_more.workspace = true
 ibc-testkit = { workspace = true, optional = true }
 ibc.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/allocator.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/allocator.rs
@@ -1,10 +1,105 @@
+//! Defines custom allocator (when necessary) and wraps access to global state.
+//!
+//! This module serves two purposes.  First of all, when running on Solana, it
+//! defines a custom allocator which can handle heap sizes larger than 32 KiB.
+//! Default allocator defined by solana_program assumes heap is 32 KiB.  We’re
+//! replacing it with a custom one which can handle heaps of arbitrary size.
+//!
+//! Second of all, Solana doesn’t allow mutable global variables.  We’re working
+//! around that by allocating global state on the heap.  This is done by the
+//! custom allocator.  This module than provides a [`global`] function which
+//! returns `Global` type with all the available global variables.  While the
+//! returned reference is static, the variables may use inner mutability.
+
+use alloc::boxed::Box;
+use core::sync::atomic::{AtomicPtr, Ordering};
+
+use solana_ed25519::Verifier;
+
+/// Mutable global state.
+#[derive(bytemuck::Zeroable)]
+pub(crate) struct Global {
+    verifier_ptr: AtomicPtr<Verifier>,
+}
+
+impl Global {
+    /// Returns global verifier, if initialised.
+    pub fn verifier(&self) -> Option<&'static Verifier> {
+        let ptr = self.verifier_ptr.load(Ordering::SeqCst);
+        // SAFETY: We’ve initialised the pointer from a leaked 'static
+        // reference in set_verifier.  It’s thus safe to dereference it.
+        unsafe { ptr.as_ref() }
+    }
+
+    /// Takes ownership of the verifier and sets it as the global verifier.
+    ///
+    /// This operation leaks memory thus it shouldn’t be called multiple times.
+    /// It’s intended to be called at most once at the start of the program.
+    pub fn set_verifier(&self, verifier: Verifier) {
+        // Allocate the verifier on heap so it has fixed address and leak so it
+        // has 'static lifetime.
+        let verifier = Box::leak(Box::new(verifier));
+        self.verifier_ptr.store(verifier, Ordering::SeqCst);
+    }
+}
+
+pub(crate) use imp::global;
+
 #[cfg(all(
     target_os = "solana",
     feature = "custom-heap",
     not(feature = "no-entrypoint"),
+    not(test),
 ))]
-#[global_allocator]
-static ALLOCATOR: solana_allocator::BumpAllocator<()> = {
-    // SAFETY: We’re only instantiating the BumpAllocator once.
-    unsafe { solana_allocator::BumpAllocator::new() }
-};
+mod imp {
+    #[global_allocator]
+    static ALLOCATOR: solana_allocator::BumpAllocator<super::Global> = {
+        // SAFETY: We’re only instantiating the BumpAllocator once and setting
+        // it as global allocator.
+        unsafe { solana_allocator::BumpAllocator::new() }
+    };
+
+    pub(crate) fn global() -> &'static super::Global { ALLOCATOR.global() }
+}
+
+#[cfg(any(
+    not(target_os = "solana"),
+    not(feature = "custom-heap"),
+    feature = "no-entrypoint",
+    test,
+))]
+mod imp {
+    static GLOBAL: super::Global = super::Global {
+        verifier_ptr: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),
+    };
+
+    pub(crate) fn global() -> &'static super::Global { &GLOBAL }
+}
+
+/// Returns global verifier if one has been set.
+///
+/// Together with [`Global::set_verifier`] this function provides an interface
+/// analogous to a mutable global.
+///
+/// Returns `*const Verifier` pointer cast to `*const ()`.  Caller should cast
+/// the result back to `*const Verifier` (or better yet `*mut Verifier` and then
+/// use `NonNull`).  The pointer conversion is used to avoid [`Verifier`] having
+/// to be FFI-safe.
+///
+/// Due to symbol resolution and cyclical crate dependency shenanigans, this is
+/// defined as C function so that it can be accessed from other crates.
+/// Client of this interface should declare an extern function and use that to
+/// get access to Verifier.
+///
+/// # Safety
+///
+/// The function is always safe to run.  If it returns non-null pointer, the
+/// pointer is safe to convert to `*const Verifier` and dereferenced.
+#[no_mangle]
+#[allow(dead_code)]
+pub extern "C" fn get_global_ed25519_verifier() -> *const () {
+    match global().verifier() {
+        None => core::ptr::null(),
+        Some(verifier) => verifier as *const Verifier as *const (),
+    }
+}

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -465,6 +465,10 @@ pub struct Deliver<'info> {
     associated_token_program: Option<Program<'info, AssociatedToken>>,
     token_program: Option<Program<'info, Token>>,
     system_program: Program<'info, System>,
+
+    #[account(address = solana_program::sysvar::instructions::ID)]
+    /// CHECK:
+    ix_sysvar: Option<AccountInfo<'info>>,
 }
 
 #[derive(Accounts)]

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -166,6 +166,13 @@ pub mod solana_ibc {
     ) -> Result<()> {
         let mut store = storage::from_ctx!(ctx, with accounts);
         let mut router = store.clone();
+
+        if let Some(ix_sysvar) = ctx.accounts.ix_sysvar.as_ref() {
+            if let Ok(verifier) = solana_ed25519::Verifier::new(ix_sysvar) {
+                global().set_verifier(verifier)
+            }
+        }
+
         ::ibc::core::entrypoint::dispatch(&mut store, &mut router, message)
             .map_err(error::Error::ContextError)
             .map_err(move |err| error!((&err)))

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -41,6 +41,9 @@ mod tests;
 mod transfer;
 mod validation_context;
 
+#[allow(unused_imports)]
+pub(crate) use allocator::global;
+
 #[anchor_lang::program]
 pub mod solana_ibc {
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -168,7 +168,7 @@ pub mod solana_ibc {
         let mut router = store.clone();
 
         if let Some((last, rest)) = ctx.remaining_accounts.split_last() {
-            if let Some(verifier) = solana_ed25519::Verifier::new(last).ok() {
+            if let Ok(verifier) = solana_ed25519::Verifier::new(last) {
                 global().set_verifier(verifier);
                 ctx.remaining_accounts = rest;
             }

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -166,7 +166,6 @@ fn anchor_test_deliver() -> Result<()> {
             receiver_token_account: None,
             associated_token_program: None,
             token_program: None,
-            ix_sysvar: None,
         })
         .args(instruction::Deliver { message })
         .payer(authority.clone())
@@ -229,7 +228,6 @@ fn anchor_test_deliver() -> Result<()> {
             receiver_token_account: None,
             associated_token_program: None,
             token_program: None,
-            ix_sysvar: None,
         })
         .args(instruction::Deliver { message })
         .payer(authority.clone())
@@ -505,7 +503,6 @@ fn anchor_test_deliver() -> Result<()> {
             receiver_token_account: Some(receiver_token_address),
             associated_token_program: Some(anchor_spl::associated_token::ID),
             token_program: Some(anchor_spl::token::ID),
-            ix_sysvar: None,
         })
         .args(instruction::Deliver { message })
         .payer(authority.clone())
@@ -656,7 +653,6 @@ fn anchor_test_deliver() -> Result<()> {
             receiver_token_account: Some(receiver_native_token_address),
             associated_token_program: Some(anchor_spl::associated_token::ID),
             token_program: Some(anchor_spl::token::ID),
-            ix_sysvar: None,
         })
         .args(instruction::Deliver { message })
         .payer(authority.clone())

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -166,6 +166,7 @@ fn anchor_test_deliver() -> Result<()> {
             receiver_token_account: None,
             associated_token_program: None,
             token_program: None,
+            ix_sysvar: None,
         })
         .args(instruction::Deliver { message })
         .payer(authority.clone())
@@ -228,6 +229,7 @@ fn anchor_test_deliver() -> Result<()> {
             receiver_token_account: None,
             associated_token_program: None,
             token_program: None,
+            ix_sysvar: None,
         })
         .args(instruction::Deliver { message })
         .payer(authority.clone())
@@ -503,6 +505,7 @@ fn anchor_test_deliver() -> Result<()> {
             receiver_token_account: Some(receiver_token_address),
             associated_token_program: Some(anchor_spl::associated_token::ID),
             token_program: Some(anchor_spl::token::ID),
+            ix_sysvar: None,
         })
         .args(instruction::Deliver { message })
         .payer(authority.clone())
@@ -653,6 +656,7 @@ fn anchor_test_deliver() -> Result<()> {
             receiver_token_account: Some(receiver_native_token_address),
             associated_token_program: Some(anchor_spl::associated_token::ID),
             token_program: Some(anchor_spl::token::ID),
+            ix_sysvar: None,
         })
         .args(instruction::Deliver { message })
         .payer(authority.clone())


### PR DESCRIPTION
Take advantage of the support for global state in the allocator and
use it for the verifier state.  We’re using that state in patched
Tendermint client implementation to verify signatures there.

At the moment, because of the limitations of Solana we can verify less
than 10 signatures, but this change at least demonstrates the approach
we can take to have Tendermint client state updates implemented.
