### PR TITLE
Unpin nightly Rust version

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,12 +24,7 @@ jobs:
         id: install-rust
         uses: dtolnay/rust-toolchain@master
         with:
-          # Pin nightly to specific version to avoid ahash breakage.
-          # See https://github.com/tkaitchuck/aHash/issues/200
-          # TODO(mina86): Unpin once situation with ahash is resolved.
-          # Hopefully we won’t need to patch.
-          #toolchain: nightly
-          toolchain: nightly-2024-02-05
+          toolchain: nightly
           components: clippy rustfmt miri
 
       - name: Install Protoc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.11",
  "once_cell",
@@ -1950,7 +1950,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]


### PR DESCRIPTION
ahash 0.7.8 has been released with fix for the build failure on nightly Rust so unpin the compiler version and instead update ahash dependency.