### PR TITLE
solana-trie: change header and pointer format 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5231,6 +5231,7 @@ dependencies = [
  "bytemuck",
  "lib",
  "memory",
+ "pretty_assertions",
  "sealable-trie",
  "solana-program",
  "stdx",

--- a/solana/trie/Cargo.toml
+++ b/solana/trie/Cargo.toml
@@ -12,3 +12,6 @@ lib = { workspace = true, features = ["solana-program"] }
 memory.workspace = true
 sealable-trie.workspace = true
 stdx.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true

--- a/solana/trie/src/alloc.rs
+++ b/solana/trie/src/alloc.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroU32;
+
 use lib::hash::CryptoHash;
 use memory::Ptr;
 use sealable_trie::nodes::RawNode;
@@ -18,51 +20,125 @@ pub struct Allocator<D> {
     /// Blocks which were allocated and then freed don’t count as ‘unallocated’
     /// in this context.  This is position of the next block to return if the
     /// free list is empty.
-    pub(crate) next_block: u32,
+    pub(crate) next_block: Addr,
 
     /// Pointer to the first freed block; `None` if there were no freed blocks
     /// yet.
-    pub(crate) first_free: Option<Ptr>,
+    pub(crate) first_free: Option<Addr>,
 }
 
 impl<D: DataRef> Allocator<D> {
     /// Initialises the allocator with data in given account.
     pub(crate) fn new(data: D) -> Option<(Self, (Option<Ptr>, CryptoHash))> {
         let hdr = Header::decode(&data)?;
-        let next_block = hdr.next_block;
-        let first_free = Ptr::new(hdr.first_free).ok()?;
+        let next_block = Addr::new(hdr.next_block)?;
+        let first_free = Addr::new(hdr.first_free);
         let alloc = Self { data, next_block, first_free };
         let root = (hdr.root_ptr, hdr.root_hash);
         Some((alloc, root))
     }
 
     /// Grabs a block from a free list.  Returns `None` if free list is empty.
-    fn alloc_from_freelist(&mut self) -> Option<Ptr> {
-        let ptr = self.first_free.take()?;
-        let idx = ptr.get() as usize;
+    fn alloc_from_freelist(&mut self) -> Option<Addr> {
+        let addr = self.first_free?;
+        let idx = addr.usize().unwrap();
         let next = self.data.get(idx..idx + 4).unwrap().try_into().unwrap();
-        self.first_free = Ptr::new(u32::from_ne_bytes(next)).unwrap();
-        Some(ptr)
+        self.first_free = Addr::new(u32::from_ne_bytes(next));
+        Some(addr)
     }
 
     /// Grabs a next available block.  Returns `None` if account run out of
     /// space.
-    fn alloc_next_block(&mut self) -> Option<Ptr> {
-        let ptr = Ptr::new(self.next_block).ok().flatten()?;
-        let len = u32::try_from(self.data.len()).unwrap_or(u32::MAX);
-        let end = self.next_block.checked_add(RawNode::SIZE as u32)?;
-        if end > len && !self.data.enlarge(usize::try_from(end).ok()?) {
+    fn alloc_next_block(&mut self) -> Option<Addr> {
+        let addr = self.next_block;
+        let next = addr.succ()?;
+        let end = next.usize()?;
+        if end > self.data.len() && !self.data.enlarge(end) {
             None
         } else {
-            self.next_block = end;
-            Some(ptr)
+            self.next_block = next;
+            Some(addr)
         }
+    }
+}
+
+
+/// Address within the trie data.
+///
+/// The value is never zero and when converting from [`Ptr`] always aligned to
+/// [`RawNode::SIZE`] bytes, i.e. size of a single allocation.
+#[derive(Clone, Copy)]
+pub(crate) struct Addr(NonZeroU32);
+
+impl Addr {
+    fn new(addr: u32) -> Option<Self> { NonZeroU32::new(addr).map(Self) }
+
+    /// Returns next properly aligned block or `None` if next address would
+    /// overflow.
+    pub fn succ(self) -> Option<Self> {
+        self.0.get().checked_add(RawNode::SIZE as u32).and_then(Self::new)
+    }
+
+    /// Cast address to `usize` or retuns `None` if the value doesn’t fit.  The
+    /// latter only happens on 16-bit systems.
+    pub fn usize(self) -> Option<usize> { usize::try_from(self.0.get()).ok() }
+
+    /// Returns wrapped `u32` value.
+    pub fn u32(self) -> u32 { self.0.get() }
+
+    /// Returns range of addresses covered by block this address points at.
+    fn range(self) -> core::ops::Range<usize> {
+        self.usize()
+            .and_then(|addr| Some(addr..(addr.checked_add(RawNode::SIZE)?)))
+            .unwrap()
+    }
+}
+
+impl From<Ptr> for Addr {
+    fn from(ptr: Ptr) -> Self {
+        ptr.get().checked_mul(RawNode::SIZE as u32).and_then(Self::new).unwrap()
+    }
+}
+
+impl From<Addr> for Ptr {
+    /// Converts address to a [`Ptr`] pointer; panics if the address isn’t
+    /// properly aligned.
+    ///
+    /// If the address has been constructed by conversion from [`Ptr`] than it
+    /// is guaranteed to be properly aligned.
+    fn from(addr: Addr) -> Self {
+        let addr = addr.0.get();
+        debug_assert_eq!(
+            0,
+            addr % RawNode::SIZE as u32,
+            "Misaligned address: {addr}"
+        );
+        // The first unwrap handles Result.  It never fails since the only
+        // possible error condition is value passed to Ptr::new being too large.
+        // However, we’re dividing u32 by 72 which will never exceed Ptr::MAX.
+        // (This is something compiler will hopefully notice).
+        //
+        // The second unwrap handles Option.  It never fails since addr is at
+        // least RawNode::SIZE so dividing it gets us at least one.
+        Self::new(addr / RawNode::SIZE as u32).unwrap().unwrap()
+    }
+}
+
+impl core::fmt::Display for Addr {
+    fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> core::fmt::Result {
+        self.0.get().fmt(fmtr)
+    }
+}
+
+impl core::fmt::Debug for Addr {
+    fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> core::fmt::Result {
+        self.0.get().fmt(fmtr)
     }
 }
 
 /// Structure of an unallocated node.
 #[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
-#[repr(C, packed)]
+#[repr(C)]
 struct FreeRawNode {
     /// Pointer of the next free node on a free-list (encoded using native
     /// endianess) or zero if this is the last free node.
@@ -84,30 +160,21 @@ impl<D: DataRef + Sized> memory::Allocator for Allocator<D> {
         let ptr = self
             .alloc_from_freelist()
             .or_else(|| self.alloc_next_block())
-            .ok_or(memory::OutOfMemory)?;
+            .ok_or(memory::OutOfMemory)?
+            .into();
         self.set(ptr, value);
         Ok(ptr)
     }
 
     fn get(&self, ptr: Ptr) -> &Self::Value {
-        let idx = ptr.get() as usize;
-        let bytes = self
-            .data
-            .get(idx..idx + RawNode::SIZE)
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let range = Addr::from(ptr).range();
+        let bytes = self.data.get(range).unwrap().try_into().unwrap();
         bytemuck::TransparentWrapper::wrap_ref(bytes)
     }
 
     fn get_mut(&mut self, ptr: Ptr) -> &mut Self::Value {
-        let idx = ptr.get() as usize;
-        let bytes = self
-            .data
-            .get_mut(idx..idx + RawNode::SIZE)
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let range = Addr::from(ptr).range();
+        let bytes = self.data.get_mut(range).unwrap().try_into().unwrap();
         bytemuck::TransparentWrapper::wrap_mut(bytes)
     }
 
@@ -120,12 +187,26 @@ impl<D: DataRef + Sized> memory::Allocator for Allocator<D> {
     /// will zero them.
     fn free(&mut self, ptr: Ptr) {
         let next_free =
-            self.first_free.map_or([0; 4], |ptr| ptr.get().to_ne_bytes());
+            self.first_free.map_or(0u32, |addr| addr.0.get()).to_ne_bytes();
         let bytes = bytemuck::TransparentWrapper::peel_mut(self.get_mut(ptr));
         let bytes: &mut FreeRawNode = bytemuck::must_cast_mut(bytes);
         assert_ne!([0; 32], bytes.marker, "Double-free detected at {ptr}");
         bytes.marker.fill(0);
         bytes.next_free = next_free;
-        self.first_free = Some(ptr);
+        self.first_free = Some(Addr::from(ptr));
     }
+}
+
+#[test]
+#[should_panic]
+fn test_double_free_detection() {
+    use memory::Allocator as _;
+    use sealable_trie::nodes::Reference;
+
+    let (mut alloc, _root) = Allocator::new([0; 740]).unwrap();
+    let hash = CryptoHash::test(42);
+    let child = Reference::value(false, &hash);
+    let ptr = alloc.alloc(RawNode::branch(child, child)).unwrap();
+    alloc.free(ptr);
+    alloc.free(ptr);
 }


### PR DESCRIPTION
There are two changes to the format.  They are backwards-incompatible.

Firstly, add more padding to the header so that it is 72 bytes.  This
way the header has the same size as allocated blocks and indexes at
which blocks are stored are aligned to their size.  Secondly, change
the Ptr value from being byte offset to block index.  I.e. rather than
offset 72 or 144 the Ptr is now 1 or 2.

There are two motivating factors for this change.

Firstly, this change makes Ptr space more ‘dense’.  With Solana
account being at most 10 MiB, the highest Ptr value fits in 18 bits.
Ptr is limited to 30 bits so that leaves 12 bits for further
extensions.  For example, if we ever need to split the trie into
multiple accounts, those bits could be used to store 4-bit account
index and 8-bit bump value.

Secondly, Ptr no longer has alignment requirement.  Therefore it’s not
possible for the caller to provide a misaligned address for the node.
All alignment is handled internally by the allocator.  This removes
potential error vector and potential need to verify incoming Ptr
values.  Values out of bound can of course still be provided but those
are naturally checked when indexing the array.
