### PR TITLE
solana-ibc: store protobuf encoded value in trie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4707,6 +4707,7 @@ dependencies = [
  "guestchain",
  "hex-literal",
  "ibc",
+ "ibc-proto",
  "ibc-testkit",
  "insta",
  "lib",

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -26,6 +26,7 @@ bytemuck = { workspace = true, features = ["must_cast", "zeroable_atomics"] }
 derive_more.workspace = true
 ibc-testkit = { workspace = true, optional = true }
 ibc.workspace = true
+ibc-proto.workspace = true
 linear-map.workspace = true
 primitive-types.workspace = true
 tendermint.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -6,6 +6,8 @@ use crate::consensus_state::AnyConsensusState;
 use crate::ibc;
 use crate::storage::{self, IbcStorage};
 
+use ibc_proto::Protobuf;
+
 type Result<T = (), E = ibc::ContextError> = core::result::Result<T, E>;
 
 impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
@@ -21,7 +23,9 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
         msg!("store_client_state({}, {:?})", path, state);
         let mut store = self.borrow_mut();
         let mut client = store.private.client_mut(&path.0, true)?;
-        let hash = client.client_state.set(&state)?.digest_with_client(&path.0);
+        client.client_state.set(&state)?;
+        let state_any = state.encode_vec();
+        let hash = cf_guest::digest_with_client_id(&path.0, state_any.as_slice());
         let key = trie_ids::TrieKey::for_client_state(client.index);
         store.provable.set(&key, &hash).map_err(error)
     }
@@ -89,14 +93,16 @@ impl IbcStorage<'_, '_> {
             (head.timestamp_ns, head.block_height)
         };
 
+        let encoded_state = state.clone().encode_vec();
+        let hash = cf_guest::digest_with_client_id(client_id, encoded_state.as_slice());
         let mut client = store.private.client_mut(client_id, false)?;
         let state = storage::ClientConsensusState::new(
             processed_time,
             processed_height,
             &state,
         )?;
-        let hash = state.digest(client_id)?;
         client.consensus_states.insert(height, state);
+
 
         let trie_key =
             trie_ids::TrieKey::for_consensus_state(client.index, height);
@@ -135,7 +141,8 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_> {
         msg!("store_connection({}, {:?})", path, connection_end);
         let connection = trie_ids::ConnectionIdx::try_from(&path.0)?;
         let serialised = storage::Serialised::new(&connection_end)?;
-        let hash = serialised.digest();
+        let encoded_connection_end = connection_end.encode_vec();
+        let hash = CryptoHash::digest(encoded_connection_end.as_slice());
 
         let mut store = self.borrow_mut();
 
@@ -237,14 +244,16 @@ impl ibc::ExecutionContext for IbcStorage<'_, '_> {
         let port_channel = trie_ids::PortChannelPK::try_from(&path.0, &path.1)?;
         let trie_key = trie_ids::TrieKey::for_channel_end(&port_channel);
         let mut store = self.borrow_mut();
-        let digest = store
+        let encoded_channel_end = channel_end.clone().encode_vec();
+        let hash = CryptoHash::digest(encoded_channel_end.as_slice());
+        store
             .private
             .port_channel
             .entry(port_channel)
             .or_insert_with(Default::default)
             .set_channel_end(&channel_end)
             .map_err(error)?;
-        store.provable.set(&trie_key, &digest).map_err(error)
+        store.provable.set(&trie_key, &hash).map_err(error)
     }
 
     fn store_next_sequence_send(

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -1,12 +1,11 @@
 use anchor_lang::solana_program::msg;
+use ibc_proto::Protobuf;
 use lib::hash::CryptoHash;
 
 use crate::client_state::AnyClientState;
 use crate::consensus_state::AnyConsensusState;
 use crate::ibc;
 use crate::storage::{self, IbcStorage};
-
-use ibc_proto::Protobuf;
 
 type Result<T = (), E = ibc::ContextError> = core::result::Result<T, E>;
 
@@ -25,7 +24,8 @@ impl ibc::ClientExecutionContext for IbcStorage<'_, '_> {
         let mut client = store.private.client_mut(&path.0, true)?;
         client.client_state.set(&state)?;
         let state_any = state.encode_vec();
-        let hash = cf_guest::digest_with_client_id(&path.0, state_any.as_slice());
+        let hash =
+            cf_guest::digest_with_client_id(&path.0, state_any.as_slice());
         let key = trie_ids::TrieKey::for_client_state(client.index);
         store.provable.set(&key, &hash).map_err(error)
     }
@@ -94,7 +94,10 @@ impl IbcStorage<'_, '_> {
         };
 
         let encoded_state = state.clone().encode_vec();
-        let hash = cf_guest::digest_with_client_id(client_id, encoded_state.as_slice());
+        let hash = cf_guest::digest_with_client_id(
+            client_id,
+            encoded_state.as_slice(),
+        );
         let mut client = store.private.client_mut(client_id, false)?;
         let state = storage::ClientConsensusState::new(
             processed_time,

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -223,9 +223,9 @@ impl PortChannelStore {
     pub fn set_channel_end(
         &mut self,
         end: &ibc::ChannelEnd,
-    ) -> Result<CryptoHash, ibc::ClientError> {
+    ) -> Result<(), ibc::ClientError> {
         self.channel_end.set(end)?;
-        Ok(self.channel_end.digest())
+        Ok(())
     }
 }
 
@@ -519,16 +519,6 @@ impl<T> Serialised<T> {
     }
 
     pub fn as_bytes(&self) -> &[u8] { self.0.as_slice() }
-
-    /// Returns digest of the serialised value.
-    #[inline]
-    pub fn digest(&self) -> CryptoHash { CryptoHash::digest(self.0.as_slice()) }
-
-    /// Returns digest of the serialised value with client id mixed in.
-    #[inline]
-    pub fn digest_with_client(&self, client_id: &ibc::ClientId) -> CryptoHash {
-        cf_guest::digest_with_client_id(client_id, self.as_bytes())
-    }
 }
 
 impl<T: borsh::BorshSerialize> Serialised<T> {


### PR DESCRIPTION
We used to store hash of the borsh encoded value in the trie but IBC encodes the value in protobuf and checks the proof against it. So encoding the value as protobuf so that we match the value which IBC expects.