### PR TITLE
solana-ibc: update revision number of height to 1

### DIFF
--- a/common/cf-guest/src/client_impls.rs
+++ b/common/cf-guest/src/client_impls.rs
@@ -275,7 +275,7 @@ where
             return Ok(ibc::Status::Frozen);
         }
 
-        let height = ibc::Height::new(0, self.latest_height.into())?;
+        let height = ibc::Height::new(1, self.latest_height.into())?;
         let consensus = CommonContext::consensus_state(ctx, client_id, height)
             .and_then(|state| state.try_into().map_err(error));
         let consensus = match consensus {

--- a/common/cf-guest/src/client_impls.rs
+++ b/common/cf-guest/src/client_impls.rs
@@ -77,7 +77,7 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
     }
 
     fn latest_height(&self) -> ibc::Height {
-        ibc::Height::new(0, self.latest_height.into()).unwrap()
+        ibc::Height::new(1, self.latest_height.into()).unwrap()
     }
 
     fn validate_proof_height(&self, proof_height: ibc::Height) -> Result {
@@ -187,7 +187,7 @@ where
         let header = crate::proto::Header::try_from(header)?;
         let header = crate::Header::<PK>::try_from(header)?;
         let header_height =
-            ibc::Height::new(0, header.block_header.block_height.into())?;
+            ibc::Height::new(1, header.block_header.block_height.into())?;
 
         let (host_timestamp, host_height) = CommonContext::host_metadata(ctx)?;
         self.prune_oldest_consensus_state(ctx, client_id, host_timestamp)?;

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -204,7 +204,7 @@ impl cf_guest::CommonContext for IbcStorage<'_, '_> {
             })?;
 
         let height = u64::from(self.borrow().chain.head()?.block_height);
-        let height = ibc::Height::new(0, height)?;
+        let height = ibc::Height::new(1, height)?;
 
         Ok((timestamp, height))
     }

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -59,7 +59,7 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
         height: &ibc::Height,
     ) -> Result<Self::AnyConsensusState> {
         let store = self.borrow();
-        let state = if height.revision_number() == 0 {
+        let state = if height.revision_number() == 1 {
             store.chain.consensus_state(height.revision_height().into())?
         } else {
             None
@@ -302,7 +302,7 @@ impl ibc::ClientValidationContext for IbcStorage<'_, '_> {
                 let ts = state.processed_time()?.get();
                 let ts = ibc::Timestamp::from_nanoseconds(ts).ok()?;
                 let height = state.processed_height()?;
-                let height = ibc::Height::new(0, height.into()).ok()?;
+                let height = ibc::Height::new(1, height.into()).ok()?;
                 Some((ts, height))
             })
             .ok_or_else(|| {

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -43,7 +43,7 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
 
     fn host_height(&self) -> Result<ibc::Height> {
         let height = u64::from(self.borrow().chain.head()?.block_height);
-        let height = ibc::Height::new(0, height)?;
+        let height = ibc::Height::new(1, height)?;
         Ok(height)
     }
 


### PR DESCRIPTION
Updating revision number of height to 1 from 0 since while decoding, the revision number field which is omitted while encoding ( since its 0 ) fails when decoding because of missing field. It could be fixed by having a default value in case of missing field but since it would require upgrading of cosmos node, we can just use revision number as 1.