### PR TITLE
Tiny typo fix; s/bond/bound/

### DIFF
--- a/common/cf-guest/src/lib.rs
+++ b/common/cf-guest/src/lib.rs
@@ -61,12 +61,12 @@ pub fn digest_with_client_id(
 macro_rules! any_convert {
     (
         $Proto:ty,
-        $Type:ident $( <$T:ident: $bond:path = $concrete:path> )?,
+        $Type:ident $( <$T:ident: $bound:path = $concrete:path> )?,
         $(obj: $obj:expr,)*
         $(bad: $bad:expr,)*
         $(conv: $any:ident => $from_any:expr,)?
     ) => {
-        impl $(<$T: $bond>)* $Type $(<$T>)* {
+        impl $(<$T: $bound>)* $Type $(<$T>)* {
             /// Encodes the object into a vector as protocol buffer message.
             pub fn encode(&self) -> alloc::vec::Vec<u8> {
                 prost::Message::encode_to_vec(&$crate::proto::$Type::from(self))
@@ -94,34 +94,34 @@ macro_rules! any_convert {
             }
         }
 
-        impl $(<$T: $bond>)* $crate::proto::AnyConvert for $Type $(<$T>)* {
+        impl $(<$T: $bound>)* $crate::proto::AnyConvert for $Type $(<$T>)* {
             fn to_any(&self) -> (&'static str, alloc::vec::Vec<u8>) {
                 (<$Proto>::IBC_TYPE_URL, self.encode())
             }
             $crate::any_convert!(@try_from_any $Proto; $($any => $from_any)*);
         }
 
-        impl $(<$T: $bond>)* From<$Type $(<$T>)*> for $crate::proto::Any {
+        impl $(<$T: $bound>)* From<$Type $(<$T>)*> for $crate::proto::Any {
             fn from(msg: $Type $(<$T>)*) -> Self {
                 Self::from(&msg)
             }
         }
 
-        impl $(<$T: $bond>)* From<&$Type $(<$T>)*> for $crate::proto::Any {
+        impl $(<$T: $bound>)* From<&$Type $(<$T>)*> for $crate::proto::Any {
             fn from(msg: &$Type $(<$T>)*) -> Self {
                 let (url, value) = $crate::proto::AnyConvert::to_any(msg);
                 Self { type_url: url.into(), value }
             }
         }
 
-        impl $(<$T: $bond>)* TryFrom<$crate::proto::Any> for $Type $(<$T>)* {
+        impl $(<$T: $bound>)* TryFrom<$crate::proto::Any> for $Type $(<$T>)* {
             type Error = $crate::proto::DecodeError;
             fn try_from(any: $crate::proto::Any) -> Result<Self, Self::Error> {
                 Self::try_from(&any)
             }
         }
 
-        impl $(<$T: $bond>)* TryFrom<&$crate::proto::Any> for $Type $(<$T>)* {
+        impl $(<$T: $bound>)* TryFrom<&$crate::proto::Any> for $Type $(<$T>)* {
             type Error = $crate::proto::DecodeError;
             fn try_from(any: &$crate::proto::Any) -> Result<Self, Self::Error> {
                 <Self as $crate::proto::AnyConvert>::try_from_any(
@@ -131,7 +131,7 @@ macro_rules! any_convert {
             }
         }
 
-        impl $(<$T: $bond>)* ibc_primitives::proto::Protobuf<$Proto>
+        impl $(<$T: $bound>)* ibc_primitives::proto::Protobuf<$Proto>
             for $Type $(<$T>)* { }
 
         #[test]

--- a/common/guestchain/src/ibc_state.rs
+++ b/common/guestchain/src/ibc_state.rs
@@ -62,11 +62,11 @@ pub fn digest_with_client_id(
 macro_rules! any_convert {
     (
         $Proto:ty,
-        $Type:ident $( <$T:ident: $bond:path = $concrete:path> )?,
+        $Type:ident $( <$T:ident: $bound:path = $concrete:path> )?,
         $(obj: $obj:expr,)*
         $(bad: $bad:expr,)*
     ) => {
-        impl $(<$T: $bond>)* $Type $(<$T>)* {
+        impl $(<$T: $bound>)* $Type $(<$T>)* {
             /// Encodes the object into a vector as protocol buffer message.
             pub fn encode_to_vec(&self) -> alloc::vec::Vec<u8> {
                 prost::Message::encode_to_vec(&$crate::proto::$Type::from(self))
@@ -82,19 +82,19 @@ macro_rules! any_convert {
             }
         }
 
-        impl $(<$T: $bond>)* From<$Type $(<$T>)*> for $crate::Any {
+        impl $(<$T: $bound>)* From<$Type $(<$T>)*> for $crate::Any {
             fn from(obj: $Type $(<$T>)*) -> $crate::Any {
                 $crate::proto::$Type::from(obj).into()
             }
         }
 
-        impl $(<$T: $bond>)* From<&$Type $(<$T>)*> for $crate::Any {
+        impl $(<$T: $bound>)* From<&$Type $(<$T>)*> for $crate::Any {
             fn from(obj: &$Type $(<$T>)*) -> $crate::Any {
                 $crate::proto::$Type::from(obj).into()
             }
         }
 
-        impl $(<$T: $bond>)* TryFrom<$crate::Any> for $Type $(<$T>)* {
+        impl $(<$T: $bound>)* TryFrom<$crate::Any> for $Type $(<$T>)* {
             type Error = $crate::proto::DecodeError;
             fn try_from(
                 any: $crate::Any,
@@ -104,7 +104,7 @@ macro_rules! any_convert {
             }
         }
 
-        impl $(<$T: $bond>)* TryFrom<&$crate::Any> for $Type $(<$T>)*
+        impl $(<$T: $bound>)* TryFrom<&$crate::Any> for $Type $(<$T>)*
         {
             type Error = $crate::proto::DecodeError;
             fn try_from(
@@ -115,7 +115,7 @@ macro_rules! any_convert {
             }
         }
 
-        impl $(<$T: $bond>)* ibc_primitives::proto::Protobuf<$Proto>
+        impl $(<$T: $bound>)* ibc_primitives::proto::Protobuf<$Proto>
             for $Type $(<$T>)* { }
 
         #[test]


### PR DESCRIPTION
Through the magic of copy’n’paste, the typo of ‘bond’ rather than ‘bound’ spread to multiplle places.  Fix all of that.