### PR TITLE
lib: guard Solana support by `solana-program` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,6 +4636,7 @@ dependencies = [
  "bytemuck",
  "derive_more",
  "guestchain",
+ "lib",
  "solana-program",
 ]
 

--- a/common/lib/Cargo.toml
+++ b/common/lib/Cargo.toml
@@ -9,14 +9,10 @@ base64.workspace = true
 borsh = { workspace = true, optional = true }
 bytemuck = { workspace = true, features = ["derive"] }
 derive_more.workspace = true
+sha2.workspace = true
+solana-program = { workspace = true, optional = true }
 
 stdx.workspace = true
-
-[target.'cfg(not(target_os = "solana"))'.dependencies]
-sha2.workspace = true
-
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-program.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/solana/ed25519/Cargo.toml
+++ b/solana/ed25519/Cargo.toml
@@ -13,6 +13,7 @@ derive_more.workspace = true
 solana-program.workspace = true
 
 guestchain = { workspace = true, optional = true }
+lib = { workspace = true, features = ["solana-program"] }
 
 [features]
 default = ["borsh", "guest"]

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -36,7 +36,7 @@ strum.workspace = true
 uint.workspace = true
 
 guestchain.workspace = true
-lib.workspace = true
+lib = { workspace = true, features = ["solana-program"] }
 memory.workspace = true
 solana-allocator = { workspace = true, optional = true }
 solana-ed25519 = { workspace = true, features = ["borsh", "guest"] }

--- a/solana/trie/Cargo.toml
+++ b/solana/trie/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 solana-program.workspace = true
 
-lib.workspace = true
+lib = { workspace = true, features = ["solana-program"] }
 memory.workspace = true
 sealable-trie.workspace = true
 stdx.workspace = true


### PR DESCRIPTION
lib crate conditionally includes solana-program dependency if it’s built for Solana.  This allows using Solana-provided host functions for calculating the hash without caller having to care about the details.

However, the issue is that Cargo doesn’t always take target_os into consideration when resolving dependencies.  To be perfectly honest I’m not completely sure of the exact mechanics but the way the code is written now, when working with this crate in another project I’m getting the following failures:

    error: failed to select a version for `curve25519-dalek`.
        ... required by package `solana-program v1.17.7`

    versions that meet the requirements `^3.2.1` are: 3.2.1

      previously selected package `curve25519-dalek v3.0.0`
        ... which satisfies dependency `curve25519-dalek = "^3"` of package `ed25519-dalek v1.0.1`

Change the code such that solana-program needs to be explicitly requested by the user.  This resolves the aforementioned issue while allowing Solana programs to continue using the optimised code.