### PR TITLE
solana-ibc: update ibc-rs to upstream version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "base64 0.21.7",
  "borsh 0.10.3",
@@ -2251,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2285,8 +2285,9 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
+ "derive_more",
  "ibc-client-tendermint-types",
  "ibc-core-client",
  "ibc-core-commitment-types",
@@ -2301,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "displaydoc",
@@ -2311,7 +2312,6 @@ dependencies = [
  "ibc-primitives",
  "ibc-proto",
  "serde",
- "solana-ed25519",
  "tendermint",
  "tendermint-light-client-verifier",
  "tendermint-proto",
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2426,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2497,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2512,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2578,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?branch=solana-verifier#cb67d6640128eacb3d829784bc19edf7e71a5c6c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=6dd3c6465e594d4c177f21724dd896a15e8f3634#6dd3c6465e594d4c177f21724dd896a15e8f3634"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -4738,6 +4738,8 @@ dependencies = [
  "spl-token",
  "stdx",
  "strum",
+ "tendermint",
+ "tendermint-light-client-verifier",
  "trie-ids",
  "uint",
 ]
@@ -5757,8 +5759,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74994da9de4b1144837a367ca2c60c650f5526a7c1a54760a3020959b522e474"
+source = "git+https://github.com/informalsystems/tendermint-rs?rev=37822e540e272d2ca9e763769ad20c581203ff9a#37822e540e272d2ca9e763769ad20c581203ff9a"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -6821,3 +6822,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "tendermint-light-client"
+version = "0.34.0"
+source = "git+https://github.com/informalsystems/tendermint-rs?rev=37822e540e272d2ca9e763769ad20c581203ff9a#37822e540e272d2ca9e763769ad20c581203ff9a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,20 @@ directories = "5.0"
 ed25519-dalek = "=1.0.1"  # Must match solana-sdk’s dependency.
 env_logger = "0.7.1"
 hex-literal = "0.4.1"
-ibc = { version = "0.50.0", default-features = false, features = ["borsh", "serde"] }
-ibc-core-channel-types = { version = "0.50.0", default-features = false }
-ibc-core-client-context = { version = "0.50.0", default-features = false }
-ibc-core-client-types = { version = "0.50.0", default-features = false }
-ibc-core-commitment-types = { version = "0.50.0", default-features = false }
-ibc-core-connection-types = { version = "0.50.0", default-features = false }
-ibc-core-host = { version = "0.50.0", default-features = false }
-ibc-core-host-types = { version = "0.50.0", default-features = false }
-ibc-primitives = { version = "0.50.0", default-features = false }
+
+# Use unreleased ibc-rs which supports custom verifier.
+ibc                       = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false, features = ["borsh", "serde"] }
+ibc-core-channel-types    = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+ibc-core-client-context   = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+ibc-core-client-types     = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+ibc-core-commitment-types = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+ibc-core-connection-types = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+ibc-core-host             = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+ibc-core-host-types       = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+ibc-primitives            = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+ibc-testkit               = { git = "https://github.com/cosmos/ibc-rs", rev = "6dd3c6465e594d4c177f21724dd896a15e8f3634", default-features = false }
+
 ibc-proto = { version = "0.41.0", default-features = false }
-ibc-testkit = { version = "0.50.0", default-features = false }
 insta = { version = "1.34.0" }
 # https://github.com/contain-rs/linear-map/pull/38 adds no_std support
 linear-map = { git = "https://github.com/contain-rs/linear-map", rev = "57f1432e26ff902bc883b250a85e0b5716bd241c", default-features = false }
@@ -73,6 +76,8 @@ solana-sdk = "1.17.7"
 spl-associated-token-account = "2.2.0"
 spl-token = "4.0.0"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
+tendermint = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
+tendermint-light-client-verifier = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
 tokio = "1.35.1"
 toml = "0.8.8"
 uint = "0.9.5"
