### PR TITLE
solana-ibc: use serde default for memo to use default value when field is not found

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -310,6 +310,7 @@ pub struct FtPacketData {
     /// the recipient address on the destination chain
     pub receiver: String,
     /// optional memo
+    #[serde(default)]
     pub memo: String,
 }
 


### PR DESCRIPTION
Using a default value for `memo` inside `packet` so that if field is not found, we use the default value which is an empty string.