### PR TITLE
write-account: add support for creating and resizing the Write account

### DIFF
--- a/solana/write-account/src/lib.rs
+++ b/solana/write-account/src/lib.rs
@@ -87,8 +87,8 @@ fn handle_write(
     if !payer.is_writable || !write_account.is_writable {
         return Err(ProgramError::InvalidAccountData);
     }
-    if let Some(ref system) = system {
-        if !system_program::check_id(&system.key) {
+    if let Some(system) = system {
+        if !system_program::check_id(system.key) {
             return Err(ProgramError::InvalidAccountData);
         }
     }
@@ -162,8 +162,8 @@ fn setup_write_account<'info>(
         let _ = system.ok_or(ProgramError::NotEnoughAccountKeys)?;
         let lamports = get_required_lamports()?;
         let instruction = solana_program::system_instruction::create_account(
-            &payer.key,
-            &write_account.key,
+            payer.key,
+            write_account.key,
             lamports,
             size as u64,
             program_id,
@@ -207,7 +207,7 @@ fn read<const N: usize, T>(
     bytes: &mut &[u8],
     convert: impl FnOnce([u8; N]) -> T,
 ) -> Result<T> {
-    if let Some((head, tail)) = stdx::split_at::<N, u8>(*bytes) {
+    if let Some((head, tail)) = stdx::split_at::<N, u8>(bytes) {
         *bytes = tail;
         Ok(convert(*head))
     } else {
@@ -242,9 +242,4 @@ fn read_slice<'a>(bytes: &mut &'a [u8], len: usize) -> Result<&'a [u8]> {
     let (head, tail) = bytes.split_at(len);
     *bytes = tail;
     Ok(head)
-}
-
-/// Checks whether if there’s no data left.
-fn check_empty(bytes: &[u8]) -> Result {
-    bytes.is_empty().then_some(()).ok_or(ProgramError::InvalidInstructionData)
 }

--- a/solana/write-account/src/lib.rs
+++ b/solana/write-account/src/lib.rs
@@ -173,7 +173,7 @@ fn setup_write_account<'info>(
     } else if write_account.data_len() < size {
         // If size is less than required, reallocate.  We may need to transfer
         // more lamports to keep the account as rent-exempt.
-        let system = system.ok_or(ProgramError::NotEnoughAccountKeys)?;
+        let _ = system.ok_or(ProgramError::NotEnoughAccountKeys)?;
         let lamports = get_required_lamports()?.saturating_sub(lamports);
         if lamports > 0 {
             solana_program::program::invoke(
@@ -182,7 +182,7 @@ fn setup_write_account<'info>(
                     write_account.key,
                     lamports,
                 ),
-                &[payer.clone(), write_account.clone(), system.clone()],
+                &[payer.clone(), write_account.clone()],
             )?;
         }
         write_account.realloc(size, false)

--- a/solana/write-account/src/lib.rs
+++ b/solana/write-account/src/lib.rs
@@ -1,6 +1,9 @@
-use solana_program::account_info::AccountInfo;
+use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
+use solana_program::rent::Rent;
+use solana_program::sysvar::Sysvar;
+use solana_program::{system_instruction, system_program};
 
 type Result<T = (), E = ProgramError> = core::result::Result<T, E>;
 
@@ -9,145 +12,239 @@ solana_program::entrypoint!(process_instruction);
 /// Processes the Solana instruction.
 ///
 /// The first byte of the `instruction` determines operation to perform.  Format
-/// of the instruction and required accounts depend on that.
+/// of the instruction and required accounts depend on that.  Integers are
+/// encoded using Solana’s native endianess which is little-endian.
 ///
 /// # Write
 ///
-/// Instruction with discriminant zero is Write and its format is as follows:
+/// Instruction with discriminant zero is Write.  Its format is represented by
+/// the following pseudo-Rust structure:
 ///
-/// ```ignore,text
-/// +-----+-------------+------------+
-/// | 0u8 | offset: u32 | data: [u8] |
-/// +-----+-------------+------------+
+/// ```ignore
+/// #[repr(C, packed)]
+/// struct CreateAccount {
+///     discriminant: u8,  // always 0u8,
+///     seed_len: u8,
+///     seed: [u8; seed_len],
+///     offset: u32,
+///     data: [u8],
+/// }
 /// ```
 ///
-/// It writes specified `data` at given `offset` in the first account included
-/// in the instruction.  The first account must be writable.  Returns an error
-/// if the account is too small (i.e. it’s length is less than `offset +
-/// data.len()`).
+/// It takes three accounts with the first two required:
+/// 1. Payer account (signer, writable),
+/// 2. Write account (writable) and
+/// 3. System program (optional; should be `11111111111111111111111111111111`).
 ///
-/// # Copy
+/// It writes `data` into a Write account at given offset.  The Write account is
+/// a PDA owned by this program constructed with seeds `[payer.key, seed]`.
+/// Since payer’s key is included in the seeds, only payer can modify the
+/// account and from this program’s point of view, payer is considered an owner
+/// of the write account.
 ///
-/// Instruction with discriminant one is Copy and its format is as follows:
+/// If the Write account doesn’t exist, creates the account.  Similarly, if it’s
+/// too small, increases its size.  Note that due to Solana’s limitations,
+/// account’s size can increase by at most 10 KiB (that includes creation of the
+/// account).
 ///
-/// ```ignore,text
-/// +-----+----------+-------------+------------+----------+
-/// | 1u8 | algo: u8 | offset: u32 | start: u32 | end: u32 |
-/// +-----+----------+-------------+------------+----------+
-/// ```
-///
-/// It expects two accounts where the first must be writeable.  It copies data
-/// from the second one to the first one at specified offset.  Returns an error
-/// if the account is too small (i.e. it’s length is less than `offset + end -
-/// start`)..
-///
-/// `algo` is a future-proof flag specifies decoding to perform when copying.
-/// Idea being that in the future the contract will be able to decompress data.
-/// Currently only one algorithm is defined:
-/// - `0` → null compression, i.e. the data is copied over verbatim.
-///
-/// Starting from the end, each argument of the instruction can be omitted.
-/// Default value for each is as follows:
-/// - `end` → read till the end of second account,
-/// - `start` → zero (read from the start of the second account),
-/// - `offset` → zero (write from the start of the first account),
-/// - `algo` → zero (null compression).
-pub fn process_instruction(
-    _program_id: &Pubkey,
+/// Note: `data` may be empty in which case the instruction will just create or
+/// resize the Write account.
+fn process_instruction(
+    program_id: &Pubkey,
     accounts: &[AccountInfo],
     mut instruction: &[u8],
 ) -> Result {
-    match instruction.unshift().ok_or(ProgramError::InvalidInstructionData)? {
-        0 => handle_write(accounts, instruction),
-        1 => handle_copy(accounts, instruction),
+    match read(&mut instruction, u8::from_le_bytes)? {
+        0 => handle_write(program_id, accounts, instruction),
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }
 
-
-/// Handles a Write operation.  See [`process_instruction`].
-fn handle_write(accounts: &[AccountInfo], mut data: &[u8]) -> Result {
-    let account = match accounts {
-        [account, ..] if account.is_writable => Ok(account),
-        [_, ..] => Err(ProgramError::InvalidAccountData),
-        _ => Err(ProgramError::NotEnoughAccountKeys),
-    }?;
-
-    let offset = data
-        .unshift_n::<4>()
-        .ok_or(ProgramError::InvalidInstructionData)
-        .and_then(usize_from_bytes)?;
-    let end = offset
+/// Handles Write operation.  See [`process_instruction`].
+fn handle_write(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    mut data: &[u8],
+) -> Result {
+    // Parse instruction data
+    let seed_len = read_usize(&mut data, u8::from_le_bytes)?;
+    let seed = read_slice(&mut data, seed_len)?;
+    let start = read_usize(&mut data, u32::from_le_bytes)?;
+    let end = start
         .checked_add(data.len())
         .ok_or(ProgramError::ArithmeticOverflow)?;
 
-    account
+    // Get accounts
+    let accounts = &mut accounts.iter();
+    let payer = next_account_info(accounts)?;
+    let write_account = next_account_info(accounts)?;
+    let system = accounts.next();
+
+    // Verify accounts
+    if !payer.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if !payer.is_writable || !write_account.is_writable {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    if let Some(ref system) = system {
+        if !system_program::check_id(&system.key) {
+            return Err(ProgramError::InvalidAccountData);
+        }
+    }
+
+    // Initialise write account as necessary
+    setup_write_account(program_id, payer, write_account, seed, end, system)?;
+
+    // Write the data.  Once we reached this point, we should never fail.
+    // try_borrow_mut should succeed since no one else is borrowing
+    // write_account’s data and get_mut should succeed since setup_write_account
+    // made sure account is large enough.
+    write_account
         .try_borrow_mut_data()?
-        .get_mut(offset..end)
+        .get_mut(start..end)
         .ok_or(ProgramError::AccountDataTooSmall)?
         .copy_from_slice(data);
     Ok(())
 }
 
-
-/// Handles an Copy operation.  See [`process_instruction`].
-fn handle_copy(accounts: &[AccountInfo], mut data: &[u8]) -> Result {
-    let (wr, rd) = match accounts {
-        [wr, rd, ..] if wr.is_writable => Ok((wr, rd)),
-        [_, _, ..] => Err(ProgramError::InvalidAccountData),
-        _ => Err(ProgramError::NotEnoughAccountKeys),
-    }?;
-
-    let algo = data.unshift().map_or(0, |n| *n);
-    let offset = data.unshift_n().map_or(Ok(0), usize_from_bytes)?;
-    let start = data.unshift_n().map_or(Ok(0), usize_from_bytes)?;
-    let end = data.unshift_n().map(usize_from_bytes).transpose()?;
-    if !data.is_empty() {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let mut dst = wr.try_borrow_mut_data()?;
-    let dst = dst.get_mut(offset..).ok_or(ProgramError::AccountDataTooSmall)?;
-    let end = end.map_or_else(|| rd.try_data_len(), Ok)?;
-    let src = rd.try_borrow_data()?;
-    let src = src.get(start..end).ok_or(ProgramError::AccountDataTooSmall)?;
-
-    match algo {
-        0 => handle_copy_null(dst, src),
-        _ => Err(ProgramError::InvalidInstructionData),
-    }
-}
-
-fn handle_copy_null(dst: &mut [u8], src: &[u8]) -> Result {
-    dst.get_mut(..src.len())
-        .map(|dst| dst.copy_from_slice(src))
-        .ok_or(ProgramError::AccountDataTooSmall)
-}
-
-
-/// Decode 32-bit unsigned little-endian value and returns it as `usize`.
+/// Verifies Write account’s address.
 ///
-/// Returns an error if the value overflows `usize`.  Only possible on
-/// 16-bit architectures so in practice on Solana this never fails.
-fn usize_from_bytes(bytes: &[u8; 4]) -> Result<usize> {
-    usize::try_from(u32::from_le_bytes(*bytes))
-        .map_err(|_| ProgramError::ArithmeticOverflow)
+/// If account’s address is correct, returns bump.
+fn check_write_id(
+    program_id: &Pubkey,
+    payer: &AccountInfo,
+    write_account: &AccountInfo,
+    seed: &[u8],
+) -> Result<u8> {
+    // Check that key matches expected PDA address
+    let (pda, bump) =
+        Pubkey::find_program_address(&[payer.key.as_ref(), seed], program_id);
+    if &pda == write_account.key {
+        Ok(bump)
+    } else {
+        Err(ProgramError::InvalidSeeds)
+    }
+}
+
+/// Verifies and sets up the write account.
+///
+/// Firstly, checks that the write accounts address corresponds to the PDA which
+/// we’d get by using `[payer.key, seed]` as seeds.  If it doesn’t, returns
+/// `InvalidSeeds` error.
+///
+/// Secondly, if the account doesn’t exist, creates it with size of `size`.
+/// Note that due to Solana limitations, `size` may be at most 10 KiB in this
+/// case (see [`solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE`]).
+///
+/// Otherwise, checks if account’s size it at least `size`.  If it isn’t,
+/// resizes the account (see [`AccountInfo::realloc`]).  Again, due to Solana’s
+/// limitations, account may grow by at most 10 KiB.  To remain rent exempt,
+/// this may lead to lamports being transferred from `payer` to the
+/// `write_account`.
+///
+fn setup_write_account<'info>(
+    program_id: &Pubkey,
+    payer: &AccountInfo<'info>,
+    write_account: &AccountInfo<'info>,
+    seed: &[u8],
+    size: usize,
+    system: Option<&AccountInfo<'info>>,
+) -> Result {
+    let bump = check_write_id(program_id, payer, write_account, seed)?;
+
+    let lamports = write_account.lamports();
+    let get_required_lamports =
+        || Rent::get().map(|rent| rent.minimum_balance(size));
+
+    // If the account has zero lamports it needs to be created first.
+    if lamports == 0 {
+        let _ = system.ok_or(ProgramError::NotEnoughAccountKeys)?;
+        let lamports = get_required_lamports()?;
+        let instruction = solana_program::system_instruction::create_account(
+            &payer.key,
+            &write_account.key,
+            lamports,
+            size as u64,
+            program_id,
+        );
+        return solana_program::program::invoke_signed(
+            &instruction,
+            &[payer.clone(), write_account.clone()],
+            &[&[payer.key.as_ref(), seed, core::slice::from_ref(&bump)]],
+        );
+    }
+
+    // If size is less than required, reallocate.
+    if write_account.data_len() < size {
+        let system = system.ok_or(ProgramError::NotEnoughAccountKeys)?;
+
+        // If we need more lamports for rent exempt status, transfer them first.
+        let lamports = get_required_lamports()?.saturating_sub(lamports);
+        if lamports > 0 {
+            solana_program::program::invoke(
+                &system_instruction::transfer(
+                    payer.key,
+                    write_account.key,
+                    lamports,
+                ),
+                &[payer.clone(), write_account.clone(), system.clone()],
+            )?;
+        }
+
+        return write_account.realloc(size, false);
+    }
+
+    // Account exists and has correct size.
+    Ok(())
 }
 
 
-trait Unshift<T> {
-    /// Pops first element in the array shortening it.
-    fn unshift(&mut self) -> Option<&T> {
-        self.unshift_n::<1>().map(|car| &car[0])
+/// Reads given object from the start of the slice advancing it.
+///
+/// Returns an error if slice is too short.
+fn read<const N: usize, T>(
+    bytes: &mut &[u8],
+    convert: impl FnOnce([u8; N]) -> T,
+) -> Result<T> {
+    if let Some((head, tail)) = stdx::split_at::<N, u8>(*bytes) {
+        *bytes = tail;
+        Ok(convert(*head))
+    } else {
+        Err(ProgramError::InvalidInstructionData)
     }
-    /// Pops first `N` elements in the array shortening it.
-    fn unshift_n<const N: usize>(&mut self) -> Option<&[T; N]>;
 }
 
-impl<T> Unshift<T> for &[T] {
-    fn unshift_n<const N: usize>(&mut self) -> Option<&[T; N]> {
-        let (head, tail) = stdx::split_at(self)?;
-        *self = tail;
-        Some(head)
+/// Reads integer of type `T` from start of the slice and converts it to
+/// `usize`.
+///
+/// Returns an error if slice is too short or the read value doesn’t fit
+/// `usize`.  Note that the latter can only happen if `T` is signed or
+/// `sizeof(T) > sizeof(usize)`.
+///
+/// Note that other than with [`Self::read`], if this returns an error it’s
+/// unspecified whether the slice has advanced or not.
+fn read_usize<const N: usize, T: TryInto<usize>>(
+    bytes: &mut &[u8],
+    convert: impl FnOnce([u8; N]) -> T,
+) -> Result<usize> {
+    let size = read(bytes, convert)?;
+    size.try_into().map_err(|_| ProgramError::ArithmeticOverflow)
+}
+
+/// Advances slice by given length and returns slice view of skipped bytes.
+///
+/// Returns an error if slice is too short.
+fn read_slice<'a>(bytes: &mut &'a [u8], len: usize) -> Result<&'a [u8]> {
+    if bytes.len() < len {
+        return Err(ProgramError::InvalidInstructionData);
     }
+    let (head, tail) = bytes.split_at(len);
+    *bytes = tail;
+    Ok(head)
+}
+
+/// Checks whether if there’s no data left.
+fn check_empty(bytes: &[u8]) -> Result {
+    bytes.is_empty().then_some(()).ok_or(ProgramError::InvalidInstructionData)
 }


### PR DESCRIPTION
Since the Write account needs to be a PDA, add support for creating
and resizing it as necessary.  We’re potentially missing Truncate and
Free instructions but we can live without them for the time being.

Furthermore, remove the Copy instruction.  We don’t use it currently
and having support for it while details of creation and resizing of
the account aren’t yet established create unnecessary maintenance
burden.
