### PR TITLE
solana-ibc: support reading instruction data from account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,8 +276,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9101b84702fed2ea57bd22992f75065da5648017135b844283a2f6d74f27825"
+source = "git+https://github.com/mina86/anchor?branch=custom-entrypoint#788c61c2d72aad374457d7619d8fe37d6ac2c0e9"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,9 @@ curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dal
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
 tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
 
+# Adds support for custom-entrypoint feature
+anchor-syn = { git = "https://github.com/mina86/anchor", branch = "custom-entrypoint" }
+
 # We need to patch ibc-client-tendermint to support custom verifier.
 # Unfortunately, because that crate refers to other ibc-rs crates by
 # path, we then need to patch all the other crates in ibc-rs as well.

--- a/solana-test.sh
+++ b/solana-test.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 set -eux
+solana config set --url http://127.0.0.1:8899
+cd solana/write-account
+cargo build-sbf
+cd ../..
+solana program deploy target/deploy/write.so
 cargo test  --lib -- --nocapture --include-ignored ::anchor
 find solana/restaking/tests/ -name '*.ts' \
      -exec yarn run ts-mocha -p ./tsconfig.json -t 1000000 {} +

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -9,9 +9,10 @@ crate-type = ["cdylib", "lib"]
 name = "solana_ibc"
 
 [features]
-default = ["custom-heap"]
+default = ["custom-entrypoint", "custom-heap"]
 cpi = ["no-entrypoint"]
 custom-heap = ["solana-allocator"]
+custom-entrypoint = ["custom-heap"]
 mocks = ["ibc-testkit"]
 no-entrypoint = []
 no-idl = []

--- a/solana/solana-ibc/programs/solana-ibc/src/allocator.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/allocator.rs
@@ -76,7 +76,7 @@ mod imp {
 
     // Make sure we’re not using AtomicPtr when compiling for CPI.  I’m not
     // entirely sure why this is a problem, but just having AtomicPtr::store in
-    // the code (whether it’s executed or not) causes CPI to fail.
+    // the code (whether it’s executed or not) causes CPI builds to fail.
     #[cfg(not(all(target_os = "solana", feature = "cpi")))]
     static VERIFIER: core::sync::atomic::AtomicPtr<Verifier> =
         core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
@@ -101,7 +101,7 @@ mod imp {
             core::ptr::null()
         }
 
-        pub(super) fn set_verifier_ptr(&self, verifier: *const Verifier) {
+        pub(super) fn set_verifier_ptr(&self, _verifier: *const Verifier) {
             panic!();
         }
     }

--- a/solana/solana-ibc/programs/solana-ibc/src/ix_data_account.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ix_data_account.rs
@@ -1,0 +1,128 @@
+//! Support for calling Solana IBC smart contract with instruction data read
+//! from an account.
+//!
+//! Solana limits transaction size to at most 1232 bytes.  This includes all
+//! accounts participating in the transaction as well as all the instruction
+//! data.  Unfortunately, with IBC we may need to encode instructions which
+//! don’t fit in that limit.
+//!
+//! To address this, Solana IBc smart contract supports reading instruction data
+//! from an account.  To take advantage of this feature, the smart contract
+//! needs to be called with an empty instruction data and additional account
+//! (passed as the last account) whose data is interpreted as the instruction.
+//!
+//! The account data must be a length-prefixed slice of bytes.  In other words,
+//! borsh-serialised `Vec<u8>`.  The account may contain trailing bytes which
+//! are ignored.
+//!
+//! This module provides types to help use this feature of the Solana IBC
+//! contract.  [`Accounts`] is used to add the account with instruction data to
+//! an instruction and [`Instruction`] constructs an empty instruction data to
+//! call the contract with.
+//!
+//! For example, consider client invocation such as:
+//!
+//! ```ignore
+//! program
+//!     .request()
+//!     .accounts(solana_ibc::accounts::Foo { /* ... */ })
+//!     .args(solana_ibc::instruction::Foo { /* ... */ })
+//!     .payer(payer.clone())
+//!     .signer(&*payer)
+//!     .send_with_spinner_and_config(/* ... */)?;
+//! ```
+//!
+//! To take advantage of the instruction data account feature, first the
+//! instruction needs to be serialised and stored in an account.  Let’s say that
+//! account’s pubkey is `ix_data_account`.  With that, the invocation becomes:
+//!
+//! ```ignore
+//! let mut instruction_data = instruction::Foo { ... }.data();
+//! let instruction_len = instruction_data.len() as u32;
+//! instruction_data.splice(..0, instruction_len.to_le_bytes());
+//!
+//! /* ... write instruction_data to account ix_data_account ... */
+//!
+//! program
+//!     .request()
+//!     .accounts(solana_ibc::ix_data_account::Accounts::new(
+//!         solana_ibc::accounts::Foo { /* ... */ },
+//!         ix_data_account,
+//!     ))
+//!     .args(solana_ibc::ix_data_account::Instruction)
+//!     .payer(payer.clone())
+//!     .signer(&*payer)
+//!     .send_with_spinner_and_config(/* ... */)?;
+//! ```
+use anchor_lang::prelude::borsh;
+use anchor_lang::solana_program;
+use borsh::maybestd::io;
+use solana_program::account_info::AccountInfo;
+use solana_program::instruction::AccountMeta;
+use solana_program::program_error::ProgramError;
+use solana_program::pubkey::Pubkey;
+
+/// Wrapper for request builder which adds an instruction data account to a list
+/// of accounts.
+///
+/// Together with [`Instruction`] this allows calling the smart program with
+/// instruction data read from an account.  This is used when the instruction
+/// data is too long to fit in a single transaction.
+pub struct Accounts<T>(T, Pubkey);
+
+impl<T> Accounts<T> {
+    pub fn new(accounts: T, ix_data: Pubkey) -> Self { Self(accounts, ix_data) }
+}
+
+/// An ‘instruction’ which instructs smart contract to read the data from an
+/// account.
+///
+/// This type must be used with `anchor_client::RequestBuilder::args` method
+/// only.  Even though it implements [`anchor_lang::Discriminator`], the
+/// implementation isn’t well-behaved.  In particular, calling `discriminator`
+/// method panics.
+pub struct Instruction;
+
+impl<T: anchor_lang::ToAccountMetas> anchor_lang::ToAccountMetas
+    for Accounts<T>
+{
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        let mut accounts = self.0.to_account_metas(is_signer);
+        accounts.push(AccountMeta {
+            pubkey: self.1,
+            is_signer: false,
+            is_writable: false,
+        });
+        accounts
+    }
+}
+
+/// Interprets data in the last account as instruction data.
+#[allow(dead_code)]
+pub(crate) fn get_ix_data<'a>(
+    accounts: &mut Vec<AccountInfo<'a>>,
+) -> Result<&'a [u8], ProgramError> {
+    let account = accounts.pop().ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let data = alloc::rc::Rc::try_unwrap(account.data).ok().unwrap();
+    let (len, data) = stdx::split_at::<4, _>(data.into_inner())
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let len = usize::try_from(u32::from_le_bytes(*len))
+        .map_err(|_| ProgramError::ArithmeticOverflow)?;
+    data.get(..len).ok_or(ProgramError::InvalidInstructionData)
+}
+
+impl anchor_lang::Discriminator for Instruction {
+    const DISCRIMINATOR: [u8; 8] = [0; 8];
+    fn discriminator() -> [u8; 8] { panic!() }
+}
+
+impl borsh::BorshSerialize for Instruction {
+    fn serialize<W: io::Write>(&self, _writer: &mut W) -> io::Result<()> {
+        Ok(())
+    }
+    fn try_to_vec(&self) -> io::Result<Vec<u8>> { Ok(Vec::new()) }
+}
+
+impl anchor_lang::InstructionData for Instruction {
+    fn data(&self) -> Vec<u8> { Vec::new() }
+}

