### PR TITLE
cf-guest: provide explicit Any conversion methods and update type URLs

### DIFF
--- a/common/cf-guest/src/client_impls.rs
+++ b/common/cf-guest/src/client_impls.rs
@@ -3,9 +3,9 @@ use alloc::vec::Vec;
 
 use guestchain::PubKey;
 
+use super::proto::Any;
 use super::{
-    proof, Any, ClientMessage, ClientState, ConsensusState, Header,
-    Misbehaviour,
+    proof, ClientMessage, ClientState, ConsensusState, Header, Misbehaviour,
 };
 
 mod ibc {

--- a/common/cf-guest/src/lib.rs
+++ b/common/cf-guest/src/lib.rs
@@ -6,8 +6,6 @@ extern crate std;
 
 use alloc::string::ToString;
 
-use ibc_proto::google::protobuf::Any;
-
 mod client;
 mod client_impls;
 mod consensus;
@@ -67,7 +65,7 @@ macro_rules! any_convert {
         $Type:ident $( <$T:ident: $bond:path = $concrete:path> )?,
         $(obj: $obj:expr,)*
         $(bad: $bad:expr,)*
-        $(from: $any:ident => $from_expr:expr,)?
+        $(conv: $any:ident => $from_any:expr,)?
     ) => {
         impl $(<$T: $bond>)* $Type $(<$T>)* {
             /// Encodes the object into a vector as protocol buffer message.
@@ -97,29 +95,41 @@ macro_rules! any_convert {
             }
         }
 
-        impl $(<$T: $bond>)* From<$Type $(<$T>)*> for $crate::Any {
-            fn from(obj: $Type $(<$T>)*) -> $crate::Any {
-                $crate::proto::$Type::from(obj).into()
+        impl $(<$T: $bond>)* $crate::proto::AnyConvert for $Type $(<$T>)* {
+            fn to_any(&self) -> (&'static str, alloc::vec::Vec<u8>) {
+                (<$Proto>::IBC_TYPE_URL, self.encode())
+            }
+            $crate::any_convert!(@try_from_any $Proto; $($any => $from_any)*);
+        }
+
+        impl $(<$T: $bond>)* From<$Type $(<$T>)*> for $crate::proto::Any {
+            fn from(msg: $Type $(<$T>)*) -> Self {
+                Self::from(&msg)
             }
         }
 
-        impl $(<$T: $bond>)* From<&$Type $(<$T>)*> for $crate::Any {
-            fn from(obj: &$Type $(<$T>)*) -> $crate::Any {
-                $crate::proto::$Type::from(obj).into()
+        impl $(<$T: $bond>)* From<&$Type $(<$T>)*> for $crate::proto::Any {
+            fn from(msg: &$Type $(<$T>)*) -> Self {
+                let (url, value) = $crate::proto::AnyConvert::to_any(msg);
+                Self { type_url: url.into(), value }
             }
         }
 
-        impl $(<$T: $bond>)* TryFrom<$crate::Any> for $Type $(<$T>)* {
+        impl $(<$T: $bond>)* TryFrom<$crate::proto::Any> for $Type $(<$T>)* {
             type Error = $crate::proto::DecodeError;
-            fn try_from(any: $crate::Any) -> Result<Self, Self::Error> {
-                $crate::proto::$Type::try_from(any)
-                    .and_then(|msg| Ok(msg.try_into()?))
+            fn try_from(any: $crate::proto::Any) -> Result<Self, Self::Error> {
+                Self::try_from(&any)
             }
         }
 
-        impl $(<$T: $bond>)* TryFrom<&$crate::Any> for $Type $(<$T>)* {
+        impl $(<$T: $bond>)* TryFrom<&$crate::proto::Any> for $Type $(<$T>)* {
             type Error = $crate::proto::DecodeError;
-            $crate::any_convert!(@from $Type $($any => $from_expr)*);
+            fn try_from(any: &$crate::proto::Any) -> Result<Self, Self::Error> {
+                <Self as $crate::proto::AnyConvert>::try_from_any(
+                    &any.type_url,
+                    &any.value,
+                )
+            }
         }
 
         impl $(<$T: $bond>)* ibc_primitives::proto::Protobuf<$Proto>
@@ -145,16 +155,28 @@ macro_rules! any_convert {
         }
     };
 
-    (@from $Type:ident) => {
-        $crate::any_convert!(@from $Type any => {
-            $crate::proto::$Type::try_from(any)
-                .and_then(|msg| Ok(msg.try_into()?))
-        });
+    (@try_from_any $Proto:ty;) => {
+        fn try_from_any(
+            type_url: &str,
+            value: &[u8],
+        ) -> Result<Self, $crate::proto::DecodeError> {
+            if type_url.ends_with(<$Proto>::IBC_TYPE_URL) {
+                Self::decode(value).map_err(|err| err.into())
+            } else {
+                Err($crate::proto::DecodeError::BadType)
+            }
+        }
     };
-    (@from $Type:ident $any:ident => $expr:expr) => {
-        fn try_from(
-            $any: &$crate::Any,
-        ) -> Result<Self, Self::Error> {
+    (@try_from_any $Proto:ty; $any:ident => $expr:expr) => {
+        fn try_from_any(
+            type_url: &str,
+            value: &[u8],
+        ) -> Result<Self, $crate::proto::DecodeError> {
+            struct Any<'a> {
+                type_url: &'a str,
+                value: &'a [u8]
+            }
+            let $any = Any { type_url, value };
             $expr
         }
     };

--- a/common/cf-guest/src/message.rs
+++ b/common/cf-guest/src/message.rs
@@ -132,12 +132,12 @@ super::any_convert! {
     // TODO(mina86): Add `obj: ...`.
     bad: proto::ClientMessage { message: None },
     conv: any => if any.type_url.ends_with(proto::ClientMessage::IBC_TYPE_URL) {
-        Self::decode(&any.value)
+        Self::decode(any.value)
     } else if any.type_url.ends_with(proto::Header::IBC_TYPE_URL) {
-        Header::decode(&any.value).map(Self::Header)
+        Header::decode(any.value).map(Self::Header)
     } else if any.type_url.ends_with(proto::Misbehaviour::IBC_TYPE_URL) {
-        Misbehaviour::decode(&any.value).map(Self::Misbehaviour)
+        Misbehaviour::decode(any.value).map(Self::Misbehaviour)
     } else {
-        return Err(crate::proto::DecodeError::BadType);
-    }.map_err(|err| err.into()),
+        Err(crate::proto::DecodeError::BadType)
+    },
 }

--- a/common/cf-guest/src/proto.rs
+++ b/common/cf-guest/src/proto.rs
@@ -1,5 +1,4 @@
-use ibc_primitives::proto::Any;
-use prost::Message as _;
+pub use ibc_primitives::proto::Any;
 
 mod pb {
     include!(concat!(env!("OUT_DIR"), "/messages.rs"));
@@ -80,54 +79,86 @@ impl From<Misbehaviour> for ClientMessage {
     }
 }
 
+pub trait AnyConvert: Sized {
+    /// Converts the message into a Protobuf Any message.
+    ///
+    /// The Any message is returned as `(type_url, value)` tuple which caller
+    /// can use the values to build `Any` object from them.  This is intended to
+    /// handle cases where `Any` type coming from different crates is used and
+    /// `From<Self> for Any` implementation is not present.
+    fn to_any(&self) -> (&'static str, alloc::vec::Vec<u8>);
+
+    /// Converts the message from a Protobuf Any message.
+    ///
+    /// The Any message is accepted as separate `type_url` and `value` arguments
+    /// rather than a single `Any` object.  This is intended to handle cases
+    /// where `Any` type coming from different crates is used and `From<Self>
+    /// for Any` implementation is not present.
+    fn try_from_any(type_url: &str, value: &[u8]) -> Result<Self, DecodeError>;
+}
 
 macro_rules! impl_proto {
     ($Msg:ident; $test:ident; $test_object:expr) => {
         impl pb::lightclients::guest::v1::$Msg {
-            /// Type URL of the type as used in Any protocol message.
+            /// Type URL of the type as used in Any protocol message in IBC.
             ///
-            /// This is the same value as returned by [`prost::Name::type_url`]
-            /// however it’s a `const` and is set at compile time.  (In current
-            /// Prost implementation, `type_url` method computes the URL at
-            /// run-time).
-            pub const TYPE_URL: &'static str = concat!(
-                "composable.finance/lightclients.guest.v1.",
-                stringify!($Msg)
-            );
+            /// Note that this isn’t the same as `Self::type_url()` which
+            /// returns the fully-qualified unique name for this message
+            /// including the domain.  For IBC purposes, we usually don’t
+            /// include the domain and just use `/foo.bar.Baz` as the type
+            ///URL; this constant provides that value for this type.
+            ///
+            /// This is equals `format!("/{}", Self::full_name())` but provided
+            /// as a constant value.
+            pub const IBC_TYPE_URL: &'static str =
+                concat!("/lightclients.guest.v1.", stringify!($Msg));
 
             /// An example test message.
             #[cfg(test)]
             pub fn test() -> Self { $test_object }
         }
 
-        impl From<$Msg> for Any {
-            fn from(msg: $Msg) -> Self { Self::from(&msg) }
-        }
+        impl AnyConvert for pb::lightclients::guest::v1::$Msg {
+            fn to_any(&self) -> (&'static str, alloc::vec::Vec<u8>) {
+                (Self::IBC_TYPE_URL, prost::Message::encode_to_vec(self))
+            }
 
-        impl From<&$Msg> for Any {
-            fn from(msg: &$Msg) -> Self {
-                Self {
-                    type_url: $Msg::TYPE_URL.into(),
-                    value: msg.encode_to_vec(),
+            fn try_from_any(
+                type_url: &str,
+                value: &[u8],
+            ) -> Result<Self, $crate::proto::DecodeError> {
+                if type_url.ends_with(Self::IBC_TYPE_URL) {
+                    Ok(<Self as prost::Message>::decode(value)?)
+                } else {
+                    Err($crate::proto::DecodeError::BadType)
                 }
             }
         }
 
-        impl TryFrom<Any> for $Msg {
+        impl From<pb::lightclients::guest::v1::$Msg> for Any {
+            fn from(msg: pb::lightclients::guest::v1::$Msg) -> Self {
+                Self::from(&msg)
+            }
+        }
+
+        impl From<&pb::lightclients::guest::v1::$Msg> for Any {
+            fn from(msg: &pb::lightclients::guest::v1::$Msg) -> Self {
+                let (url, value) = AnyConvert::to_any(msg);
+                Self { type_url: url.into(), value }
+            }
+        }
+
+        impl TryFrom<Any> for pb::lightclients::guest::v1::$Msg {
             type Error = DecodeError;
             fn try_from(any: Any) -> Result<Self, Self::Error> {
                 Self::try_from(&any)
             }
         }
 
-        impl TryFrom<&Any> for $Msg {
+        impl TryFrom<&Any> for pb::lightclients::guest::v1::$Msg {
             type Error = DecodeError;
             fn try_from(any: &Any) -> Result<Self, Self::Error> {
-                if Self::TYPE_URL == any.type_url {
-                    Ok($Msg::decode(any.value.as_slice())?)
-                } else {
-                    Err(DecodeError::BadType)
-                }
+                <Self as AnyConvert>::try_from_any(&any.type_url, &any.value)
             }
         }
 
@@ -139,7 +170,8 @@ macro_rules! impl_proto {
 
             // Make sure TYPE_URL we set by hand matches type_url which is
             // derived.
-            assert_eq!($Msg::type_url(), $Msg::TYPE_URL);
+            assert_eq!(format!("/{}", $Msg::full_name()), $Msg::IBC_TYPE_URL);
+            assert!($Msg::type_url().ends_with($Msg::IBC_TYPE_URL));
 
             // Check round-trip conversion through Any.
             let state = $Msg::test();

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -48,7 +48,7 @@ impl AnyClientState {
     const TENDERMINT_TYPE: &'static str =
         ibc::tm::TENDERMINT_CLIENT_STATE_TYPE_URL;
     /// Protobuf type URL for Guest client state used in Any message.
-    const GUEST_TYPE: &'static str = cf_guest::proto::ClientState::TYPE_URL;
+    const GUEST_TYPE: &'static str = cf_guest::proto::ClientState::IBC_TYPE_URL;
     #[cfg(any(test, feature = "mocks"))]
     /// Protobuf type URL for Mock client state used in Any message.
     const MOCK_TYPE: &'static str = ibc::mock::MOCK_CLIENT_STATE_TYPE_URL;

--- a/solana/solana-ibc/programs/solana-ibc/src/consensus_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/consensus_state.rs
@@ -48,7 +48,8 @@ impl AnyConsensusState {
     const TENDERMINT_TYPE: &'static str =
         ibc::tm::TENDERMINT_CONSENSUS_STATE_TYPE_URL;
     /// Protobuf type URL for Guest consensus state used in Any message.
-    const GUEST_TYPE: &'static str = cf_guest::proto::ConsensusState::TYPE_URL;
+    const GUEST_TYPE: &'static str =
+        cf_guest::proto::ConsensusState::IBC_TYPE_URL;
     #[cfg(any(test, feature = "mocks"))]
     /// Protobuf type URL for Mock client state used in Any message.
     const MOCK_TYPE: &'static str = ibc::mock::MOCK_CONSENSUS_STATE_TYPE_URL;


### PR DESCRIPTION
To make it easier to convert to and from Any types which come from other crates than cf-guest depends on, provide AnyConvert trait with to_any and try_from_any methods which perform conversion between given type and Any message without relying on specific Any type.

Secondly, since IBC uses type URLs without domain in Any messages, do the same in our code base.  Firstly, change code converting from Any such that it ignores the domain in the type_url¹.  Secondly, replace TYPE_URL constant with IBC_TYPE_URL constant which excludes the domain.  And lastly, use that constant for GUEST_TYPE in AnyClientState and AnyConsensusState.

This new code will produce different Any representation for types. Though it will be capable of decoding old Any representations.

¹ This is in fact the correct behaviour.  The previous code which
  compared the domain was invalid according to Protocol Buffer
  specification.  So in addition to working better with IBC, this
  change also improves compatibility with Protobuf.