### PR TITLE
cf-guest: add method to create new guest client state

### DIFF
--- a/common/cf-guest/src/client.rs
+++ b/common/cf-guest/src/client.rs
@@ -30,6 +30,22 @@ pub struct ClientState<PK> {
 }
 
 impl<PK: guestchain::PubKey> ClientState<PK> {
+    pub fn new(
+		genesis_hash: CryptoHash,
+		latest_height: guestchain::BlockHeight,
+		trusting_period_ns: u64,
+		epoch_commitment: CryptoHash,
+		is_frozen: bool,
+	) -> Self {
+		Self {
+			genesis_hash,
+			latest_height,
+			trusting_period_ns,
+			epoch_commitment,
+			is_frozen,
+			_ph: core::marker::PhantomData::<PK>,
+		}
+	}
     pub fn with_header(&self, header: &super::Header<PK>) -> Self {
         let mut this = self.clone();
         if header.block_header.block_height > this.latest_height {

--- a/common/cf-guest/src/client.rs
+++ b/common/cf-guest/src/client.rs
@@ -31,21 +31,21 @@ pub struct ClientState<PK> {
 
 impl<PK: guestchain::PubKey> ClientState<PK> {
     pub fn new(
-		genesis_hash: CryptoHash,
-		latest_height: guestchain::BlockHeight,
-		trusting_period_ns: u64,
-		epoch_commitment: CryptoHash,
-		is_frozen: bool,
-	) -> Self {
-		Self {
-			genesis_hash,
-			latest_height,
-			trusting_period_ns,
-			epoch_commitment,
-			is_frozen,
-			_ph: core::marker::PhantomData,
-		}
-	}
+        genesis_hash: CryptoHash,
+        latest_height: guestchain::BlockHeight,
+        trusting_period_ns: u64,
+        epoch_commitment: CryptoHash,
+        is_frozen: bool,
+    ) -> Self {
+        Self {
+            genesis_hash,
+            latest_height,
+            trusting_period_ns,
+            epoch_commitment,
+            is_frozen,
+            _ph: core::marker::PhantomData,
+        }
+    }
     pub fn with_header(&self, header: &super::Header<PK>) -> Self {
         let mut this = self.clone();
         if header.block_header.block_height > this.latest_height {

--- a/common/cf-guest/src/client.rs
+++ b/common/cf-guest/src/client.rs
@@ -43,7 +43,7 @@ impl<PK: guestchain::PubKey> ClientState<PK> {
 			trusting_period_ns,
 			epoch_commitment,
 			is_frozen,
-			_ph: core::marker::PhantomData::<PK>,
+			_ph: core::marker::PhantomData,
 		}
 	}
     pub fn with_header(&self, header: &super::Header<PK>) -> Self {


### PR DESCRIPTION
Add a method to create a new guest `ClientState` since it has `PhantomData` as private field. It would be used by the relayer generally to form new clientState