--- a/solana/solana-ibc/programs/solana-ibc/src/ix_data_account.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ix_data_account.rs
@@ -6,7 +6,7 @@
 //! data.  Unfortunately, with IBC we may need to encode instructions which
 //! don’t fit in that limit.
 //!
-//! To address this, Solana IBc smart contract supports reading instruction data
+//! To address this, Solana IBC smart contract supports reading instruction data
 //! from an account.  To take advantage of this feature, the smart contract
 //! needs to be called with an empty instruction data and additional account
 //! (passed as the last account) whose data is interpreted as the instruction.

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -13,7 +13,9 @@ use anchor_client::solana_sdk::pubkey::Pubkey;
 use anchor_client::solana_sdk::signature::{
     read_keypair_file, Keypair, Signature, Signer,
 };
+use anchor_client::solana_sdk::transaction::Transaction;
 use anchor_client::{Client, Cluster};
+use anchor_lang::solana_program::instruction::{AccountMeta, Instruction};
 use anchor_lang::solana_program::system_instruction::create_account;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
@@ -21,12 +23,15 @@ use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
 use spl_token::instruction::initialize_mint2;
 
 use crate::ibc::ClientStateCommon;
-use crate::storage::PrivateStorage;
-use crate::{accounts, chain, ibc, instruction, CryptoHash, MINT_ESCROW_SEED};
+use crate::{
+    accounts, chain, ibc, instruction, ix_data_account, CryptoHash,
+    MINT_ESCROW_SEED,
+};
 
 const IBC_TRIE_PREFIX: &[u8] = b"ibc/";
 pub const STAKING_PROGRAM_ID: &str =
     "8n3FHwYxFgQCQc2FNFkwDUf9mcqupxXcCvgfHbApMLv3";
+pub const WRITE_ACCOUNT_SEED: &[u8] = b"write";
 // const BASE_DENOM: &str = "PICA";
 
 const TRANSFER_AMOUNT: u64 = 1000000;
