### PR TITLE
sigverify: sort entries to speed up lookup

### DIFF
--- a/common/stdx/src/lib.rs
+++ b/common/stdx/src/lib.rs
@@ -39,6 +39,18 @@ pub fn split_at<const L: usize, T>(xs: &[T]) -> Option<(&[T; L], &[T])> {
     Some((head.try_into().unwrap(), tail))
 }
 
+/// Splits `&mut [T]` into `(&mut [T; L], &mut [T])`.  Returns `None` if input is too
+/// shorter.
+pub fn split_at_mut<const L: usize, T>(
+    xs: &mut [T],
+) -> Option<(&mut [T; L], &mut [T])> {
+    if xs.len() < L {
+        return None;
+    }
+    let (head, tail) = xs.split_at_mut(L);
+    Some((head.try_into().unwrap(), tail))
+}
+
 /// Splits `&[u8]` into `(&[u8], &[u8; R])`.  Returns `None` if input is too
 /// shorter.
 #[allow(dead_code)]

--- a/solana/signature-verifier/src/api.rs
+++ b/solana/signature-verifier/src/api.rs
@@ -105,7 +105,7 @@ impl<'a, 'info> SignaturesAccount<'a, 'info> {
     ) -> Result<bool> {
         let data = self.0.try_borrow_data()?;
         let signature = SignatureHash::new_ed25519(key, signature, message);
-        find_sighash(&*data, signature)
+        find_sighash(*data, signature)
     }
 
     /// Reads number of signatures saved in the account.

--- a/solana/signature-verifier/src/program.rs
+++ b/solana/signature-verifier/src/program.rs
@@ -129,8 +129,9 @@ fn handle_update(
         Ok::<(), ProgramError>(())
     })?;
 
-    // Update number of signatures saved in the Signatures account.
-    ctx.signatures.write_count(count)
+    // Update number of signatures saved in the Signatures account and sort
+    // the entries.
+    ctx.signatures.write_count_and_sort(count)
 }
 
 

--- a/solana/signature-verifier/src/verifier.rs
+++ b/solana/signature-verifier/src/verifier.rs
@@ -156,9 +156,8 @@ fn check_ed25519_data(data: &[u8], entry: &Entry) -> Result<bool, Error> {
 /// Checks that given sigverify account with aggregated signatures contains
 /// given entry.
 fn check_sigverify_data(data: &[u8], entry: &Entry) -> Result<bool, Error> {
-    let mut iter = crate::api::iter(data).map_err(|_| Error::BadData)?;
-    let hash = crate::SignatureHash::from(entry);
-    Ok(iter.any(|item| item == &hash))
+    crate::api::find_sighash(data, crate::SignatureHash::from(entry))
+        .map_err(|_| Error::BadData)
 }
 
 impl From<crate::ed25519_program::BadData> for Error {


### PR DESCRIPTION
Change sigverify program so that whenever new entries are add, they are sorted.  While this makes adding signatures more expensive, this helps when checking signatures since a logarithmic search can be used rather than linear scan of the account.