### PR TITLE
solana-ibc: provide hash implementations to Tendermint code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2242,7 +2242,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "base64 0.21.7",
  "borsh 0.10.3",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2306,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2323,10 +2323,9 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
- "bytes",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -2343,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2357,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2366,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2382,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2397,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2420,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2433,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2449,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2469,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2487,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -2499,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2520,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2535,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2559,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2577,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2601,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2616,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2630,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2649,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2659,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2698,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.50.0"
-source = "git+https://github.com/dhruvja/ibc-rs?rev=6bb51e2d02c016d572974ec8f47633c1f85b6ba8#6bb51e2d02c016d572974ec8f47633c1f85b6ba8"
+source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,16 +45,16 @@ env_logger = "0.7.1"
 hex-literal = "0.4.1"
 
 # Use unreleased ibc-rs which supports custom verifier.
-ibc                       = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false, features = ["borsh", "serde"] }
-ibc-core-channel-types    = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
-ibc-core-client-context   = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
-ibc-core-client-types     = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
-ibc-core-commitment-types = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
-ibc-core-connection-types = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
-ibc-core-host             = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
-ibc-core-host-types       = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
-ibc-primitives            = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
-ibc-testkit               = { git = "https://github.com/dhruvja/ibc-rs", rev = "6bb51e2d02c016d572974ec8f47633c1f85b6ba8", default-features = false }
+ibc                       = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false, features = ["borsh", "serde"] }
+ibc-core-channel-types    = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc-core-client-context   = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc-core-client-types     = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc-core-commitment-types = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc-core-connection-types = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc-core-host             = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc-core-host-types       = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc-primitives            = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc-testkit               = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
 
 ibc-proto = { version = "0.41.0", default-features = false }
 insta = { version = "1.34.0" }

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -24,20 +24,21 @@ anchor-spl.workspace = true
 base64.workspace = true
 bytemuck = { workspace = true, features = ["must_cast", "zeroable_atomics"] }
 derive_more.workspace = true
+hex-literal.workspace = true
+ibc-proto.workspace = true
 ibc-testkit = { workspace = true, optional = true }
 ibc.workspace = true
-ibc-proto.workspace = true
 linear-map.workspace = true
 primitive-types.workspace = true
-tendermint.workspace = true
-tendermint-light-client-verifier.workspace = true
+prost.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 spl-associated-token-account.workspace = true
 spl-token.workspace = true
 strum.workspace = true
+tendermint-light-client-verifier.workspace = true
+tendermint.workspace = true
 uint.workspace = true
-prost.workspace = true  
 
 guestchain.workspace = true
 cf-guest.workspace = true
@@ -53,7 +54,6 @@ wasm = { workspace = true }
 [dev-dependencies]
 anchor-client.workspace = true
 anyhow.workspace = true
-hex-literal.workspace = true
 ibc-testkit.workspace = true
 insta.workspace = true
 

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -261,7 +261,6 @@ impl tendermint::merkle::MerkleHash for SolanaHostFunctions {
         // correct.
         hex_literal::hex!("e3b0c44298fc1c14 9afbf4c8996fb924"
                           "27ae41e4649b934c a495991b7852b855")
-        .into()
     }
 
     fn leaf_hash(&mut self, bytes: &[u8]) -> [u8; 32] {

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -4,6 +4,8 @@
 //! implementation for `verify_client_message` which uses custom signature
 //! verifier.
 
+use anchor_lang::solana_program;
+
 use super::AnyClientState;
 use crate::ibc;
 use crate::storage::IbcStorage;
@@ -36,21 +38,56 @@ impl ibc::ClientStateCommon for AnyClientState {
         proof_upgrade_consensus_state: ibc::CommitmentProofBytes,
         root: &ibc::CommitmentRoot,
     ) -> Result);