@@ -115,52 +120,9 @@ curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dal
 # version which doesn’t do that hasn’t been released yet so we need to
 # refer to a commit on master.
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
+tendermint-light-client = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
+tendermint-light-client-verifier = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
 tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
 
 # Adds support for custom-entrypoint feature
 anchor-syn = { git = "https://github.com/mina86/anchor", branch = "custom-entrypoint" }
-
-# We need to patch ibc-client-tendermint to support custom verifier.
-# Unfortunately, because that crate refers to other ibc-rs crates by
-# path, we then need to patch all the other crates in ibc-rs as well.
-#cw-check = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-app-nft-transfer = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-app-nft-transfer-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-app-transfer = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-app-transfer-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-apps = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-client-tendermint = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-client-tendermint-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-client-wasm-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-clients = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-channel = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-channel-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-client = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-client-context = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-client-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-commitment-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-connection = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-connection-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-handler = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-handler-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-host = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-host-cosmos = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-host-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-router = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-core-router-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-#ibc-data-types = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-derive = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-primitives = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-#ibc-query = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-ibc-testkit = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-#no-std-check = { git = "https://github.com/mina86/ibc-rs", branch = "solana-verifier" }
-
-# We need to further instruct Crate to take solana-ed25519 from this
-# directory rather than from git when ibc-rs uses it.  Otherwise we
-# would end up with two versions of solana-ed25519: we would use ours
-# (from the checked out directory) and ibc-rs would use one from the
-# repository.
-[patch."https://github.com/ComposableFi/emulated-light-client/"]
-solana-ed25519 = { path = "solana/ed25519" }

