### PR TITLE
solana-trie: add double-free detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,6 +5228,7 @@ dependencies = [
 name = "solana-trie"
 version = "0.0.0"
 dependencies = [
+ "bytemuck",
  "lib",
  "memory",
  "sealable-trie",

--- a/common/cf-guest/src/proof.rs
+++ b/common/cf-guest/src/proof.rs
@@ -235,9 +235,10 @@ fn test_proofs() {
     use core::str::FromStr;
 
     use ibc_core_host::types::identifiers;
+    use sealable_trie::nodes::RawNode;
 
     struct Trie {
-        trie: sealable_trie::Trie<memory::test_utils::TestAllocator<[u8; 72]>>,
+        trie: sealable_trie::Trie<memory::test_utils::TestAllocator<RawNode>>,
         header: BlockHeader,
     }
 

--- a/common/sealable-trie/src/lib.rs
+++ b/common/sealable-trie/src/lib.rs
@@ -10,9 +10,6 @@ pub mod trie;
 
 pub use trie::{Error, Trie};
 
-pub trait Allocator:
-    memory::Allocator<Value = [u8; nodes::RawNode::SIZE]>
-{
-}
+pub trait Allocator: memory::Allocator<Value = nodes::RawNode> {}
 
-impl<A: memory::Allocator<Value = [u8; nodes::RawNode::SIZE]>> Allocator for A {}
+impl<A: memory::Allocator<Value = nodes::RawNode>> Allocator for A {}

--- a/common/sealable-trie/src/trie.rs
+++ b/common/sealable-trie/src/trie.rs
@@ -4,7 +4,7 @@ use core::num::NonZeroU16;
 use lib::hash::CryptoHash;
 use memory::Ptr;
 
-use crate::nodes::{Node, NodeRef, RawNode, Reference};
+use crate::nodes::{Node, NodeRef, Reference};
 use crate::{bits, proof};
 
 mod del;
@@ -105,7 +105,7 @@ impl From<crate::nodes::DecodeError> for Error {
 }
 
 type Result<T, E = Error> = ::core::result::Result<T, E>;
-type Value = [u8; crate::nodes::RawNode::SIZE];
+type Value = crate::nodes::RawNode;
 
 macro_rules! proof {
     ($proof:ident push $item:expr) => {
@@ -187,7 +187,7 @@ impl<A: memory::Allocator<Value = Value>> Trie<A> {
         let mut node_hash = self.root_hash.clone();
         loop {
             let node = self.alloc.get(node_ptr.ok_or(Error::Sealed)?);
-            let node = <&RawNode>::from(node).decode()?;
+            let node = node.decode()?;
             debug_assert_eq!(node_hash, node.hash());
 
             let child = match node {
@@ -363,7 +363,7 @@ impl<A: memory::Allocator<Value = Value>> Trie<A> {
             println!(" (sealed)");
             return;
         };
-        let node = <&RawNode>::from(self.alloc.get(ptr));
+        let node = self.alloc.get(ptr);
         match node.decode() {
             Ok(Node::Branch { children }) => {
                 println!(" Branch");

--- a/common/sealable-trie/src/trie/del.rs
+++ b/common/sealable-trie/src/trie/del.rs
@@ -60,7 +60,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
     /// Processes a node.
     fn handle(&mut self, nref: NodeRef) -> Result<Action> {
         let ptr = nref.ptr.ok_or(Error::Sealed)?;
-        let node = RawNode(*self.wlog.allocator().get(ptr));
+        let node = *self.wlog.allocator().get(ptr);
         let node = node.decode()?;
         debug_assert_eq!(*nref.hash, node.hash());
 
@@ -147,7 +147,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
         make_key: &dyn Fn(bits::ExtKey) -> bits::Owned,
     ) -> Result<Option<Action>> {
         if let Reference::Node(NodeRef { ptr: Some(ptr), hash }) = child {
-            let node = RawNode(*self.wlog.allocator().get(ptr));
+            let node = *self.wlog.allocator().get(ptr);
             let node = node.decode()?;
             debug_assert_eq!(*hash, node.hash());
 
@@ -165,7 +165,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
     /// pointing at the node.
     fn set_node(&mut self, ptr: Ptr, node: RawNode) -> Result<OwnedRef> {
         let hash = node.decode()?.hash();
-        self.wlog.set(ptr, *node);
+        self.wlog.set(ptr, node);
         Ok(OwnedRef::Node(Some(ptr), hash))
     }
 
@@ -186,7 +186,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
 
         for chunk in key.as_slice().chunks().rev() {
             let node = RawNode::extension(chunk, child.to_ref());
-            let ptr = self.wlog.alloc(node.0)?;
+            let ptr = self.wlog.alloc(node)?;
             child = OwnedRef::Node(Some(ptr), node.decode()?.hash());
         }
 

--- a/common/sealable-trie/src/trie/iter.rs
+++ b/common/sealable-trie/src/trie/iter.rs
@@ -5,7 +5,7 @@ use memory::Ptr;
 
 use super::{Error, Result};
 use crate::bits;
-use crate::nodes::{DecodeError, Node, RawNode, Reference};
+use crate::nodes::{DecodeError, Node, Reference};
 
 /// A possibly sealed value returned from subtrie iterator.
 pub struct Entry {
@@ -82,7 +82,7 @@ fn get_subtrie_root<A: memory::Allocator<Value = super::Value>>(
     let mut prefix = bits::Owned::default();
     while !key.is_empty() && node_ptr.is_some() {
         let node = alloc.get(node_ptr.unwrap());
-        let node = match <&RawNode>::from(node).decode() {
+        let node = match node.decode() {
             Ok(node) => node,
             Err(err) => return GetSubtrieRootResult::Err(err),
         };
@@ -174,7 +174,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
             return Ok(());
         };
 
-        match <&RawNode>::from(self.alloc.get(ptr)).decode()? {
+        match self.alloc.get(ptr).decode()? {
             Node::Branch { children } => {
                 self.prefix.push_back(false).unwrap();
                 self.handle_ref(children[0], self.prefix.len())?;

--- a/common/sealable-trie/src/trie/seal.rs
+++ b/common/sealable-trie/src/trie/seal.rs
@@ -26,7 +26,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
     /// that `ptr` has been freed and it has to update references to it.
     pub(super) fn seal(&mut self, nref: NodeRef) -> Result<bool> {
         let ptr = nref.ptr.ok_or(Error::Sealed)?;
-        let node = RawNode(*self.alloc.get(ptr));
+        let node = *self.alloc.get(ptr);
         let node = node.decode()?;
         debug_assert_eq!(*nref.hash, node.hash());
 
@@ -37,7 +37,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
 
         match result {
             SealResult::Replace(node) => {
-                self.alloc.set(ptr, *node);
+                self.alloc.set(ptr, node);
                 Ok(false)
             }
             SealResult::Free => {

--- a/common/sealable-trie/src/trie/set.rs
+++ b/common/sealable-trie/src/trie/set.rs
@@ -63,7 +63,7 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
     /// Inserts value into the trie starting at node pointed by given reference.
     fn handle(&mut self, nref: NodeRef) -> Result<(Ptr, CryptoHash)> {
         let nref = (nref.ptr.ok_or(Error::Sealed)?, nref.hash);
-        let node = RawNode(*self.wlog.allocator().get(nref.0));
+        let node = *self.wlog.allocator().get(nref.0);
         let node = node.decode()?;
         debug_assert_eq!(*nref.1, node.hash());
         match node {
@@ -254,14 +254,14 @@ impl<'a, A: memory::Allocator<Value = super::Value>> Context<'a, A> {
         node: RawNode,
     ) -> Result<(Ptr, CryptoHash)> {
         let hash = node.decode().unwrap().hash();
-        self.wlog.set(ptr, *node);
+        self.wlog.set(ptr, node);
         Ok((ptr, hash))
     }
 
     /// Allocates a new node and sets it to given value.
     fn alloc_node(&mut self, node: RawNode) -> Result<(Ptr, CryptoHash)> {
         let hash = node.decode()?.hash();
-        let ptr = self.wlog.alloc(*node)?;
+        let ptr = self.wlog.alloc(node)?;
         Ok((ptr, hash))
     }
 }

--- a/solana/trie/Cargo.toml
+++ b/solana/trie/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+bytemuck = { workspace = true, features = ["min_const_generics", "must_cast"] }
 solana-program.workspace = true
 
 lib = { workspace = true, features = ["solana-program"] }

--- a/solana/trie/src/alloc.rs
+++ b/solana/trie/src/alloc.rs
@@ -1,11 +1,11 @@
 use lib::hash::CryptoHash;
 use memory::Ptr;
+use sealable_trie::nodes::RawNode;
 
 use crate::data_ref::DataRef;
 use crate::header::Header;
 
-const SZ: usize = sealable_trie::nodes::RawNode::SIZE;
-
+/// Implementation of [`sealable_trie::Allocator`] over given [`DataRef`].
 #[derive(Debug)]
 pub struct Allocator<D> {
     /// Pool of memory to allocate blocks in.
@@ -50,7 +50,7 @@ impl<D: DataRef> Allocator<D> {
     fn alloc_next_block(&mut self) -> Option<Ptr> {
         let ptr = Ptr::new(self.next_block).ok().flatten()?;
         let len = u32::try_from(self.data.len()).unwrap_or(u32::MAX);
-        let end = self.next_block.checked_add(SZ as u32)?;
+        let end = self.next_block.checked_add(RawNode::SIZE as u32)?;
         if end > len && !self.data.enlarge(usize::try_from(end).ok()?) {
             None
         } else {
@@ -60,8 +60,22 @@ impl<D: DataRef> Allocator<D> {
     }
 }
 
+/// Structure of an unallocated node.
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+#[repr(C, packed)]
+struct FreeRawNode {
+    /// Pointer of the next free node on a free-list (encoded using native
+    /// endianess) or zero if this is the last free node.
+    next_free: [u8; 4],
+
+    _dont_care: [u8; 36],
+
+    /// Marker which is always zero.  This is used to detect double-free.
+    marker: [u8; 32],
+}
+
 impl<D: DataRef + Sized> memory::Allocator for Allocator<D> {
-    type Value = [u8; SZ];
+    type Value = RawNode;
 
     fn alloc(
         &mut self,
@@ -77,19 +91,41 @@ impl<D: DataRef + Sized> memory::Allocator for Allocator<D> {
 
     fn get(&self, ptr: Ptr) -> &Self::Value {
         let idx = ptr.get() as usize;
-        self.data.get(idx..idx + SZ).unwrap().try_into().unwrap()
+        let bytes = self
+            .data
+            .get(idx..idx + RawNode::SIZE)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        bytemuck::TransparentWrapper::wrap_ref(bytes)
     }
 
     fn get_mut(&mut self, ptr: Ptr) -> &mut Self::Value {
         let idx = ptr.get() as usize;
-        self.data.get_mut(idx..idx + SZ).unwrap().try_into().unwrap()
+        let bytes = self
+            .data
+            .get_mut(idx..idx + RawNode::SIZE)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        bytemuck::TransparentWrapper::wrap_mut(bytes)
     }
 
+    /// Frees node at given pointer.  Panics if double-free is detected.
+    ///
+    /// Double-free detection relies on assumption that it’s cryptographically
+    /// impossible for a RawNode to have a valid value whose last 32 bytes are
+    /// zero.  When freeing memory, allocator will check if those bytes are
+    /// zero; if they are, this is a double-free; if they aren’t, the allocator
+    /// will zero them.
     fn free(&mut self, ptr: Ptr) {
-        let next =
+        let next_free =
             self.first_free.map_or([0; 4], |ptr| ptr.get().to_ne_bytes());
-        let idx = ptr.get() as usize;
-        self.data.get_mut(idx..idx + 4).unwrap().copy_from_slice(&next);
+        let bytes = bytemuck::TransparentWrapper::peel_mut(self.get_mut(ptr));
+        let bytes: &mut FreeRawNode = bytemuck::must_cast_mut(bytes);
+        assert_ne!([0; 32], bytes.marker, "Double-free detected at {ptr}");
+        bytes.marker.fill(0);
+        bytes.next_free = next_free;
         self.first_free = Some(ptr);
     }
 }


### PR DESCRIPTION
Take advantage of niche values of RawNode to mark nodes which has not yet been allocated or have been freed.  This allows the code to detect double-free errors.