### PR TITLE
solana-ibc: define missing custom_panic handler

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -76,6 +76,9 @@ pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
     }
 }
 
+#[cfg(not(feature = "no-entrypoint"))]
+solana_program::custom_panic_default!();
+
 #[anchor_lang::program]
 pub mod solana_ibc {
 


### PR DESCRIPTION
With the switch to custom entrypoint we also need to provide custom
panic handler.  Without it deploying the contract fails with the
following:

> Error: ELF error: ELF error: Unresolved symbol (custom_panic) at
> instruction #265306 (ELF file offset 0x2061e8)
>
> There was a problem deploying: Output { status:
> ExitStatus(unix_wait_status(256)), stdout: "", stderr: "" }.
