### PR TITLE
guestchain: add option for generating blocks if head is too old

### DIFF
--- a/common/guestchain/src/candidates/tests.rs
+++ b/common/guestchain/src/candidates/tests.rs
@@ -69,6 +69,7 @@ impl From<Cfg> for crate::Config {
             min_total_stake: NonZeroU128::new(cfg.min_total_stake).unwrap(),
             min_quorum_stake: NonZeroU128::MIN,
             min_block_length: crate::height::HostDelta::from(1),
+            max_block_age_ns: u64::MAX,
             min_epoch_length: crate::height::HostDelta::from(1),
         }
     }

--- a/common/guestchain/src/config.rs
+++ b/common/guestchain/src/config.rs
@@ -65,6 +65,25 @@ pub struct Config {
     /// changes are introduced rather bundling them together.
     pub min_block_length: crate::height::HostDelta,
 
+    /// Maximum age of a block.  If last block was generated at least this
+    /// nanoseconds ago, new block can be generated even if it doesn’t change
+    /// state.
+    ///
+    /// Normally blocks are only generated when state or epoch changes.  In
+    /// other words, it’s theoretically possible for a new block to never be
+    /// created; or at least take arbitrary amount of time.  Consequence of this
+    /// is that there is no guarantee of time updates which may block IBC packet
+    /// timeouts from being noticed.
+    ///
+    /// With this option set, a new block can be generated even if it isn’t the
+    /// last block of an epoch and doesn’t change the state.  Setting this to
+    /// `u64::MAX` effectively disables the feature.  Setting this to zero means
+    /// that new blocks can be generated as soon as last block finalises (and
+    /// other conditions such as `min_block_length` are met).
+    ///
+    /// A sensible option is something at the order of hours.
+    pub max_block_age_ns: u64,
+
     /// Minimum length of an epoch.
     ///
     /// The purpose of the minimum is to make it possible for light clients to

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -124,6 +124,7 @@ fn anchor_test_deliver() -> Result<()> {
                 min_total_stake: NonZeroU128::new(1000).unwrap(),
                 min_quorum_stake: NonZeroU128::new(1000).unwrap(),
                 min_block_length: 5.into(),
+                max_block_age_ns: 3600 * 1_000_000_000,
                 min_epoch_length: 200_000.into(),
             },
             staking_program_id: Pubkey::from_str(STAKING_PROGRAM_ID).unwrap(),


### PR DESCRIPTION
Block generation is driven by changes to the state and to the set of validators.  As a consequence, it is theoretically possible for a new block to not be produced for a very long time.  Since blocks carry time information this means that clients may lack time information necessary to handle time-based events such as timeouts.

Add option for setting maximum block age after which a new block can be generated even if old block doesn’t change state nor finishes epoch.