### PR TITLE
cf-guest: change encode_to_vec to return Result

### DIFF
--- a/common/cf-guest/src/lib.rs
+++ b/common/cf-guest/src/lib.rs
@@ -75,6 +75,11 @@ macro_rules! any_convert {
             }
 
             /// Encodes the object into a vector as protocol buffer message.
+            ///
+            /// This method is provided for compatibility with APIs
+            /// (specifically macros) which expect it to return a `Result`.  You
+            /// most likely want to use [`Self::encode`] instead which encodes
+            /// in return type the fact that this is infallible conversion.
             pub fn encode_to_vec(
                 &self,
             ) -> Result<alloc::vec::Vec<u8>, core::convert::Infallible> {
@@ -105,20 +110,15 @@ macro_rules! any_convert {
 
         impl $(<$T: $bond>)* TryFrom<$crate::Any> for $Type $(<$T>)* {
             type Error = $crate::proto::DecodeError;
-            fn try_from(
-                any: $crate::Any,
-            ) -> Result<Self, Self::Error> {
+            fn try_from(any: $crate::Any) -> Result<Self, Self::Error> {
                 $crate::proto::$Type::try_from(any)
                     .and_then(|msg| Ok(msg.try_into()?))
             }
         }
 
-        impl $(<$T: $bond>)* TryFrom<&$crate::Any> for $Type $(<$T>)*
-        {
+        impl $(<$T: $bond>)* TryFrom<&$crate::Any> for $Type $(<$T>)* {
             type Error = $crate::proto::DecodeError;
-            fn try_from(
-                any: &$crate::Any,
-            ) -> Result<Self, Self::Error> {
+            fn try_from(any: &$crate::Any) -> Result<Self, Self::Error> {
                 $crate::proto::$Type::try_from(any)
                     .and_then(|msg| Ok(msg.try_into()?))
             }

--- a/common/cf-guest/src/lib.rs
+++ b/common/cf-guest/src/lib.rs
@@ -70,8 +70,15 @@ macro_rules! any_convert {
     ) => {
         impl $(<$T: $bond>)* $Type $(<$T>)* {
             /// Encodes the object into a vector as protocol buffer message.
-            pub fn encode_to_vec(&self) -> alloc::vec::Vec<u8> {
+            pub fn encode(&self) -> alloc::vec::Vec<u8> {
                 prost::Message::encode_to_vec(&$crate::proto::$Type::from(self))
+            }
+
+            /// Encodes the object into a vector as protocol buffer message.
+            pub fn encode_to_vec(
+                &self,
+            ) -> Result<alloc::vec::Vec<u8>, core::convert::Infallible> {
+                Ok(self.encode())
             }
 
             /// Decodes the object from a protocol buffer message.


### PR DESCRIPTION
For compatibility with APIs used in other places, change encode_to_vec method defined via any_convert macro to return a Result.  The method is still infallible and the error type reflects that but it’s now valid to run `foo.encode_to_vec().unwrap()`.  To not deal with the error case, `encode` method is provided in addition.