### PR TITLE
solana-ibc: display pubkey using base58 instead of base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4633,6 +4633,7 @@ dependencies = [
  "base64 0.21.7",
  "blockchain",
  "borsh 0.10.3",
+ "bs58 0.5.0",
  "bytemuck",
  "derive_more",
  "solana-program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ codegen-units = 1
 anchor-lang = {version = "0.29.0", features = ["init-if-needed"]}
 anchor-spl = "0.29.0"
 ascii = "1.1.0"
+bs58 = { version = "0.5.0", features = ["alloc"] }
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 borsh = { version = "0.10.3", default-features = false }
 bytemuck = { version = "1.14", default-features = false }

--- a/solana/ed25519/Cargo.toml
+++ b/solana/ed25519/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+bs58.workspace = true
 base64.workspace = true
 borsh = { workspace = true, optional = true }
 bytemuck.workspace = true

--- a/solana/ed25519/src/lib.rs
+++ b/solana/ed25519/src/lib.rs
@@ -239,20 +239,20 @@ impl SignatureOffsets {
 }
 
 macro_rules! fmt_impl {
-    (impl $trait:ident for $ty:ident) => {
+    (impl $trait:ident for $ty:ident, $func_name:ident) => {
         impl fmt::$trait for $ty {
             #[inline]
             fn fmt(&self, fmtr: &mut fmt::Formatter) -> fmt::Result {
-                base64_display(&self.0, fmtr)
+                $func_name(&self.0, fmtr)
             }
         }
     };
 }
 
-fmt_impl!(impl Display for PubKey);
-fmt_impl!(impl Debug for PubKey);
-fmt_impl!(impl Display for Signature);
-fmt_impl!(impl Debug for Signature);
+fmt_impl!(impl Display for PubKey, base58_display);
+fmt_impl!(impl Debug for PubKey, base58_display);
+fmt_impl!(impl Display for Signature, base64_display);
+fmt_impl!(impl Debug for Signature, base64_display);
 
 /// Displays slice using base64 encoding.  Slice must be at most 64 bytes
 /// (i.e. length of a signature).
@@ -264,6 +264,13 @@ fn base64_display(bytes: &[u8], fmtr: &mut fmt::Formatter) -> fmt::Result {
     let len = BASE64_ENGINE.encode_slice(bytes, &mut buf[..]).unwrap();
     // SAFETY: base64 fills the buffer with ASCII characters only.
     fmtr.write_str(unsafe { core::str::from_utf8_unchecked(&buf[..len]) })
+}
+
+/// Displays slice using base58 encoding.
+fn base58_display(bytes: &[u8], fmtr: &mut fmt::Formatter) -> fmt::Result {
+    let data = bs58::encode(bytes).into_string();
+    // SAFETY: base58 fills the buffer with ASCII characters only.
+    fmtr.write_str(&data)
 }
 
 

--- a/solana/ed25519/src/lib.rs
+++ b/solana/ed25519/src/lib.rs
@@ -256,7 +256,7 @@ fmt_impl!(impl Debug for Signature, base64_display);
 
 /// Displays slice using base64 encoding.  Slice must be at most 64 bytes
 /// (i.e. length of a signature).
-fn base64_display(bytes: &[u8], fmtr: &mut fmt::Formatter) -> fmt::Result {
+fn base64_display(bytes: &[u8; 64], fmtr: &mut fmt::Formatter) -> fmt::Result {
     use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
     use base64::Engine;
 

--- a/solana/ed25519/src/lib.rs
+++ b/solana/ed25519/src/lib.rs
@@ -267,12 +267,19 @@ fn base64_display(bytes: &[u8], fmtr: &mut fmt::Formatter) -> fmt::Result {
 }
 
 /// Displays slice using base58 encoding.
-fn base58_display(bytes: &[u8], fmtr: &mut fmt::Formatter) -> fmt::Result {
-    let data = bs58::encode(bytes).into_string();
-    // SAFETY: base58 fills the buffer with ASCII characters only.
-    fmtr.write_str(&data)
+// TODO(mina86): Get rid of this once bs58 has this feature.  There’s currently
+// PR for that: https://github.com/Nullus157/bs58-rs/pull/97
+fn base58_display(bytes: &[u8; 32], fmtr: &mut fmt::Formatter) -> fmt::Result {
+    // The largest buffer we’re ever encoding is 32-byte long.  Base58
+    // increases size of the value by less than 40%.  45-byte buffer is
+    // therefore enough to fit 32-byte values.
+    let mut buf = [0u8; 45];
+    let len = bs58::encode(bytes).onto(&mut buf[..]).unwrap();
+    let output = &buf[..len];
+    // SAFETY: We know that alphabet can only include ASCII characters
+    // thus our result is an ASCII string.
+    fmtr.write_str(unsafe { std::str::from_utf8_unchecked(output) })
 }
-
 
 
 #[test]


### PR DESCRIPTION
Since solana uses base58 to display public keys, its better to use the same.