### PR TITLE
cf-guest: provide more IBC-independent interfaces

### DIFF
--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -149,7 +149,8 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
         value: Vec<u8>,
     ) -> Result {
         let value = Some(value.as_slice());
-        proof::verify(prefix, proof, root, path, value).map_err(Into::into)
+        proof::verify(prefix, proof.as_ref(), root.as_bytes(), path, value)
+            .map_err(Into::into)
     }
 
     /// Verifies membership proof.
@@ -162,7 +163,8 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
     ) -> Result {
-        proof::verify(prefix, proof, root, path, None).map_err(Into::into)
+        proof::verify(prefix, proof.as_ref(), root.as_bytes(), path, None)
+            .map_err(Into::into)
     }
 }
 

--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -214,7 +214,8 @@ where
         client_id: &ibc::ClientId,
         header: Any,
     ) -> Result<Vec<ibc::Height>> {
-        self.update_state(ctx, client_id, header)
+        let header = Header::<PK>::try_from(header)?;
+        self.do_update_state(ctx, client_id, header)
     }
 
     fn update_state_on_misbehaviour(
@@ -251,10 +252,11 @@ where
     fn verify_client_message(
         &self,
         ctx: &V,
-        client_id: &ibc::ClientId,
+        _client_id: &ibc::ClientId,
         client_message: Any,
     ) -> Result {
-        self.verify_client_message(ctx, client_id, client_message)
+        let client_message = ClientMessage::<PK>::try_from(client_message)?;
+        self.do_verify_client_message(ctx, client_message)
     }
 
     fn check_for_misbehaviour(
@@ -263,7 +265,8 @@ where
         client_id: &ibc::ClientId,
         client_message: Any,
     ) -> Result<bool> {
-        self.check_for_misbehaviour(ctx, client_id, client_message)
+        let client_message = ClientMessage::<PK>::try_from(client_message)?;
+        self.do_check_for_misbehaviour(ctx, client_id, client_message)
     }
 
     fn status(
@@ -297,14 +300,12 @@ where
 
 
 impl<PK: PubKey> ClientState<PK> {
-    pub fn update_state(
+    pub fn do_update_state(
         &self,
         ctx: &mut impl CommonContext<PK>,
         client_id: &ibc::ClientId,
-        header: Any,
+        header: Header<PK>,
     ) -> Result<Vec<ibc::Height>> {
-        let header = crate::proto::Header::try_from(header)?;
-        let header = crate::Header::<PK>::try_from(header)?;
         let header_height =
             ibc::Height::new(1, header.block_header.block_height.into())?;
 
@@ -330,13 +331,12 @@ impl<PK: PubKey> ClientState<PK> {
         Ok(alloc::vec![header_height])
     }
 
-    pub fn verify_client_message(
+    pub fn do_verify_client_message(
         &self,
         ctx: &impl guestchain::Verifier<PK>,
-        _client_id: &ibc::ClientId,
-        client_message: Any,
+        client_message: ClientMessage<PK>,
     ) -> Result<()> {
-        match ClientMessage::<PK>::try_from(client_message)? {
+        match client_message {
             ClientMessage::Header(header) => self.verify_header(ctx, header),
             ClientMessage::Misbehaviour(misbehaviour) => {
                 self.verify_misbehaviour(ctx, misbehaviour)
@@ -350,7 +350,17 @@ impl<PK: PubKey> ClientState<PK> {
         client_id: &ibc::ClientId,
         client_message: Any,
     ) -> Result<bool> {
-        match ClientMessage::<PK>::try_from(client_message)? {
+        let client_message = ClientMessage::<PK>::try_from(client_message)?;
+        self.do_check_for_misbehaviour(ctx, client_id, client_message)
+    }
+
+    pub fn do_check_for_misbehaviour(
+        &self,
+        ctx: &impl CommonContext<PK>,
+        client_id: &ibc::ClientId,
+        client_message: ClientMessage<PK>,
+    ) -> Result<bool> {
+        match client_message {
             ClientMessage::Header(header) => {
                 self.check_for_misbehaviour_in_header(ctx, client_id, header)
             }

--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -149,8 +149,14 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
         value: Vec<u8>,
     ) -> Result {
         let value = Some(value.as_slice());
-        proof::verify(prefix, proof.as_ref(), root.as_bytes(), path, value)
-            .map_err(Into::into)
+        proof::verify(
+            prefix.as_bytes(),
+            proof.as_ref(),
+            root.as_bytes(),
+            path,
+            value,
+        )
+        .map_err(Into::into)
     }
 
     /// Verifies membership proof.
@@ -163,8 +169,14 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
     ) -> Result {
-        proof::verify(prefix, proof.as_ref(), root.as_bytes(), path, None)
-            .map_err(Into::into)
+        proof::verify(
+            prefix.as_bytes(),
+            proof.as_ref(),
+            root.as_bytes(),
+            path,
+            None,
+        )
+        .map_err(Into::into)
     }
 }
 

--- a/common/guestchain/src/validators.rs
+++ b/common/guestchain/src/validators.rs
@@ -19,6 +19,7 @@ pub trait PubKey:
     type Signature: Signature;
 
     fn to_vec(&self) -> Vec<u8>;
+    fn as_bytes<'a>(&'a self) -> alloc::borrow::Cow<'a, [u8]>;
     fn from_bytes(bytes: &[u8]) -> Result<Self, BadFormat>;
 }
 
@@ -27,6 +28,7 @@ pub trait Signature:
     Clone + Eq + core::fmt::Debug + borsh::BorshSerialize + borsh::BorshDeserialize
 {
     fn to_vec(&self) -> Vec<u8>;
+    fn as_bytes<'a>(&'a self) -> alloc::borrow::Cow<'a, [u8]>;
     fn from_bytes(bytes: &[u8]) -> Result<Self, BadFormat>;
 }
 
@@ -151,6 +153,9 @@ pub(crate) mod test_utils {
         type Signature = MockSignature;
 
         fn to_vec(&self) -> Vec<u8> { self.0.to_be_bytes().to_vec() }
+        fn as_bytes<'a>(&'a self) -> alloc::borrow::Cow<'a, [u8]> {
+            self.to_vec().into()
+        }
         fn from_bytes(bytes: &[u8]) -> Result<Self, super::BadFormat> {
             Ok(Self(u32::from_be_bytes(bytes.try_into()?)))
         }
@@ -174,6 +179,10 @@ pub(crate) mod test_utils {
                 pubkey: self.1 .0.to_be_bytes(),
             })
             .to_vec()
+        }
+
+        fn as_bytes<'a>(&'a self) -> alloc::borrow::Cow<'a, [u8]> {
+            self.to_vec().into()
         }
 
         fn from_bytes(bytes: &[u8]) -> Result<Self, super::BadFormat> {

--- a/solana/signature-verifier/src/ed25519.rs
+++ b/solana/signature-verifier/src/ed25519.rs
@@ -60,6 +60,9 @@ impl guestchain::PubKey for PubKey {
     type Signature = Signature;
 
     fn to_vec(&self) -> alloc::vec::Vec<u8> { self.0.to_vec() }
+    fn as_bytes<'a>(&'a self) -> alloc::borrow::Cow<'a, [u8]> {
+        (&self.0[..]).into()
+    }
     fn from_bytes(bytes: &[u8]) -> Result<Self, guestchain::BadFormat> {
         Ok(Self(bytes.try_into()?))
     }
@@ -100,6 +103,9 @@ impl<'a> TryFrom<&'a [u8]> for &'a Signature {
 #[cfg(feature = "guest")]
 impl guestchain::Signature for Signature {
     fn to_vec(&self) -> alloc::vec::Vec<u8> { self.0.to_vec() }
+    fn as_bytes<'a>(&'a self) -> alloc::borrow::Cow<'a, [u8]> {
+        (&self.0[..]).into()
+    }
     fn from_bytes(bytes: &[u8]) -> Result<Self, guestchain::BadFormat> {
         Ok(Self(bytes.try_into()?))
     }

--- a/solana/signature-verifier/src/ed25519.rs
+++ b/solana/signature-verifier/src/ed25519.rs
@@ -59,10 +59,9 @@ impl PartialEq<PubKey> for solana_program::pubkey::Pubkey {
 impl guestchain::PubKey for PubKey {
     type Signature = Signature;
 
-    fn to_vec(&self) -> alloc::vec::Vec<u8> { self.0.to_vec() }
-    fn as_bytes<'a>(&'a self) -> alloc::borrow::Cow<'a, [u8]> {
-        (&self.0[..]).into()
-    }
+    #[inline]
+    fn as_bytes(&self) -> alloc::borrow::Cow<'_, [u8]> { (&self.0[..]).into() }
+    #[inline]
     fn from_bytes(bytes: &[u8]) -> Result<Self, guestchain::BadFormat> {
         Ok(Self(bytes.try_into()?))
     }
@@ -102,10 +101,9 @@ impl<'a> TryFrom<&'a [u8]> for &'a Signature {
 
 #[cfg(feature = "guest")]
 impl guestchain::Signature for Signature {
-    fn to_vec(&self) -> alloc::vec::Vec<u8> { self.0.to_vec() }
-    fn as_bytes<'a>(&'a self) -> alloc::borrow::Cow<'a, [u8]> {
-        (&self.0[..]).into()
-    }
+    #[inline]
+    fn as_bytes(&self) -> alloc::borrow::Cow<'_, [u8]> { (&self.0[..]).into() }
+    #[inline]
     fn from_bytes(bytes: &[u8]) -> Result<Self, guestchain::BadFormat> {
         Ok(Self(bytes.try_into()?))
     }


### PR DESCRIPTION
To help usage of cf-guest with old IBC versions, provide more APIs
which don’t depend on IBC types.  For example, rather than taking
CommitmentRoot simply take byte slice.
