### PR TITLE
solana-ibc: log client state and current block height

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -219,10 +219,22 @@ pub mod solana_ibc {
                 ctx.remaining_accounts = rest;
             }
         }
+        let height = store.borrow().chain.head().unwrap().block_height;
+        // height just before the data is added to the trie.
+        msg!("Current Block height {:?}", u64::from(height));
 
         ::ibc::core::entrypoint::dispatch(&mut store, &mut router, message)
             .map_err(error::Error::ContextError)
-            .map_err(move |err| error!((&err)))
+            .map_err(move |err| error!((&err)))?;
+
+        // Log client state only when it is updated which is when `UpdateClient` message
+        // sent.
+        if ctx.remaining_accounts.split_last().is_some() {
+            let storage = &store.borrow().private;
+            let client_state = &storage.clients[0].client_state;
+            msg!("This is updated client state {:?}", client_state.as_bytes());
+        }
+        Ok(())
     }
 
     /// Called to set up a connection, channel and store the next

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -221,7 +221,7 @@ pub mod solana_ibc {
         }
         let height = store.borrow().chain.head()?.block_height;
         // height just before the data is added to the trie.
-        msg!("Current Block height {:?}", u64::from(height));
+        msg!("Current Block height {}", height);
 
         ::ibc::core::entrypoint::dispatch(&mut store, &mut router, message)
             .map_err(error::Error::ContextError)

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -219,7 +219,7 @@ pub mod solana_ibc {
                 ctx.remaining_accounts = rest;
             }
         }
-        let height = store.borrow().chain.head().unwrap().block_height;
+        let height = store.borrow().chain.head()?.block_height;
         // height just before the data is added to the trie.
         msg!("Current Block height {:?}", u64::from(height));
 


### PR DESCRIPTION
There might be some instances where we need client state at a particular height mostly for finding the proof height of a packet. But since we are only storing the latest client state and storing previous states is expensive, we can just log it and fetch it whenever we want by traversing the previous logs. The height is also logged to find the proof height which is `height + 1`. Though it might not be used as much, but its logged for convenience.