--- a/common/trie-ids/src/path_info.rs
+++ b/common/trie-ids/src/path_info.rs
@@ -78,6 +78,16 @@ macro_rules! try_from_impl {
 }
 
 try_from_impl! {
+    NextClientSequence(path: NextClientSequencePath) => {
+        Err(ibc::path::Path::from(path).into())
+    }
+    NextConnectionSequence(path: NextConnectionSequencePath) => {
+        Err(ibc::path::Path::from(path).into())
+    }
+    NextChannelSequence(path: NextChannelSequencePath) => {
+        Err(ibc::path::Path::from(path).into())
+    }
+
     ClientState(path: ClientStatePath) => {
         Self::with_client(path.0, TrieKey::for_client_state)
     }
@@ -87,6 +97,13 @@ try_from_impl! {
         Self::with_client(path.client_id, |idx| {
             TrieKey::new(Tag::ConsensusState, (idx, height))
         })
+    }
+
+    ClientUpdateTime(path: ClientUpdateTimePath) => {
+        Err(ibc::path::Path::from(path).into())
+    }
+    ClientUpdateHeight(path: ClientUpdateHeightPath) => {
+        Err(ibc::path::Path::from(path).into())
     }
 
     ClientConnection(path: ClientConnectionPath) => {

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -28,6 +28,8 @@ ibc-testkit = { workspace = true, optional = true }
 ibc.workspace = true
 linear-map.workspace = true
 primitive-types.workspace = true
+tendermint.workspace = true
+tendermint-light-client-verifier.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 spl-associated-token-account.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/allocator.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/allocator.rs
@@ -110,34 +110,6 @@ mod imp {
     pub(crate) fn global() -> &'static Global { &Global }
 }
 
-/// Returns global verifier if one has been set.
-///
-/// Together with [`Global::set_verifier`] this function provides an interface
-/// analogous to a mutable global.
-///
-/// Returns `*const Verifier` pointer cast to `*const ()`.  Caller should cast
-/// the result back to `*const Verifier` (or better yet `*mut Verifier` and then
-/// use `NonNull`).  The pointer conversion is used to avoid [`Verifier`] having
-/// to be FFI-safe.
-///
-/// Due to symbol resolution and cyclical crate dependency shenanigans, this is
-/// defined as C function so that it can be accessed from other crates.
-/// Client of this interface should declare an extern function and use that to
-/// get access to Verifier.
-///
-/// # Safety
-///
-/// The function is always safe to run.  If it returns non-null pointer, the
-/// pointer is safe to convert to `*const Verifier` and dereferenced.
-#[no_mangle]
-#[allow(dead_code)]
-pub extern "C" fn get_global_ed25519_verifier() -> *const () {
-    match global().verifier() {
-        None => core::ptr::null(),
-        Some(verifier) => verifier as *const Verifier as *const (),
-    }
-}
-
 impl Global {
     /// Returns global verifier, if initialised.
     pub fn verifier(&self) -> Option<&'static Verifier> {

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -1,4 +1,3 @@
-use ::ibc::derive::ClientState;
 use anchor_lang::prelude::borsh;
 use anchor_lang::prelude::borsh::maybestd::io;
 
@@ -7,18 +6,11 @@ use crate::ibc;
 use crate::ibc::Protobuf;
 use crate::storage::IbcStorage;
 
+mod impls;
+
 type Result<T = (), E = ibc::ClientError> = core::result::Result<T, E>;
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    derive_more::From,
-    derive_more::TryInto,
-    ClientState,
-)]
-#[validation(IbcStorage<'a, 'b>)]
-#[execution(IbcStorage<'a, 'b>)]
+#[derive(Clone, Debug, PartialEq, derive_more::From, derive_more::TryInto)]
 pub enum AnyClientState {
     Tendermint(ibc::tm::ClientState),
     Guest(cf_guest::ClientState<solana_ed25519::PubKey>),
@@ -116,6 +108,12 @@ impl AnyClientState {
                     .map(Self::Mock)
             }
         }
+    }
+}
+
+impl From<ibc::tm::types::ClientState> for AnyClientState {
+    fn from(state: ibc::tm::types::ClientState) -> Self {
+        Self::Tendermint(state.into())
     }
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -1,0 +1,165 @@
+use super::AnyClientState;
+/// Implementation of IBC traits for [`AnyClientState`].
+///
+/// We cannot use [`::ibc::derive::ClientState`] derive because we need a custom
+/// implementation for `verify_client_message` which uses custom signature
+/// verifier.
+use crate::ibc;
+use crate::storage::IbcStorage;
+
+type Result<T = (), E = ibc::ClientError> = core::result::Result<T, E>;
+
+macro_rules! delegate {
+    (fn $name:ident(&self $(, $arg:ident: $ty:ty)* $(,)?) -> $ret:ty) => {
+        fn $name(&self, $($arg: $ty),*) -> $ret {
+            match self {
+                AnyClientState::Tendermint(cs) => cs.$name($($arg),*),
+                AnyClientState::Guest(cs) => cs.$name($($arg),*),
+                #[cfg(feature = "mocks")]
+                AnyClientState::Mock(cs) => cs.$name($($arg),*),
+            }
+        }
+    }
+}
+
+impl ibc::ClientStateCommon for AnyClientState {
+    delegate!(fn verify_consensus_state(&self, consensus_state: ibc::Any) -> Result);
+    delegate!(fn client_type(&self) -> ibc::ClientType);
+    delegate!(fn latest_height(&self) -> ibc::Height);
+    delegate!(fn validate_proof_height(&self, proof_height: ibc::Height) -> Result);
+    delegate!(fn verify_upgrade_client(
+        &self,
+        upgraded_client_state: ibc::Any,
+        upgraded_consensus_state: ibc::Any,
+        proof_upgrade_client: ibc::CommitmentProofBytes,
+        proof_upgrade_consensus_state: ibc::CommitmentProofBytes,
+        root: &ibc::CommitmentRoot,
+    ) -> Result);
+    delegate!(fn verify_membership(
+        &self,
+        prefix: &ibc::CommitmentPrefix,
+        proof: &ibc::CommitmentProofBytes,
+        root: &ibc::CommitmentRoot,
+        path: ibc::path::Path,
+        value: Vec<u8>,
+    ) -> Result);
+    delegate!(fn verify_non_membership(
+        &self,
+        prefix: &ibc::CommitmentPrefix,
+        proof: &ibc::CommitmentProofBytes,
+        root: &ibc::CommitmentRoot,
+        path: ibc::path::Path,
+    ) -> Result);
+}
+
+impl<'a, 'b> ibc::ClientStateValidation<IbcStorage<'a, 'b>> for AnyClientState {
+    fn verify_client_message(
+        &self,
+        ctx: &IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        client_message: ibc::Any,
+    ) -> Result {
+        match self {
+            AnyClientState::Tendermint(cs) => {
+                ibc::tm::client_state::verify_client_message(
+                    cs.inner(),
+                    ctx,
+                    client_id,
+                    client_message,
+                    &tm::TmVerifier,
+                )
+            }
+            AnyClientState::Guest(cs) => {
+                cs.verify_client_message(ctx, client_id, client_message)
+            }
+            #[cfg(feature = "mocks")]
+            AnyClientState::Mock(cs) => {
+                cs.verify_client_message(ctx, client_id, client_message)
+            }
+        }
+    }
+
+    delegate!(fn check_for_misbehaviour(
+        &self,
+        ctx: &IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        client_message: ibc::Any,
+    ) -> Result<bool>);
+    delegate!(fn status(
+        &self,
+        ctx: &IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+    ) -> Result<ibc::Status>);
+}
+
+impl<'a, 'b> ibc::ClientStateExecution<IbcStorage<'a, 'b>> for AnyClientState {
+    delegate!(fn initialise(
+        &self,
+        ctx: &mut IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        consensus_state: ibc::Any,
+    ) -> Result);
+    delegate!(fn update_state(
+        &self,
+        ctx: &mut IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        header: ibc::Any,
+    ) -> Result<Vec<ibc::Height>>);
+    delegate!(fn update_state_on_misbehaviour(
+        &self,
+        ctx: &mut IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        client_message: ibc::Any,
+    ) -> Result);
+    delegate!(fn update_state_on_upgrade(
+        &self,
+        ctx: &mut IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        upgraded_client_state: ibc::Any,
+        upgraded_consensus_state: ibc::Any,
+    ) -> Result<ibc::Height>);
+}
+
+mod tm {
+    use tendermint::crypto::signature::Error;
+    use tendermint_light_client_verifier::operations::commit_validator::ProdCommitValidator;
+    use tendermint_light_client_verifier::operations::voting_power::ProvidedVotingPowerCalculator;
+    use tendermint_light_client_verifier::predicates::ProdPredicates;
+    use tendermint_light_client_verifier::PredicateVerifier;
+
+    pub(super) struct TmVerifier;
+    pub(super) struct SigVerifier;
+
+    impl crate::ibc::tm::TmVerifier for TmVerifier {
+        type Verifier = PredicateVerifier<
+            ProdPredicates,
+            ProvidedVotingPowerCalculator<SigVerifier>,
+            ProdCommitValidator,
+        >;
+        fn verifier(&self) -> Self::Verifier { Default::default() }
+    }
+
+    impl tendermint::crypto::signature::Verifier for SigVerifier {
+        fn verify(
+            pubkey: tendermint::PublicKey,
+            msg: &[u8],
+            signature: &tendermint::Signature,
+        ) -> Result<(), Error> {
+            let pubkey = match pubkey {
+                tendermint::PublicKey::Ed25519(pubkey) => pubkey,
+                _ => return Err(Error::UnsupportedKeyType),
+            };
+            let pubkey = <&solana_ed25519::PubKey>::try_from(pubkey.as_bytes())
+                .map_err(|_| Error::MalformedPublicKey)?;
+            let sig =
+                <&solana_ed25519::Signature>::try_from(signature.as_bytes())
+                    .map_err(|_| Error::MalformedSignature)?;
+            if let Some(verifier) = crate::global().verifier() {
+                if verifier.exists(msg, pubkey, sig) {
+                    return Ok(());
+                }
+            }
+            Err(Error::VerificationFailed)
+        }
+    }
+}

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -72,7 +72,7 @@ impl<'a, 'b> ibc::ClientStateValidation<IbcStorage<'a, 'b>> for AnyClientState {
             AnyClientState::Guest(cs) => {
                 cs.verify_client_message(ctx, client_id, client_message)
             }
-            #[cfg(feature = "mocks")]
+            #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(cs) => {
                 cs.verify_client_message(ctx, client_id, client_message)
             }

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -15,7 +15,7 @@ macro_rules! delegate {
             match self {
                 AnyClientState::Tendermint(cs) => cs.$name($($arg),*),
                 AnyClientState::Guest(cs) => cs.$name($($arg),*),
-                #[cfg(feature = "mocks")]
+                #[cfg(any(test, feature = "mocks"))]
                 AnyClientState::Mock(cs) => cs.$name($($arg),*),
             }
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -48,9 +48,9 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
 
     /// Does nothing in the current implementation.
     ///
-    /// Instead, the update height is deleted when consensus state at given
-    /// height is deleted.
-    fn delete_update_height(
+    /// Instead, the update timestamp and height are deleted when consensus
+    /// state at given height is deleted.
+    fn delete_update_meta(
         &mut self,
         _client_id: ibc::ClientId,
         _height: ibc::Height,
@@ -60,37 +60,14 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
 
     /// Does nothing in the current implementation.
     ///
-    /// Instead, the update time is deleted when consensus state at given
-    /// height is deleted.
-    fn delete_update_time(
-        &mut self,
-        _client_id: ibc::ClientId,
-        _height: ibc::Height,
-    ) -> Result {
-        Ok(())
-    }
-
-    /// Does nothing in the current implementation.
-    ///
-    /// Instead, the update time is set when storing consensus state to the host
-    /// time at the moment `store_consensus_state` method is called.
-    fn store_update_time(
+    /// Instead, the update timestamp and time are set when storing consensus
+    /// state to the host time at the moment `store_consensus_state` method is
+    /// called.
+    fn store_update_meta(
         &mut self,
         _client_id: ibc::ClientId,
         _height: ibc::Height,
         _host_timestamp: ibc::Timestamp,
-    ) -> Result {
-        Ok(())
-    }
-
-    /// Does nothing in the current implementation.
-    ///
-    /// Instead, the update height is set when storing consensus state to the
-    /// host height at the moment `store_consensus_state` method is called.
-    fn store_update_height(
-        &mut self,
-        _client_id: ibc::ClientId,
-        _height: ibc::Height,
         _host_height: ibc::Height,
     ) -> Result {
         Ok(())

--- a/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
@@ -76,15 +76,16 @@ pub mod mock {
 }
 
 pub mod tm {
-    pub use ibc::clients::tendermint::client_state::ClientState;
+    pub use ibc::clients::tendermint::client_state::{self, ClientState};
     pub use ibc::clients::tendermint::consensus_state::ConsensusState;
     pub use ibc::clients::tendermint::context::{
-        CommonContext, ValidationContext,
+        CommonContext, TmVerifier, ValidationContext,
     };
     pub use ibc::clients::tendermint::types::proto::v1::{
         ClientState as ClientStatePB, ConsensusState as ConsensusStatePB,
     };
     pub use ibc::clients::tendermint::types::{
-        TENDERMINT_CLIENT_STATE_TYPE_URL, TENDERMINT_CONSENSUS_STATE_TYPE_URL,
+        self, TENDERMINT_CLIENT_STATE_TYPE_URL,
+        TENDERMINT_CONSENSUS_STATE_TYPE_URL,
     };
 }


### PR DESCRIPTION
Upstream ibc-rs now supports custom signature verifier for Tendermint light client.  While version with the support hasn’t been released yet, it’s still better to use upstream code rather than using our own fork.

Apart from not maintaining a fork, this has additional benefit of providing much cleaner interface for accessing global state solana-ibc uses.