### PR TITLE
solana-ibc: use custom hash for tm sig verification

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -120,22 +120,66 @@ impl<'a, 'b> ibc::ClientStateExecution<IbcStorage<'a, 'b>> for AnyClientState {
 }
 
 mod tm {
+    use lib::hash::CryptoHash;
     use tendermint::crypto::signature::Error;
+    use tendermint::crypto::Sha256;
+    use tendermint::merkle::{MerkleHash, NonIncremental};
     use tendermint_light_client_verifier::operations::commit_validator::ProdCommitValidator;
     use tendermint_light_client_verifier::operations::voting_power::ProvidedVotingPowerCalculator;
-    use tendermint_light_client_verifier::predicates::ProdPredicates;
+    use tendermint_light_client_verifier::predicates::{
+        ProdPredicates, VerificationPredicates,
+    };
     use tendermint_light_client_verifier::PredicateVerifier;
 
     pub(super) struct TmVerifier;
     pub(super) struct SigVerifier;
 
+    #[derive(Default)]
+    pub(super) struct InnerProdPredicates;
+
     impl crate::ibc::tm::TmVerifier for TmVerifier {
         type Verifier = PredicateVerifier<
-            ProdPredicates,
+            InnerProdPredicates,
             ProvidedVotingPowerCalculator<SigVerifier>,
             ProdCommitValidator,
         >;
         fn verifier(&self) -> Self::Verifier { Default::default() }
+    }
+
+    #[derive(Default)]
+    pub struct CustomHash(pub [u8; 32]);
+
+    impl Sha256 for CustomHash {
+        fn digest(
+            data: impl AsRef<[u8]>,
+        ) -> [u8; tendermint::merkle::HASH_SIZE] {
+            let hash = CryptoHash::digest(data.as_ref());
+            hash.0
+        }
+    }
+
+    impl MerkleHash for CustomHash {
+        fn empty_hash(&mut self) -> tendermint::merkle::Hash {
+            CustomHash::digest(&[])
+        }
+
+        fn leaf_hash(&mut self, bytes: &[u8]) -> tendermint::merkle::Hash {
+            CustomHash::digest([[0x00].as_ref(), bytes].concat())
+        }
+
+        fn inner_hash(
+            &mut self,
+            left: tendermint::merkle::Hash,
+            right: tendermint::merkle::Hash,
+        ) -> tendermint::merkle::Hash {
+            CustomHash::digest(
+                [[0x01].as_ref(), left.as_ref(), right.as_ref()].concat(),
+            )
+        }
+    }
+
+    impl VerificationPredicates for InnerProdPredicates {
+        type Sha256 = CustomHash;
     }
 
     impl tendermint::crypto::signature::Verifier for SigVerifier {

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -123,12 +123,10 @@ mod tm {
     use lib::hash::CryptoHash;
     use tendermint::crypto::signature::Error;
     use tendermint::crypto::Sha256;
-    use tendermint::merkle::{MerkleHash, NonIncremental};
+    use tendermint::merkle::MerkleHash;
     use tendermint_light_client_verifier::operations::commit_validator::ProdCommitValidator;
     use tendermint_light_client_verifier::operations::voting_power::ProvidedVotingPowerCalculator;
-    use tendermint_light_client_verifier::predicates::{
-        ProdPredicates, VerificationPredicates,
-    };
+    use tendermint_light_client_verifier::predicates::VerificationPredicates;
     use tendermint_light_client_verifier::PredicateVerifier;
 
     pub(super) struct TmVerifier;
@@ -160,7 +158,7 @@ mod tm {
 
     impl MerkleHash for CustomHash {
         fn empty_hash(&mut self) -> tendermint::merkle::Hash {
-            CustomHash::digest(&[])
+            CustomHash::digest([])
         }
 
         fn leaf_hash(&mut self, bytes: &[u8]) -> tendermint::merkle::Hash {


### PR DESCRIPTION
Tendermint verifier has a generic which gives us ability to choose a type to implement custom hash logic. Since the default `sha256` hashing takes a lot of compute units, we need to use sha256 from solana syscalls which use significantly low compute units. 