### PR TITLE
solana-ibc: make the inner value of map as public

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/storage/map.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage/map.rs
@@ -8,7 +8,7 @@ use anchor_lang::prelude::borsh::maybestd::io;
 /// Lookup operations on the map take linear time but for small maps that might
 /// actually be faster than hash maps or B trees.
 #[derive(Clone, derive_more::Deref, derive_more::DerefMut)]
-pub struct Map<K: Eq, V>(linear_map::LinearMap<K, V>);
+pub struct Map<K: Eq, V>(pub linear_map::LinearMap<K, V>);
 
 impl<K: Eq, V> Default for Map<K, V> {
     fn default() -> Self { Self(Default::default()) }


### PR DESCRIPTION
Making inner value of map as public so that we can use the associative function of the `LinearMap` which is needed on the relayer for fetching the value from the map for a given key and so on.