### PR TITLE
validator: Improve validator client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ package-lock.json
 target
 test-ledger
 *.so
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1755,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +2001,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2179,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,9 +2238,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.11",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2190,6 +2253,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f24ce812868d86d19daa79bf3bf9175bc44ea323391147a5e3abde2a283871b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,10 +2280,46 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.11",
- "hyper",
+ "hyper 0.14.28",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.3.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3171,6 +3290,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3392,10 +3529,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3514,6 +3689,26 @@ checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
  "indexmap 2.1.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -3976,10 +4171,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.11",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -3989,7 +4184,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4003,7 +4198,50 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.3",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.0",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -4144,7 +4382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -4157,6 +4395,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -4552,9 +4806,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -4798,7 +5052,7 @@ dependencies = [
  "gethostname",
  "lazy_static",
  "log",
- "reqwest",
+ "reqwest 0.11.23",
  "solana-sdk",
  "thiserror",
 ]
@@ -4945,7 +5199,7 @@ dependencies = [
  "crossbeam-channel",
  "futures-util",
  "log",
- "reqwest",
+ "reqwest 0.11.23",
  "semver",
  "serde",
  "serde_derive",
@@ -5029,7 +5283,7 @@ dependencies = [
  "bs58 0.4.0",
  "indicatif",
  "log",
- "reqwest",
+ "reqwest 0.11.23",
  "semver",
  "serde",
  "serde_derive",
@@ -5052,7 +5306,7 @@ dependencies = [
  "base64 0.21.7",
  "bs58 0.4.0",
  "jsonrpc-core",
- "reqwest",
+ "reqwest 0.11.23",
  "semver",
  "serde",
  "serde_derive",
@@ -5779,6 +6033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6041,6 +6301,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6154,6 +6424,28 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -6388,7 +6680,9 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "base64 0.21.7",
+ "bincode",
  "borsh 0.10.3",
+ "bs58 0.5.0",
  "clap 4.4.18",
  "derive_more",
  "dialoguer",
@@ -6397,13 +6691,21 @@ dependencies = [
  "guestchain",
  "lib",
  "log",
+ "reqwest 0.12.3",
  "restaking",
  "serde",
  "serde_bytes",
+ "serde_json",
  "solana-ibc",
  "solana-signature-verifier",
  "toml 0.8.8",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -6816,6 +7118,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.11",
@@ -270,7 +270,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.9.0",
 ]
 
 [[package]]
@@ -889,9 +889,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -2009,7 +2009,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.5",
 ]
 
 [[package]]
@@ -4568,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48541b782c0fbb15ac202f2487353c3649fbf868afacae6ca1c9fe0f7df0b4a"
+checksum = "d145d4e1e33bfecd209059a0c4c75d623dbcaeb565b4c197f1815257be45726a"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -4584,7 +4584,8 @@ dependencies = [
  "solana-config-program",
  "solana-sdk",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 1.0.0",
+ "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror",
  "zstd",
@@ -4600,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a78952f057a7d4f87b3a6a5f4a8705cefbb67bbc00ecffc2c75b168a54c931"
+checksum = "1deaf83f98be3ba9ecee057efa5cdfa6112267e5b1ff53c4ef4b727f66090b9a"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -4617,9 +4618,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e85b1d68bce244750bd02c4d71ed0df415c9b8d91a4b0f1e7ce6b97748db46c"
+checksum = "2a8912026a203ff0d90973e7363f141c6ce569484e06ee0a6f72992144263136"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4650,9 +4651,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c66c9c5bbc148affd42127061af9c0e7e5901b5e5142e951912f165272203c1"
+checksum = "4000f4717f86c5f9e1105378e3a6521db770d0ad68417f59960ca4b51103fcd0"
 dependencies = [
  "bincode",
  "chrono",
@@ -4664,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4180686b6384013f062242ee9f18ea6ea68268e9b35fa9aa0206c2a622d1773f"
+checksum = "f8b1a4d67c01e5c4464ed9bffb656dec2c88e9bfd7d45bf754f650150e5d81db"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4686,11 +4687,11 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174a53486f9e0774680c2b6a53568a15c11ccc5cef1263a7e7d42958bfd61792"
+checksum = "1790013c7969353000c22907fc21610adb3389a7c9a27a386ebe7fb32b2ad307"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.5",
  "blake3",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -4716,9 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69b9bc56d9f92bd194569091d655be239a51a934df1db247e0c8bd2a9352909"
+checksum = "a3ed2b49a3dd03ddd5107d6e629e8e5895724227a057b3511bf0c107c6d48308"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4768,9 +4769,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb457626944fd2f192285c8281e887081dc346920c181aaf165426dbf081859"
+checksum = "bfc0d5b4f046d07e845b69178989a6b3bf168a82eeee006adb77391b339bce64"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -4779,9 +4780,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2a8bb3ec59a415b1c30827001c38af358a0c244e00a3d5280ca0b0ed264036"
+checksum = "857178177c6b378bcfc35df6867a6eef211059f5e4ab01ee87355d6b7493b556"
 dependencies = [
  "log",
  "solana-sdk",
@@ -4789,9 +4790,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c89e3237a73f781e0156fe419831c554f6807eb4f4bffea42535be9627d6fc1"
+checksum = "1c68f5cbfbafd002b4d94728748f632a3bd27772ca5c7139710d65940c95477c"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -4804,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec445e2d9dbfab7360bc0d846a676e318c13eb4d1e0359ef199187d07795d02"
+checksum = "8ce93c50199f077df9d8fd4a82bbdfe654422e1d21e5eecb7f878c4e0078f92f"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -4826,11 +4827,11 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b58cc4a2f4f450361bc8c1a24a94383c659e6212a74e6080a410f7d87e05a6"
+checksum = "2a233bc2032f4b3f462fe13325cd1a336f355e1d9e793faada488db409cec0d6"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.5",
  "bincode",
  "bv",
  "caps",
@@ -4855,9 +4856,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c183d16916dd70ce2b59a4b39088f5094649a592e475fb9ebfc3cfe78b3a192c"
+checksum = "4b2ae4ec9dd6fc76202c94d23942da3cf624325a178e1b0125e70db90b8d7f15"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4909,9 +4910,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fca7d79b03e54e108069f32cf553c863838b647be7f7135644f8a1d2bdcd3a1"
+checksum = "b50a6da7b501117f68ef51fc113d771b52af646dc42c43af23a85e32461d59c9"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -4937,9 +4938,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90c6e27f0d1e627728f137db688c45accb1b7ae839021b978d1dcceff40d7a3"
+checksum = "bf920143eb7d5bd5f2ea8fc6ab8a1f521512dfe50af7833af40d7cbae83d955d"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4962,9 +4963,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f340646d1bdd7b7c8e0c71f1f817a4eaeba35c06f025944c52df8f82bb565c79"
+checksum = "627491c0afd615efb2538c8a49948663ac01aadf99a3cfebb0a63e2b9431ed79"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4989,9 +4990,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7effa9e68a7ab9883f7fb4a91c083970223e8e8e355979eb605279608fafa6b7"
+checksum = "4d5c306f32e26031c043c218a0ba3cde08cbb0e08511ab8a4128445d92a535e0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4999,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59fee3edad929473b7178f84ae58dbb3feb004a26873c8ab557b3aecfaa6d87"
+checksum = "f1c9dbb8cca1b917a01979a1ca98b682f6123df56f11a5227a37c36494ad7740"
 dependencies = [
  "console",
  "dialoguer",
@@ -5018,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ae66b579851b5142ace6133b95192b38f9a72fb4a81ce936f0af92977c062f"
+checksum = "2edc8c0f26561e770f28edb9d456221a5554ee90eeb9052ed38942dbb31c035b"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -5044,9 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a62a61c8c5989f2b5e4b75bda30b4647ad4affbcfe4a2890b1adb05e2b54c8"
+checksum = "5ff63ab63805a6302ec21284a1138daf5478020f79641d77e53bb84f16c1f5a6"
 dependencies = [
  "base64 0.21.7",
  "bs58 0.4.0",
@@ -5060,15 +5061,15 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022",
+ "spl-token-2022 1.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db51df524aceb35e305b735086191db052dc163d09b6d5d9be65e216ab7413b"
+checksum = "897db0c1085b8a99ca35871132b6dc6dca3eff68d9210fcd168ccc2e3843dc26"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -5079,9 +5080,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284587e20a7256621b6061589a6d7f9fc1c1bcb9f25d183555034f7817ec49a6"
+checksum = "368430d6c9f033e86f8f590d19232d10986d1188c3ad3a6836628d2acc09c21a"
 dependencies = [
  "assert_matches",
  "base64 0.21.7",
@@ -5133,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fee7090babd8fe6cedd2e377366979464d29fa958bf5fc6554f6c7577b73fd4"
+checksum = "f554d2a144bb0138cfdeced9961cc8a09aaa09f0c3c9a63bd10da41c4a06d420"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -5143,6 +5144,12 @@ dependencies = [
  "rustversion",
  "syn 2.0.46",
 ]
+
+[[package]]
+name = "solana-security-txt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-signature-verifier"
@@ -5164,9 +5171,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219f40db983a290ea75212b9e47013a47715eb224ca18e05bd094d86baefc37"
+checksum = "e28e8941bc0b137f851626ff4d4ce9ebcf9be10619b48d2ed83cd1953af21821"
 dependencies = [
  "async-channel",
  "bytes",
@@ -5196,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8d9eb19550425cbb6a96fdea18171a2e44529414fe09f8cf7a238a78fd9a37"
+checksum = "760b94e2875b54350f786c85faf50fa1a9a37ae46e9897215d19b373fc2f58cd"
 dependencies = [
  "bincode",
  "log",
@@ -5211,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795d4d7e76f87640d7a3d1ab6ebc2376d9b9d76a7c2664653628dc6f4bc64ecc"
+checksum = "7cfdc7ff6cdc1512661de1f9f40723f88dc1e94c8b8938bd537f3713239173e2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5235,9 +5242,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176b554ca42e29abd21d56f31c01599f9b334e65b22911bcdb691b9b02706636"
+checksum = "ba7131d11c8d5a068bfc26a9dc8c9ee0d77eaf60856dd0c8be880542fc5fbbd6"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -5254,7 +5261,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 1.0.0",
  "thiserror",
 ]
 
@@ -5286,9 +5293,9 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a60895d452a9e2de1115d4ebaef537fb608b9a6e206cb7b24c82881a35348e3"
+checksum = "54647340d7fa1708c217cbc2411259c5b3784c2df55c1eb4353aca296635ed87"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -5301,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572a7a0f49ee43473c2f235432f98b2594c3a4e8cc9a1befd7a085be8192f5bd"
+checksum = "1de7a6bad7dff1c595be2eec0c3800a482c6068f3c87c6df87ed091b4e6e642e"
 dependencies = [
  "log",
  "rustc_version",
@@ -5317,9 +5324,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cffa52ab296ccc95ced7ae7875534cb4fd1cbb0bd9b8ad20e7ec55f15bcd5d"
+checksum = "3c828d118d1f135baacfbf51412c4f1ac18af19fdbee43b002d2908e69cdf50b"
 dependencies = [
  "bincode",
  "log",
@@ -5347,9 +5354,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.17.13"
+version = "1.17.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e8e2f6c0d78bc9eb07efc1fcd034dd0fcc508af8809343ac861096aab84876"
+checksum = "112944743b08f7e1101368ff6d84745e7b4abb075fabaccc02e01bd3ce4b6d6c"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",
@@ -5427,9 +5434,9 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385e31c29981488f2820b2022d8e731aae3b02e6e18e2fd854e4c9a94dc44fc3"
+checksum = "992d9c64c2564cc8f63a4b508bf3ebcdf2254b0429b13cd1d31adb6162432a5f"
 dependencies = [
  "assert_matches",
  "borsh 0.10.3",
@@ -5437,7 +5444,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 1.0.0",
  "thiserror",
 ]
 
@@ -5538,6 +5545,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-tlv-account-resolution"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+]
+
+[[package]]
 name = "spl-token"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5569,9 +5590,46 @@ dependencies = [
  "spl-pod",
  "spl-token",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
+ "spl-transfer-hook-interface 0.3.0",
  "spl-type-length-value",
  "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d697fac19fd74ff472dfcc13f0b442dd71403178ce1de7b5d16f83a33561c059"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.1",
+ "num-traits",
+ "num_enum 0.7.1",
+ "solana-program",
+ "solana-security-txt",
+ "solana-zk-token-sdk",
+ "spl-memo",
+ "spl-pod",
+ "spl-token",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
+ "spl-transfer-hook-interface 0.4.1",
+ "spl-type-length-value",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-group-interface"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b889509d49fa74a4a033ca5dae6c2307e9e918122d97e58562f5c4ffa795c75d"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
 ]
 
 [[package]]
@@ -5600,7 +5658,23 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
- "spl-tlv-account-resolution",
+ "spl-tlv-account-resolution 0.4.0",
+ "spl-type-length-value",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aabdb7c471566f6ddcee724beb8618449ea24b399e58d464d6b5bc7db550259"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution 0.5.2",
  "spl-type-length-value",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6382,7 +6382,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "validator"
-version = "0.0.0"
+version = "0.0.5"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,9 @@ serde = "1"
 serde_json = "1"
 serde_bytes = "0.11.14"
 sha2 = { version = "0.10.7", default-features = false }
-solana-client ="1.17.30"
-solana-program ="1.17.30"
-solana-sdk ="1.17.30"
+solana-client = "1.17.30"
+solana-program = "1.17.30"
+solana-sdk = "1.17.30"
 spl-associated-token-account = "2.2.0"
 spl-token = "4.0.0"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ anchor-spl = "0.29.0"
 ascii = "1.1.0"
 bs58 = { version = "0.5.0", features = ["alloc"] }
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
+bincode = { version = "1.3.3" }
 borsh = { version = "0.10.3", default-features = false }
 bytemuck = { version = "1.14", default-features = false }
 clap = { version = "4.4.18", features = ["derive"] }
@@ -66,6 +67,7 @@ primitive-types = "0.12.2"
 prost = { version = "0.12.3", default-features = false }
 prost-build = { version = "0.12.3", default-features = false }
 rand = { version = "0.8.5" }
+reqwest = "0.12.3"
 serde = "1"
 serde_json = "1"
 serde_bytes = "0.11.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,9 @@ serde = "1"
 serde_json = "1"
 serde_bytes = "0.11.14"
 sha2 = { version = "0.10.7", default-features = false }
-solana-client = "1.17.7"
-solana-program = "1.17.7"
-solana-sdk = "1.17.7"
+solana-client ="1.17.30"
+solana-program ="1.17.30"
+solana-sdk ="1.17.30"
 spl-associated-token-account = "2.2.0"
 spl-token = "4.0.0"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator"
-version.workspace = true
+version = "0.0.5"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -11,7 +11,9 @@ rust-version.workspace = true
 anchor-client.workspace = true
 anchor-lang.workspace = true
 anchor-spl.workspace = true
+bs58.workspace = true
 base64.workspace = true
+bincode.workspace = true
 borsh.workspace = true
 clap.workspace = true
 derive_more.workspace = true
@@ -19,7 +21,9 @@ dialoguer.workspace = true
 directories.workspace = true
 env_logger.workspace = true
 log.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json"] }
 serde.workspace = true
+serde_json.workspace = true
 serde_bytes.workspace = true
 toml.workspace = true
 

--- a/validator/src/command.rs
+++ b/validator/src/command.rs
@@ -23,6 +23,8 @@ pub struct Config {
     pub ws_url: String,
     pub program_id: String,
     pub keypair: InnerKeypair,
+    #[serde(default)]
+    pub priority_fees: u64,
     pub log_level: String,
 }
 
@@ -100,6 +102,9 @@ struct RunArgs {
     #[arg(long)]
     keypair_path: Option<String>,
 
+    #[arg(long)]
+    priority_fees: Option<u64>,
+
     /// Log Level
     #[arg(short, long)]
     log_level: Option<LevelFilter>,
@@ -122,6 +127,9 @@ struct InitArgs {
     /// Private key
     #[arg(long)]
     keypair_path: String,
+
+    #[arg(long)]
+    priority_fees: Option<u64>,
 
     /// Log Level
     #[arg(short, long)]
@@ -149,6 +157,9 @@ struct StakeArgs {
     /// program ID
     #[arg(long)]
     program_id: Option<String>,
+
+    #[arg(long)]
+    priority_fees: Option<u64>,
 
     /// Private key
     #[arg(long)]
@@ -207,6 +218,7 @@ pub fn process_command() {
                 ws_url: cmd.ws_url.unwrap_or(default_config.ws_url),
                 program_id: cmd.program_id.unwrap_or(default_config.program_id),
                 keypair,
+                priority_fees: cmd.priority_fees.unwrap_or(0),
                 log_level: cmd
                     .log_level
                     .unwrap_or(LevelFilter::Info)
@@ -236,6 +248,7 @@ pub fn process_command() {
                 ws_url: cmd.ws_url,
                 program_id: cmd.program_id,
                 keypair: keypair.into(),
+                priority_fees: cmd.priority_fees.unwrap_or(0),
                 log_level: cmd
                     .log_level
                     .unwrap_or(LevelFilter::Info)
@@ -264,6 +277,7 @@ pub fn process_command() {
                 ws_url: cmd.ws_url.unwrap_or(default_config.ws_url),
                 program_id: cmd.program_id.unwrap_or(default_config.program_id),
                 keypair,
+                priority_fees: cmd.priority_fees.unwrap_or(0),
                 log_level: cmd
                     .log_level
                     .unwrap_or(LevelFilter::Info)

--- a/validator/src/command.rs
+++ b/validator/src/command.rs
@@ -22,7 +22,6 @@ pub struct Config {
     pub rpc_url: String,
     pub ws_url: String,
     pub program_id: String,
-    pub genesis_hash: String,
     pub keypair: InnerKeypair,
     pub log_level: String,
 }
@@ -97,10 +96,6 @@ struct RunArgs {
     #[arg(long)]
     program_id: Option<String>,
 
-    /// genesis hash
-    #[arg(short, long)]
-    genesis_hash: Option<String>,
-
     /// Private key
     #[arg(long)]
     keypair_path: Option<String>,
@@ -123,10 +118,6 @@ struct InitArgs {
     /// program ID
     #[arg(long)]
     program_id: String,
-
-    /// genesis hash
-    #[arg(short, long)]
-    genesis_hash: String,
 
     /// Private key
     #[arg(long)]
@@ -158,10 +149,6 @@ struct StakeArgs {
     /// program ID
     #[arg(long)]
     program_id: Option<String>,
-
-    /// genesis hash
-    #[arg(short, long)]
-    genesis_hash: Option<String>,
 
     /// Private key
     #[arg(long)]
@@ -219,9 +206,6 @@ pub fn process_command() {
                 rpc_url: cmd.rpc_url.unwrap_or(default_config.rpc_url),
                 ws_url: cmd.ws_url.unwrap_or(default_config.ws_url),
                 program_id: cmd.program_id.unwrap_or(default_config.program_id),
-                genesis_hash: cmd
-                    .genesis_hash
-                    .unwrap_or(default_config.genesis_hash),
                 keypair,
                 log_level: cmd
                     .log_level
@@ -251,7 +235,6 @@ pub fn process_command() {
                 rpc_url: cmd.rpc_url,
                 ws_url: cmd.ws_url,
                 program_id: cmd.program_id,
-                genesis_hash: cmd.genesis_hash,
                 keypair: keypair.into(),
                 log_level: cmd
                     .log_level
@@ -280,9 +263,6 @@ pub fn process_command() {
                 rpc_url: cmd.rpc_url.unwrap_or(default_config.rpc_url),
                 ws_url: cmd.ws_url.unwrap_or(default_config.ws_url),
                 program_id: cmd.program_id.unwrap_or(default_config.program_id),
-                genesis_hash: cmd
-                    .genesis_hash
-                    .unwrap_or(default_config.genesis_hash),
                 keypair,
                 log_level: cmd
                     .log_level

--- a/validator/src/stake.rs
+++ b/validator/src/stake.rs
@@ -7,6 +7,7 @@ use anchor_client::solana_sdk::compute_budget::ComputeBudgetInstruction;
 use anchor_client::solana_sdk::signature::Keypair;
 use anchor_client::solana_sdk::signer::Signer;
 use anchor_client::{Client, Cluster};
+use anchor_client::solana_sdk::transaction::MessageHash::Compute;
 use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::solana_program::sysvar::SysvarId;
@@ -218,8 +219,9 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
     let tx = program
         .request()
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            1_000_000u32,
+            500_000u32,
         ))
+        .instruction(ComputeBudgetInstruction::set_compute_unit_price(config.priority_fees))
         .accounts(Deposit {
             depositor: validator.pubkey(),
             vault_params,

--- a/validator/src/stake.rs
+++ b/validator/src/stake.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::compute_budget::ComputeBudgetInstruction;
-use anchor_client::solana_sdk::signature::{Keypair, Signature};
+use anchor_client::solana_sdk::signature::Keypair;
 use anchor_client::solana_sdk::signer::Signer;
 use anchor_client::solana_sdk::transaction::Transaction;
 use anchor_client::{Client, Cluster};
@@ -16,7 +16,7 @@ use restaking::{accounts, Service};
 
 use crate::command::Config;
 use crate::skip_fail;
-use crate::utils::{BundleStatusResponse, Payload, Response, ResultResponse};
+use crate::utils::{BundleStatusResponse, Payload, Response};
 
 pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
     let validator = Rc::new(Keypair::from(config.keypair));

--- a/validator/src/stake.rs
+++ b/validator/src/stake.rs
@@ -6,8 +6,8 @@ use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::compute_budget::ComputeBudgetInstruction;
 use anchor_client::solana_sdk::signature::Keypair;
 use anchor_client::solana_sdk::signer::Signer;
-use anchor_client::{Client, Cluster};
 use anchor_client::solana_sdk::transaction::MessageHash::Compute;
+use anchor_client::{Client, Cluster};
 use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::solana_program::sysvar::SysvarId;
@@ -178,9 +178,11 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
         &restaking::ID,
     )
     .0;
-    let trie =
-        Pubkey::find_program_address(&[solana_ibc::TRIE_SEED], &solana_ibc_program_id)
-            .0;
+    let trie = Pubkey::find_program_address(
+        &[solana_ibc::TRIE_SEED],
+        &solana_ibc_program_id,
+    )
+    .0;
     let chain = Pubkey::find_program_address(
         &[solana_ibc::CHAIN_SEED],
         &solana_ibc_program_id,
@@ -221,7 +223,9 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
             500_000u32,
         ))
-        .instruction(ComputeBudgetInstruction::set_compute_unit_price(config.priority_fees))
+        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
+            config.priority_fees,
+        ))
         .accounts(Deposit {
             depositor: validator.pubkey(),
             vault_params,

--- a/validator/src/stake.rs
+++ b/validator/src/stake.rs
@@ -152,6 +152,7 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
         CommitmentConfig::processed(),
     );
     let program = client.program(restaking::ID).unwrap();
+    let solana_ibc_program_id = Pubkey::from_str(&config.program_id).unwrap();
 
     let receipt_token_keypair = Keypair::new();
     let receipt_token_key = receipt_token_keypair.pubkey();
@@ -177,11 +178,11 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
     )
     .0;
     let trie =
-        Pubkey::find_program_address(&[solana_ibc::TRIE_SEED], &solana_ibc::ID)
+        Pubkey::find_program_address(&[solana_ibc::TRIE_SEED], &solana_ibc_program_id)
             .0;
     let chain = Pubkey::find_program_address(
         &[solana_ibc::CHAIN_SEED],
-        &solana_ibc::ID,
+        &solana_ibc_program_id,
     )
     .0;
     let master_edition_account = Pubkey::find_program_address(
@@ -238,7 +239,7 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
             nft_metadata,
             chain,
             trie,
-            guest_chain_program_id: solana_ibc::ID,
+            guest_chain_program_id: solana_ibc_program_id,
         })
         .args(restaking::instruction::Deposit {
             service: Service::GuestChain { validator: validator.pubkey() },
@@ -247,10 +248,7 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
         .payer(validator.clone())
         .signer(&*validator)
         .signer(&receipt_token_keypair)
-        .send_with_spinner_and_config(RpcSendTransactionConfig {
-            skip_preflight: true,
-            ..RpcSendTransactionConfig::default()
-        })
+        .send()
         .unwrap();
     println!("This is staking signature:\n  {}", tx);
 }

--- a/validator/src/stake.rs
+++ b/validator/src/stake.rs
@@ -1,149 +1,22 @@
 use std::rc::Rc;
 use std::str::FromStr;
+use std::thread::sleep;
+use std::time::Duration;
 
-use anchor_client::solana_client::rpc_config::RpcSendTransactionConfig;
 use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::compute_budget::ComputeBudgetInstruction;
-use anchor_client::solana_sdk::signature::Keypair;
+use anchor_client::solana_sdk::signature::{Keypair, Signature};
 use anchor_client::solana_sdk::signer::Signer;
-use anchor_client::solana_sdk::transaction::MessageHash::Compute;
+use anchor_client::solana_sdk::transaction::Transaction;
 use anchor_client::{Client, Cluster};
 use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::solana_program::sysvar::SysvarId;
-use anchor_lang::ToAccountMetas;
-use restaking::Service;
+use restaking::{accounts, Service};
 
 use crate::command::Config;
-
-pub struct Deposit {
-    pub depositor: Pubkey,
-    pub vault_params: Pubkey,
-    pub staking_params: Pubkey,
-    pub token_mint: Pubkey,
-    pub depositor_token_account: Pubkey,
-    pub vault_token_account: Pubkey,
-    pub receipt_token_mint: Pubkey,
-    pub receipt_token_account: Pubkey,
-    pub metadata_program: Pubkey,
-    pub token_program: Pubkey,
-    pub associated_token_program: Pubkey,
-    pub system_program: Pubkey,
-    pub rent: Pubkey,
-    pub instruction: Pubkey,
-    pub master_edition_account: Pubkey,
-    pub nft_metadata: Pubkey,
-    // Guest chain Accounts
-    chain: Pubkey,
-    trie: Pubkey,
-    guest_chain_program_id: Pubkey,
-}
-
-impl ToAccountMetas for Deposit {
-    fn to_account_metas(
-        &self,
-        _is_signer: Option<bool>,
-    ) -> Vec<anchor_lang::prelude::AccountMeta> {
-        let accounts = [
-            AccountMeta {
-                pubkey: self.depositor,
-                is_signer: true,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.vault_params,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.staking_params,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.token_mint,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.depositor_token_account,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.vault_token_account,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.receipt_token_mint,
-                is_signer: true,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.receipt_token_account,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.metadata_program,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.token_program,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.associated_token_program,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.system_program,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.rent,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.instruction,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.master_edition_account,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.nft_metadata,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.chain,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.trie,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: self.guest_chain_program_id,
-                is_signer: false,
-                is_writable: true,
-            },
-        ];
-        accounts.to_vec()
-    }
-}
+use crate::skip_fail;
+use crate::utils::{BundleStatusResponse, Payload, Response, ResultResponse};
 
 pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
     let validator = Rc::new(Keypair::from(config.keypair));
@@ -218,15 +91,23 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
             &receipt_token_key,
         );
 
-    let tx = program
+    let jito_address =
+        Pubkey::from_str("96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5")
+            .unwrap();
+    let ix = program
         .request()
+        .instruction(anchor_lang::solana_program::system_instruction::transfer(
+            &validator.pubkey(),
+            &jito_address,
+            config.priority_fees,
+        ))
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
             500_000u32,
         ))
         .instruction(ComputeBudgetInstruction::set_compute_unit_price(
             config.priority_fees,
         ))
-        .accounts(Deposit {
+        .accounts(accounts::Deposit {
             depositor: validator.pubkey(),
             vault_params,
             staking_params,
@@ -243,10 +124,16 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
             instruction: anchor_lang::solana_program::sysvar::instructions::ID,
             master_edition_account,
             nft_metadata,
-            chain,
-            trie,
-            guest_chain_program_id: solana_ibc_program_id,
         })
+        .accounts(vec![
+            AccountMeta { pubkey: chain, is_signer: false, is_writable: true },
+            AccountMeta { pubkey: trie, is_signer: false, is_writable: true },
+            AccountMeta {
+                pubkey: solana_ibc_program_id,
+                is_signer: false,
+                is_writable: true,
+            },
+        ])
         .args(restaking::instruction::Deposit {
             service: Service::GuestChain { validator: validator.pubkey() },
             amount,
@@ -254,7 +141,65 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
         .payer(validator.clone())
         .signer(&*validator)
         .signer(&receipt_token_keypair)
-        .send()
+        .instructions()
         .unwrap();
-    println!("This is staking signature:\n  {}", tx);
+    // Retrying it for 5 times.
+    for _ in 0..5 {
+        let rpc_client = program.rpc();
+        let latest_blockhash = rpc_client.get_latest_blockhash().unwrap();
+        let new_tx = Transaction::new_signed_with_payer(
+            ix.as_slice(),
+            Some(&validator.pubkey()),
+            &[&*validator, &receipt_token_keypair],
+            latest_blockhash,
+        );
+        let serialized_tx = bincode::serialize(&new_tx).unwrap();
+        // encode in base 58
+        let encoded_tx = bs58::encode(serialized_tx).into_string();
+        let client = reqwest::blocking::Client::new();
+        let send_payload = Payload {
+            jsonrpc: "2.0".to_string(),
+            id: 1,
+            method: "sendBundle".to_string(),
+            params: vec![vec![encoded_tx]],
+        };
+        let response = client
+            .post("https://mainnet.block-engine.jito.wtf/api/v1/bundles")
+            .json(&send_payload)
+            .send();
+        let response = skip_fail!(response);
+        let response: Result<Response, reqwest::Error> = response.json();
+        let response = skip_fail!(response);
+        let bundle_id = response.result;
+        // log::info!("This is bundle id {:?}", bundle_id);
+        let response_payload = Payload {
+            jsonrpc: "2.0".to_string(),
+            id: 1,
+            method: "getBundleStatuses".to_string(),
+            params: vec![vec![bundle_id]],
+        };
+        for _ in 0..5 {
+            sleep(Duration::from_secs(1));
+            let response = client
+                .post("https://mainnet.block-engine.jito.wtf/api/v1/bundles")
+                .json(&response_payload)
+                .send();
+            let response = skip_fail!(response);
+            let response: Result<BundleStatusResponse, reqwest::Error> =
+                response.json();
+            let response = skip_fail!(response);
+            // log::info!("This is text for bundle status {:?}", x);
+            // log::info!("This is response {:?}", response);
+            if !response.result.value.is_empty() {
+                log::info!(
+                    "This is staking signature:\n  {}",
+                    response.result.value[0].clone().transactions[0]
+                );
+                return;
+            }
+        }
+        log::info!("Retrying to send the transaction");
+        sleep(Duration::from_secs(1));
+    }
+    panic!("Could not send the transaction, please try again");
 }

--- a/validator/src/utils.rs
+++ b/validator/src/utils.rs
@@ -150,8 +150,8 @@ pub fn submit_call(
 ) -> Result<Signature, ClientError> {
     let mut tries = 0;
     let mut tx = Ok(signature);
-    while tries < max_retries {
-        let mut status = true;
+    for _ in 0..max_retries {
+        let mut success = true;
         tx = program
             .request()
             .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
@@ -180,11 +180,11 @@ pub fn submit_call(
             .map_err(|e| {
                 if matches!(e, ClientError::SolanaClientError(_)) {
                     // log::error!("{:?}", e);
-                    status = false;
+                    success = false;
                 }
                 e
             });
-        if status {
+        if success {
             return tx;
         }
         sleep(Duration::from_millis(500));
@@ -205,8 +205,8 @@ pub fn submit_generate_block_call(
 ) -> Result<Signature, ClientError> {
     let mut tries = 0;
     let mut tx = Ok(Signature::new_unique());
-    while tries < max_retries {
-        let mut status = true;
+    for _ in 0..max_retries {
+        let mut success = true;
         tx = program
             .request()
             .instruction(ComputeBudgetInstruction::set_compute_unit_price(
@@ -228,12 +228,12 @@ pub fn submit_generate_block_call(
             .map_err(|e| {
                 if matches!(e, ClientError::SolanaClientError(_)) {
                     // log::error!("{:?}", e);
-                    status = false;
+                    success = false;
                 }
                 e
             });
 
-        if status {
+        if success {
             return tx;
         }
         sleep(Duration::from_millis(500));

--- a/validator/src/utils.rs
+++ b/validator/src/utils.rs
@@ -188,11 +188,8 @@ pub fn submit_generate_block_call(
             .payer(validator.clone())
             .signer(validator)
             .send();
-
-        if let Err(e) = tx.clone() {
-            if !matches!(e, ClientError::SolanaClientError(_)) {
-                return Err(e);
-            }
+        if let Err(err @ ClientError::SolanaClientError(_)) = tx {
+            return Err(err);
         } else if let Ok(tx) = tx {
             return Ok(tx);
         }

--- a/validator/src/utils.rs
+++ b/validator/src/utils.rs
@@ -145,7 +145,7 @@ pub fn submit_call(
     validator: &Rc<Keypair>,
     chain: Pubkey,
     trie: Pubkey,
-    max_retries: u8,
+    max_retries: usize,
     priority_fees: &u64,
 ) -> Result<Signature, ClientError> {
     let mut tries = 0;
@@ -200,7 +200,7 @@ pub fn submit_generate_block_call(
     validator: &Rc<Keypair>,
     chain: Pubkey,
     trie: Pubkey,
-    max_retries: u8,
+    max_retries: usize,
     priority_fees: &u64,
 ) -> Result<Signature, ClientError> {
     let mut tries = 0;

--- a/validator/src/utils.rs
+++ b/validator/src/utils.rs
@@ -86,6 +86,7 @@ pub fn submit_call(
         let mut status = true;
         tx = program
             .request()
+            .instruction(ComputeBudgetInstruction::set_compute_unit_limit(60_000))
             .instruction(ComputeBudgetInstruction::set_compute_unit_price(
                 *priority_fees,
             ))

--- a/validator/src/utils.rs
+++ b/validator/src/utils.rs
@@ -78,6 +78,7 @@ pub fn submit_call(
     chain: Pubkey,
     trie: Pubkey,
     max_retries: u8,
+    priority_fees: &u64
 ) -> Result<Signature, ClientError> {
     let mut tries = 0;
     let mut tx = Ok(signature);
@@ -86,7 +87,7 @@ pub fn submit_call(
         tx = program
             .request()
             .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-                10_000,
+                *priority_fees,
             ))
             .instruction(new_ed25519_instruction_with_signature(
                 &validator.pubkey().to_bytes(),
@@ -129,6 +130,7 @@ pub fn submit_generate_block_call(
     chain: Pubkey,
     trie: Pubkey,
     max_retries: u8,
+    priority_fees: &u64
 ) -> Result<Signature, ClientError> {
     let mut tries = 0;
     let mut tx = Ok(Signature::new_unique());
@@ -137,7 +139,7 @@ pub fn submit_generate_block_call(
         tx = program
             .request()
             .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-                10_000,
+                *priority_fees,
             ))
             .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
                 60_000,

--- a/validator/src/utils.rs
+++ b/validator/src/utils.rs
@@ -78,7 +78,7 @@ pub fn submit_call(
     chain: Pubkey,
     trie: Pubkey,
     max_retries: u8,
-    priority_fees: &u64
+    priority_fees: &u64,
 ) -> Result<Signature, ClientError> {
     let mut tries = 0;
     let mut tx = Ok(signature);
@@ -130,7 +130,7 @@ pub fn submit_generate_block_call(
     chain: Pubkey,
     trie: Pubkey,
     max_retries: u8,
-    priority_fees: &u64
+    priority_fees: &u64,
 ) -> Result<Signature, ClientError> {
     let mut tries = 0;
     let mut tx = Ok(Signature::new_unique());

--- a/validator/src/utils.rs
+++ b/validator/src/utils.rs
@@ -148,10 +148,8 @@ pub fn submit_call(
             .payer(validator.clone())
             .signer(validator)
             .send();
-        if let Err(e) = tx.clone() {
-            if !matches!(e, ClientError::SolanaClientError(_)) {
-                return Err(e);
-            }
+        if let Err(err @ ClientError::SolanaClientError(_)) = tx {
+            return Err(err);
         } else if let Ok(tx) = tx {
             return Ok(tx);
         }

--- a/validator/src/utils.rs
+++ b/validator/src/utils.rs
@@ -40,7 +40,7 @@ fn project_dirs() -> ProjectDirs {
         "Composable Finance",
         "Solana Guest Chain Validator",
     )
-        .expect("Invalid Home directory!")
+    .expect("Invalid Home directory!")
 }
 
 pub fn config_file() -> PathBuf {
@@ -141,7 +141,7 @@ pub fn submit_call(
                 chain,
                 trie,
                 ix_sysvar:
-                anchor_lang::solana_program::sysvar::instructions::ID,
+                    anchor_lang::solana_program::sysvar::instructions::ID,
                 system_program: system_program::ID,
             })
             .args(instruction::SignBlock { signature: signature.into() })

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -34,6 +34,8 @@ pub fn run_validator(config: Config) {
     )
     .0;
 
+
+
     log::info!("Validator running");
 
     let max_tries = 5;

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -1,16 +1,13 @@
 use std::rc::Rc;
 use std::str::FromStr;
+use std::thread::sleep;
+use std::time::Duration;
 
-use anchor_client::solana_client::pubsub_client::PubsubClient;
-use anchor_client::solana_client::rpc_config::{
-    RpcTransactionLogsConfig, RpcTransactionLogsFilter,
-};
 use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::signature::Keypair;
 use anchor_client::solana_sdk::signer::Signer;
 use anchor_client::{Client, Cluster};
 use anchor_lang::solana_program::pubkey::Pubkey;
-use lib::hash::CryptoHash;
 use solana_ibc::chain::ChainData;
 
 use crate::command::Config;
@@ -23,104 +20,85 @@ pub fn run_validator(config: Config) {
         validator.clone(),
         CommitmentConfig::processed(),
     );
-    let program = client.program(solana_ibc::ID).unwrap();
+    let program = client.program(Pubkey::from_str(&config.program_id).unwrap()).unwrap();
 
     let trie =
-        Pubkey::find_program_address(&[solana_ibc::TRIE_SEED], &solana_ibc::ID)
+        Pubkey::find_program_address(&[solana_ibc::TRIE_SEED], &Pubkey::from_str(&config.program_id).unwrap())
             .0;
     let chain = Pubkey::find_program_address(
         &[solana_ibc::CHAIN_SEED],
-        &solana_ibc::ID,
+        &Pubkey::from_str(&config.program_id).unwrap(),
     )
-    .0;
-
-    let (_logs_subscription, receiver) = PubsubClient::logs_subscribe(
-        &config.ws_url,
-        RpcTransactionLogsFilter::Mentions(vec![config.program_id]),
-        RpcTransactionLogsConfig {
-            commitment: Some(CommitmentConfig::processed()),
-        },
-    )
-    .unwrap();
-
-    let max_retries = 5;
+        .0;
 
     log::info!("Validator running");
 
-    let genesis_hash = &CryptoHash::from_base64(&config.genesis_hash)
-        .expect("Invalid Genesis Hash");
+    let max_tries = 5;
 
-    // Check if there is a pending block to sign
-    let chain_account: ChainData = program.account(chain).unwrap();
-    if chain_account.pending_block().unwrap().is_some() {
-        if !chain_account
-            .pending_block()
-            .unwrap()
-            .unwrap()
-            .signers
-            .contains(&validator.pubkey().into())
-        {
-            log::info!("Found Pending block");
-            let fingerprint =
-                &chain_account.pending_block().unwrap().unwrap().fingerprint;
-            let signature = validator.sign_message(fingerprint.as_slice());
-
-            let tx = utils::submit_call(
+    loop {
+        sleep(Duration::from_secs(5));
+        let chain_account: ChainData = program.account(chain).unwrap();
+        if chain_account.pending_block().unwrap().is_some() {
+            if chain_account
+                .pending_block()
+                .unwrap()
+                .unwrap()
+                .signers
+                .get(&validator.pubkey().into())
+                .is_none()
+            {
+                log::info!(
+                    "Found block {:?}",
+                    chain_account.pending_block().unwrap().unwrap()
+                );
+                let fingerprint = &chain_account
+                    .pending_block()
+                    .unwrap()
+                    .unwrap()
+                    .fingerprint;
+                let signature = validator.sign_message(fingerprint.as_slice());
+                log::info!(
+                    "This is the signature of signed block {:?}",
+                    signature.to_string()
+                );
+                let tx = utils::submit_call(
+                    &program,
+                    signature,
+                    fingerprint.as_slice(),
+                    &validator,
+                    chain,
+                    trie,
+                    max_tries,
+                );
+                match tx {
+                    Ok(tx) => {
+                        log::info!("Block signed -> Transaction: {}", tx);
+                    }
+                    Err(err) => {
+                        log::error!("Failed to send the transaction {err}")
+                    }
+                }
+            } else {
+                log::info!("You have already signed the pending block");
+            }
+        } else {
+            log::info!("No pending blocks");
+            // Trying to generate a new block
+            let tx = utils::submit_generate_block_call(
                 &program,
-                signature,
-                fingerprint.as_slice(),
                 &validator,
                 chain,
                 trie,
-                max_retries,
+                max_tries,
             );
             match tx {
                 Ok(tx) => {
-                    log::info!("Pending Block signed -> Transaction: {}", tx);
+                    log::info!("New block created -> Transaction: {}", tx);
                 }
                 Err(err) => {
                     log::error!("Failed to send the transaction {err}")
                 }
             }
-        } else {
-            log::info!("Pending block is already signed");
-        }
-    } else {
-        log::info!("No pending blocks");
-    }
-
-    loop {
-        let logs =
-            receiver.recv().unwrap_or_else(|err| panic!("Disconnected: {err}"));
-
-        let events = utils::get_events_from_logs(logs.value.logs);
-        if events.is_empty() {
-            continue;
-        }
-        // Since only 1 block would be created in a transaction
-        assert_eq!(events.len(), 1);
-        let event = &events[0];
-        log::info!("Found New Block Event {:?}", event);
-        // Fetching the pending block fingerprint
-        let fingerprint = guestchain::block::Fingerprint::new(
-            genesis_hash,
-            &event.block_header.0,
-        );
-        let signature = validator.sign_message(fingerprint.as_slice());
-
-        // Send the signature
-        let tx = utils::submit_call(
-            &program,
-            signature,
-            fingerprint.as_slice(),
-            &validator,
-            chain,
-            trie,
-            max_retries,
-        );
-        match tx {
-            Ok(tx) => log::info!("Block signed -> Transaction: {}", tx),
-            Err(err) => log::error!("Failed to send the transaction {err}"),
         }
     }
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -20,16 +20,19 @@ pub fn run_validator(config: Config) {
         validator.clone(),
         CommitmentConfig::processed(),
     );
-    let program = client.program(Pubkey::from_str(&config.program_id).unwrap()).unwrap();
+    let program =
+        client.program(Pubkey::from_str(&config.program_id).unwrap()).unwrap();
 
-    let trie =
-        Pubkey::find_program_address(&[solana_ibc::TRIE_SEED], &Pubkey::from_str(&config.program_id).unwrap())
-            .0;
+    let trie = Pubkey::find_program_address(
+        &[solana_ibc::TRIE_SEED],
+        &Pubkey::from_str(&config.program_id).unwrap(),
+    )
+    .0;
     let chain = Pubkey::find_program_address(
         &[solana_ibc::CHAIN_SEED],
         &Pubkey::from_str(&config.program_id).unwrap(),
     )
-        .0;
+    .0;
 
     log::info!("Validator running");
 
@@ -69,7 +72,7 @@ pub fn run_validator(config: Config) {
                     chain,
                     trie,
                     max_tries,
-                    &config.priority_fees
+                    &config.priority_fees,
                 );
                 match tx {
                     Ok(tx) => {
@@ -91,7 +94,7 @@ pub fn run_validator(config: Config) {
                 chain,
                 trie,
                 max_tries,
-                &config.priority_fees
+                &config.priority_fees,
             );
             match tx {
                 Ok(tx) => {

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -44,14 +44,15 @@ pub fn run_validator(config: Config) {
         sleep(Duration::from_secs(5));
         let chain_account: ChainData = program.account(chain).unwrap();
         if chain_account.pending_block().unwrap().is_some() {
-            if chain_account
+            if let Some(pending_block) = chain_account
                 .pending_block()
                 .unwrap()
-                .unwrap()
-                .signers
-                .get(&validator.pubkey().into())
-                .is_none()
+                .as_ref()
             {
+                if pending_block.signers.get(&validator.pubkey().into()).is_some() {
+                    log::info!("You have already signed the pending block");
+                    continue;
+                }
                 log::info!(
                     "Found block {:?}",
                     chain_account.pending_block().unwrap().unwrap()

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -69,6 +69,7 @@ pub fn run_validator(config: Config) {
                     chain,
                     trie,
                     max_tries,
+                    &config.priority_fees
                 );
                 match tx {
                     Ok(tx) => {
@@ -90,6 +91,7 @@ pub fn run_validator(config: Config) {
                 chain,
                 trie,
                 max_tries,
+                &config.priority_fees
             );
             match tx {
                 Ok(tx) => {

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -44,12 +44,14 @@ pub fn run_validator(config: Config) {
         sleep(Duration::from_secs(5));
         let chain_account: ChainData = program.account(chain).unwrap();
         if chain_account.pending_block().unwrap().is_some() {
-            if let Some(pending_block) = chain_account
-                .pending_block()
-                .unwrap()
-                .as_ref()
+            if let Some(pending_block) =
+                chain_account.pending_block().unwrap().as_ref()
             {
-                if pending_block.signers.get(&validator.pubkey().into()).is_some() {
+                if pending_block
+                    .signers
+                    .get(&validator.pubkey().into())
+                    .is_some()
+                {
                     log::info!("You have already signed the pending block");
                     continue;
                 }


### PR DESCRIPTION
The new validator client has the following improvements.
- not use spinner to send the transaction since it takes forever.
- use program id from config for deriving PDA and calling the program.
- check if pending block exists else create a new block.
- sign only if the current block is unsigned.
- add priority fees as config to let users choose their custom fee.
- submit tx to jito client instead of rpc.
- remove custom accounts structure for staking.