@@ -76,6 +81,10 @@ fn anchor_test_deliver() -> Result<()> {
         CommitmentConfig::processed(),
     );
     let program = client.program(crate::ID).unwrap();
+    let write_account_program_id =
+        read_keypair_file("../../../../target/deploy/write-keypair.json")
+            .unwrap()
+            .pubkey();
 
     let sol_rpc_client = program.rpc();
     let _airdrop_signature =
@@ -90,6 +99,10 @@ fn anchor_test_deliver() -> Result<()> {
     let trie = Pubkey::find_program_address(&[crate::TRIE_SEED], &crate::ID).0;
     let chain =
         Pubkey::find_program_address(&[crate::CHAIN_SEED], &crate::ID).0;
+    let (chunk_account, chunk_account_bump) = Pubkey::find_program_address(
+        &[authority.pubkey().as_ref(), WRITE_ACCOUNT_SEED],
+        &write_account_program_id,
+    );
 
     let mint_keypair = Keypair::new();
     let native_token_mint_key = mint_keypair.pubkey();
@@ -156,23 +169,75 @@ fn anchor_test_deliver() -> Result<()> {
         ibc::ClientMsg::CreateClient,
         ibc::MsgEnvelope::Client,
     );
+
+    let mut instruction_data =
+        anchor_lang::InstructionData::data(&instruction::Deliver { message });
+    let instruction_len = instruction_data.len() as u32;
+    instruction_data.splice(..0, instruction_len.to_le_bytes());
+
+    let blockhash = sol_rpc_client.get_latest_blockhash().unwrap();
+
+    println!(
+        "\nSplitting the message into chunks and sending it to write-account \
+         program"
+    );
+    // Note: We’re using small chunks size on purpose to test the behaviour of
+    // the write account program.
+    let chunk_size = 50;
+    let mut offset: u32 = 0;
+    for chunk in instruction_data.chunks(chunk_size) {
+        let seed_len = u8::try_from(WRITE_ACCOUNT_SEED.len()).unwrap();
+        let instruction_data = [
+            /* discriminant: */ b"\0",
+            /* seed_len: */ &[seed_len][..],
+            /* seed: */ WRITE_ACCOUNT_SEED,
+            /* bump: */ &[chunk_account_bump],
+            /* offset: */ &offset.to_le_bytes()[..],
+            /* data: */ chunk,
+        ]
+        .concat();
+        let transaction = Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                write_account_program_id,
+                instruction_data.as_slice(),
+                vec![
+                    AccountMeta::new(authority.pubkey(), true),
+                    AccountMeta::new(chunk_account, false),
+                    AccountMeta::new(system_program::ID, false),
+                ],
+            )],
+            Some(&authority.pubkey()),
+            &[&*authority],
+            blockhash,
+        );
+        let sig = sol_rpc_client
+            .send_and_confirm_transaction_with_spinner(&transaction)
+            .unwrap();
+        println!("  Signature {sig}");
+        offset += chunk.len() as u32;
+    }
+
+    println!("\nCreating Mock Client");
     let sig = program
         .request()
-        .accounts(accounts::Deliver {
-            sender: authority.pubkey(),
-            receiver: None,
-            storage,
-            trie,
-            chain,
-            system_program: system_program::ID,
-            mint_authority: None,
-            token_mint: None,
-            escrow_account: None,
-            receiver_token_account: None,
-            associated_token_program: None,
-            token_program: None,
-        })
-        .args(instruction::Deliver { message })
+        .accounts(ix_data_account::Accounts::new(
+            accounts::Deliver {
+                sender: authority.pubkey(),
+                receiver: None,
+                storage,
+                trie,
+                chain,
+                system_program: system_program::ID,
+                mint_authority: None,
+                token_mint: None,
+                escrow_account: None,
+                receiver_token_account: None,
+                associated_token_program: None,
+                token_program: None,
+            },
+            chunk_account,
+        ))
+        .args(ix_data_account::Instruction)
         .payer(authority.clone())
         .signer(&*authority)
         .send_with_spinner_and_config(RpcSendTransactionConfig {
@@ -180,15 +245,6 @@ fn anchor_test_deliver() -> Result<()> {
             ..RpcSendTransactionConfig::default()
         })?;
     println!("  Signature: {sig}");
-
-    // Retrieve and validate state
-    let solana_ibc_storage_account: PrivateStorage =
-        program.account(storage).unwrap();
-
-    println!(
-        "  This is solana storage account {:?}",
-        solana_ibc_storage_account
-    );
 
     /*
      * Create New Mock Connection Open Init


### PR DESCRIPTION
Introduce a mechanism by which clients of Solana IBC can store
instruction data inside of an account and then instruct Solana IBC to
read instruction data from said account rather than the Solana
transaction.

This is necessary because Solana limits transactions to roughly 1.2 kB
which includes full transaction including list of accounts, all the
instructions etc.  The end result is that some of the Solana IBC
instructions simply don’t fit.

Co-authored-by: Dhruv D Jain <dhruv@iamsizzling.com>