-    delegate!(fn verify_membership(
+
+    fn verify_membership(
         &self,
         prefix: &ibc::CommitmentPrefix,
         proof: &ibc::CommitmentProofBytes,
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
         value: Vec<u8>,
-    ) -> Result);
-    delegate!(fn verify_non_membership(
+    ) -> Result {
+        match self {
+            AnyClientState::Tendermint(cs) => {
+                ibc::tm::client_state::verify_membership::<SolanaHostFunctions>(
+                    &cs.inner().proof_specs,
+                    prefix,
+                    proof,
+                    root,
+                    path,
+                    value,
+                )
+            }
+            AnyClientState::Wasm(_) => unimplemented!(),
+            #[cfg(any(test, feature = "mocks"))]
+            AnyClientState::Mock(cs) => {
+                cs.verify_membership(prefix, proof, root, path, value)
+            }
+        }
+    }
+
+    fn verify_non_membership(
         &self,
         prefix: &ibc::CommitmentPrefix,
         proof: &ibc::CommitmentProofBytes,
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
-    ) -> Result);
+    ) -> Result {
+        match self {
+            AnyClientState::Tendermint(cs) => {
+                ibc::tm::client_state::verify_non_membership::<
+                    SolanaHostFunctions,
+                >(
+                    &cs.inner().proof_specs, prefix, proof, root, path
+                )
+            }
+            AnyClientState::Wasm(_) => unimplemented!(),
+            #[cfg(any(test, feature = "mocks"))]
+            AnyClientState::Mock(cs) => {
+                cs.verify_non_membership(prefix, proof, root, path)
+            }
+        }
+    }
 }
 
 impl<'a, 'b> ibc::ClientStateValidation<IbcStorage<'a, 'b>> for AnyClientState {
@@ -62,12 +99,11 @@ impl<'a, 'b> ibc::ClientStateValidation<IbcStorage<'a, 'b>> for AnyClientState {
     ) -> Result {
         match self {
             AnyClientState::Tendermint(cs) => {
-                ibc::tm::client_state::verify_client_message(
-                    cs.inner(),
-                    ctx,
-                    client_id,
-                    client_message,
-                    &tm::TmVerifier,
+                ibc::tm::client_state::verify_client_message::<
+                    _,
+                    SolanaHostFunctions,
+                >(
+                    cs.inner(), ctx, client_id, client_message, &tm::TmVerifier
                 )
             }
             AnyClientState::Wasm(_) => unimplemented!(),
@@ -160,4 +196,100 @@ mod tm {
             Err(Error::VerificationFailed)
         }
     }
+}
+
+#[derive(Default)]
+struct SolanaHostFunctions;
+
+impl ibc::HostFunctionsProvider for SolanaHostFunctions {
+    fn sha2_256(message: &[u8]) -> [u8; 32] {
+        solana_program::hash::hash(message).to_bytes()
+    }
+
+    fn sha2_512(_message: &[u8]) -> [u8; 64] { unimplemented!() }
+    fn sha2_512_truncated(_message: &[u8]) -> [u8; 32] { unimplemented!() }
+    fn sha3_512(_message: &[u8]) -> [u8; 64] { unimplemented!() }
+    fn ripemd160(_message: &[u8]) -> [u8; 20] { unimplemented!() }
+
+    /* Following methods are needed once we upgrade to ibc 0.51:
+
+    fn keccak_256(message: &[u8]) -> [u8; 32] {
+        solana_program::keccak::hash(message).0
+    }
+
+    fn blake3(message: &[u8]) -> [u8; 32] {
+        solana_program::blake3::hash(message).0
+    }
+
+    fn blake2b_512(message: &[u8]) -> [u8; 64] { unimplemented!() }
+    fn blake2s_256(message: &[u8]) -> [u8; 32] { unimplemented!() }
+    */
+}
+
+#[test]
+fn test_host_functions() {
+    use ibc::HostFunctionsProvider;
+
+    for input in ["".as_bytes(), "foo".as_bytes(), "bar".as_bytes()] {
+        assert_eq!(
+            ibc::HostFunctionsManager::sha2_256(input),
+            SolanaHostFunctions::sha2_256(input),
+            "input: {input:?}",
+        )
+    }
+}
+
+impl tendermint::crypto::Sha256 for SolanaHostFunctions {
+    fn digest(data: impl AsRef<[u8]>) -> [u8; 32] {
+        <Self as ibc::HostFunctionsProvider>::sha2_256(data.as_ref())
+    }
+}
+
+#[test]
+fn test_sha256() {
+    use tendermint::crypto::default::Sha256;
+    use tendermint::crypto::Sha256 as _;
+
+    for input in ["".as_bytes(), "foo".as_bytes(), "bar".as_bytes()] {
+        assert_eq!(Sha256::digest(input), SolanaHostFunctions::digest(input));
+    }
+}
+
+impl tendermint::merkle::MerkleHash for SolanaHostFunctions {
+    fn empty_hash(&mut self) -> [u8; 32] {
+        // This is sha256("").  test_merkle_hash below verifies that this is
+        // correct.
+        hex_literal::hex!("e3b0c44298fc1c14 9afbf4c8996fb924"
+                          "27ae41e4649b934c a495991b7852b855")
+        .into()
+    }
+
+    fn leaf_hash(&mut self, bytes: &[u8]) -> [u8; 32] {
+        solana_program::hash::hashv(&[&[0], bytes]).to_bytes()
+    }
+
+    fn inner_hash(&mut self, left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
+        solana_program::hash::hashv(&[&[1], &left, &right]).to_bytes()
+    }
+}
+
+#[test]
+fn test_merkle_hash() {
+    use tendermint::crypto::default::Sha256;
+    use tendermint::crypto::Sha256 as _;
+    use tendermint::merkle::MerkleHash as _;
+
+    let mut theirs = tendermint::merkle::NonIncremental::<Sha256>::default();
+    let mut ours = SolanaHostFunctions;
+
+    assert_eq!(Sha256::digest(b""), ours.empty_hash());
+    assert_eq!(theirs.empty_hash(), ours.empty_hash());
+
+    for input in ["".as_bytes(), "foo".as_bytes(), "bar".as_bytes()] {
+        assert_eq!(theirs.leaf_hash(input), ours.leaf_hash(input));
+    }
+
+    let foo = Sha256::digest(b"foo");
+    let bar = Sha256::digest(b"bar");
+    assert_eq!(theirs.inner_hash(foo, bar), ours.inner_hash(foo, bar));
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -156,10 +156,7 @@ impl<'a, 'b> ibc::ClientStateExecution<IbcStorage<'a, 'b>> for AnyClientState {
 }
 
 mod tm {
-    use lib::hash::CryptoHash;
     use tendermint::crypto::signature::Error;
-    use tendermint::crypto::Sha256;
-    use tendermint::merkle::MerkleHash;
     use tendermint_light_client_verifier::operations::commit_validator::ProdCommitValidator;
     use tendermint_light_client_verifier::operations::voting_power::ProvidedVotingPowerCalculator;
     use tendermint_light_client_verifier::predicates::VerificationPredicates;
@@ -180,40 +177,8 @@ mod tm {
         fn verifier(&self) -> Self::Verifier { Default::default() }
     }
 
-    #[derive(Default)]
-    pub struct CustomHash(pub [u8; 32]);
-
-    impl Sha256 for CustomHash {
-        fn digest(
-            data: impl AsRef<[u8]>,
-        ) -> [u8; tendermint::merkle::HASH_SIZE] {
-            let hash = CryptoHash::digest(data.as_ref());
-            hash.0
-        }
-    }
-
-    impl MerkleHash for CustomHash {
-        fn empty_hash(&mut self) -> tendermint::merkle::Hash {
-            CustomHash::digest([])
-        }
-
-        fn leaf_hash(&mut self, bytes: &[u8]) -> tendermint::merkle::Hash {
-            CustomHash::digest([[0x00].as_ref(), bytes].concat())
-        }
-
-        fn inner_hash(
-            &mut self,
-            left: tendermint::merkle::Hash,
-            right: tendermint::merkle::Hash,
-        ) -> tendermint::merkle::Hash {
-            CustomHash::digest(
-                [[0x01].as_ref(), left.as_ref(), right.as_ref()].concat(),
-            )
-        }
-    }
-
     impl VerificationPredicates for InnerProdPredicates {
-        type Sha256 = CustomHash;
+        type Sha256 = super::SolanaHostFunctions;
     }
 
     impl tendermint::crypto::signature::Verifier for SigVerifier {

--- a/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/ibc.rs
@@ -28,6 +28,9 @@ pub use ibc::core::client::types::{Height, Status, UpdateKind};
 pub use ibc::core::commitment_types::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
 };
+pub use ibc::core::commitment_types::proto::ics23::{
+    HostFunctionsManager, HostFunctionsProvider,
+};
 pub use ibc::core::connection::types::error::ConnectionError;
 #[cfg(test)]
 pub use ibc::core::connection::types::msgs::{


### PR DESCRIPTION
Take advantage of new features of ibc-rs which allow passing HostFunctionsProvider and SHA256 implementation to Tendermint code.

So far, IBC would hard-code native implementation whereas what we want is calls to Solana syscalls.  With recent changes to ibc-rs it’s now possible for us to pass our own implementation for the hash calculation.