### PR TITLE
solana-ibc: implement missing traits from ibc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,6 +2349,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2361,6 +2362,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2370,6 +2372,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "base64 0.21.7",
  "borsh 0.10.3",
@@ -2389,6 +2392,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2398,6 +2402,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2412,6 +2417,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2420,6 +2426,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2436,6 +2443,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "displaydoc",
@@ -2454,6 +2462,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2467,6 +2476,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2475,6 +2485,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2490,6 +2501,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2504,6 +2516,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2526,6 +2539,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-client-tendermint-types",
  "ibc-core-client-context",
@@ -2539,6 +2553,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2555,6 +2570,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2574,6 +2590,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2591,6 +2608,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -2602,6 +2620,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2622,6 +2641,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "ibc-client-tendermint-types",
  "ibc-core-channel",
@@ -2637,6 +2657,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2660,6 +2681,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2677,6 +2699,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2700,6 +2723,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2714,6 +2738,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2727,6 +2752,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2745,6 +2771,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2754,6 +2781,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2792,6 +2820,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.50.0"
+source = "git+https://github.com/mina86/ibc-rs?rev=6015aea441d4660f7f7ecd89b5e770a993448089#6015aea441d4660f7f7ecd89b5e770a993448089"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -6071,6 +6100,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.34.1"
+source = "git+https://github.com/mina86/tendermint-rs?rev=45fbd500d731effb95a98257630feb46f6c41d06#45fbd500d731effb95a98257630feb46f6c41d06"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -6098,11 +6128,11 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.34.1"
+source = "git+https://github.com/mina86/tendermint-rs?rev=45fbd500d731effb95a98257630feb46f6c41d06#45fbd500d731effb95a98257630feb46f6c41d06"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "solana-program",
  "tendermint",
  "time",
 ]
@@ -6110,6 +6140,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.34.1"
+source = "git+https://github.com/mina86/tendermint-rs?rev=45fbd500d731effb95a98257630feb46f6c41d06#45fbd500d731effb95a98257630feb46f6c41d06"
 dependencies = [
  "bytes",
  "flex-error",
@@ -7230,3 +7261,4 @@ dependencies = [
 [[patch.unused]]
 name = "tendermint-light-client"
 version = "0.34.1"
+source = "git+https://github.com/mina86/tendermint-rs?rev=45fbd500d731effb95a98257630feb46f6c41d06#45fbd500d731effb95a98257630feb46f6c41d06"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "bytemuck",
  "derive_more",
  "guestchain",
+ "ibc-client-tendermint-types",
  "ibc-core-client-context",
  "ibc-core-commitment-types",
  "ibc-core-host",
@@ -2348,7 +2349,6 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2361,7 +2361,6 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2371,7 +2370,6 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "base64 0.21.7",
  "borsh 0.10.3",
@@ -2391,7 +2389,6 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2401,7 +2398,6 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2416,7 +2412,6 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2425,7 +2420,6 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2442,7 +2436,6 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "displaydoc",
@@ -2461,7 +2454,6 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2475,7 +2467,6 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2484,7 +2475,6 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2500,7 +2490,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2515,7 +2504,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2538,8 +2526,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
+ "ibc-client-tendermint-types",
  "ibc-core-client-context",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -2551,10 +2539,10 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "displaydoc",
+ "ibc-client-tendermint-types",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
  "ibc-core-handler-types",
@@ -2567,7 +2555,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2587,7 +2574,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2605,7 +2591,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -2617,7 +2602,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2638,8 +2622,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
+ "ibc-client-tendermint-types",
  "ibc-core-channel",
  "ibc-core-client",
  "ibc-core-commitment-types",
@@ -2653,7 +2637,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2677,7 +2660,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2695,7 +2677,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2719,7 +2700,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2734,7 +2714,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2748,7 +2727,6 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2767,7 +2745,6 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2777,7 +2754,6 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2816,11 +2792,11 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=d8ac409f5b206c389568fb2e713d2666e4b9afde#d8ac409f5b206c389568fb2e713d2666e4b9afde"
 dependencies = [
  "derive_more",
  "displaydoc",
  "ibc",
+ "ibc-client-tendermint-types",
  "ibc-proto",
  "parking_lot",
  "subtle-encoding",
@@ -4996,9 +4972,11 @@ dependencies = [
  "guestchain",
  "hex-literal",
  "ibc",
+ "ibc-client-tendermint-types",
  "ibc-proto",
  "ibc-testkit",
  "insta",
+ "itertools 0.10.5",
  "lib",
  "linear-map",
  "memory",
@@ -6092,8 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.34.0"
-source = "git+https://github.com/informalsystems/tendermint-rs?rev=37822e540e272d2ca9e763769ad20c581203ff9a#37822e540e272d2ca9e763769ad20c581203ff9a"
+version = "0.34.1"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -6120,25 +6097,22 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.34.0"
-source = "git+https://github.com/informalsystems/tendermint-rs?rev=37822e540e272d2ca9e763769ad20c581203ff9a#37822e540e272d2ca9e763769ad20c581203ff9a"
+version = "0.34.1"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
+ "solana-program",
  "tendermint",
  "time",
 ]
 
 [[package]]
 name = "tendermint-proto"
-version = "0.34.0"
-source = "git+https://github.com/informalsystems/tendermint-rs?rev=37822e540e272d2ca9e763769ad20c581203ff9a#37822e540e272d2ca9e763769ad20c581203ff9a"
+version = "0.34.1"
 dependencies = [
  "bytes",
  "flex-error",
- "num-derive 0.3.3",
- "num-traits",
  "prost",
  "prost-types",
  "serde",
@@ -7255,5 +7229,4 @@ dependencies = [
 
 [[patch.unused]]
 name = "tendermint-light-client"
-version = "0.34.0"
-source = "git+https://github.com/informalsystems/tendermint-rs?rev=37822e540e272d2ca9e763769ad20c581203ff9a#37822e540e272d2ca9e763769ad20c581203ff9a"
+version = "0.34.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ incremental = false
 codegen-units = 1
 
 [workspace.dependencies]
-anchor-lang = {version = "0.29.0", features = ["init-if-needed"]}
+anchor-lang = { version = "0.29.0", features = ["init-if-needed"] }
 anchor-spl = "0.29.0"
 ascii = "1.1.0"
 bs58 = { version = "0.5.0", features = ["alloc"] }
@@ -41,21 +41,36 @@ const_format = { version = "0.2.32", default-features = false }
 derive_more = "0.99.17"
 dialoguer = "0.10"
 directories = "5.0"
-ed25519-dalek = "=1.0.1"  # Must match solana-sdk’s dependency.
+ed25519-dalek = "=1.0.1"                                                      # Must match solana-sdk’s dependency.
 env_logger = "0.7.1"
 hex-literal = "0.4.1"
 
 # Use unreleased ibc-rs which supports custom verifier.
-ibc                       = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false, features = ["borsh", "serde"] }
-ibc-core-channel-types    = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
-ibc-core-client-context   = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
-ibc-core-client-types     = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
-ibc-core-commitment-types = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
-ibc-core-connection-types = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
-ibc-core-host             = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
-ibc-core-host-types       = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
-ibc-primitives            = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
-ibc-testkit               = { git = "https://github.com/mina86/ibc-rs", rev = "d8ac409f5b206c389568fb2e713d2666e4b9afde", default-features = false }
+ibc = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false, features = [
+    "borsh",
+    "serde",
+] }
+ibc-core-channel-types = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-core-client-context = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-core-client-types = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-core-commitment-types = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-core-connection-types = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-core-host = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-core-host-types = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-primitives = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-testkit = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+ibc-client-tendermint-types = { git = "https://github.com/mina86/ibc-rs", rev = "6015aea441d4660f7f7ecd89b5e770a993448089", default-features = false }
+#  ibc                       = { path = "../ibc-rs-mina/ibc", default-features = false, features = ["borsh", "serde"] }
+#  ibc-core-channel-types    = { path = "../ibc-rs-mina/ibc-core/ics04-channel/types", default-features = false }
+#  ibc-core-client-context   = { path = "../ibc-rs-mina/ibc-core/ics02-client/context", default-features = false }
+#  ibc-core-client-types     = { path = "../ibc-rs-mina/ibc-core/ics02-client/types", default-features = false }
+#  ibc-core-commitment-types = { path = "../ibc-rs-mina/ibc-core/ics23-commitment/types", default-features = false }
+#  ibc-core-connection-types = { path = "../ibc-rs-mina/ibc-core/ics03-connection/types", default-features = false }
+#  ibc-core-host             = { path = "../ibc-rs-mina/ibc-core/ics24-host", default-features = false }
+#  ibc-core-host-types       = { path = "../ibc-rs-mina/ibc-core/ics24-host/types", default-features = false }
+#  ibc-primitives            = { path = "../ibc-rs-mina/ibc-primitives", default-features = false }
+#  ibc-testkit               = { path = "../ibc-rs-mina/ibc-testkit", default-features = false }
+#  ibc-client-tendermint-types = { path = "../ibc-rs-mina/ibc-clients/ics07-tendermint/types", default-features = false}
 
 ibc-proto = { version = "0.41.0", default-features = false }
 insta = { version = "1.34.0" }
@@ -78,7 +93,7 @@ solana-sdk = "1.17.30"
 spl-associated-token-account = "2.2.0"
 spl-token = "4.0.0"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
-tendermint                       = { version = "0.34.0", default-features = false }
+tendermint = { version = "0.34.0", default-features = false }
 tendermint-light-client-verifier = { version = "0.34.0", default-features = false }
 tokio = "1.35.1"
 toml = "0.8.8"
@@ -122,10 +137,14 @@ curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dal
 # programs cannot have.  tendermint 0.34 enables eyre unconditionally;
 # version which doesn’t do that hasn’t been released yet so we need to
 # refer to a commit on master.
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
-tendermint-light-client = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
-tendermint-light-client-verifier = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
-tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", rev = "37822e540e272d2ca9e763769ad20c581203ff9a" }
+tendermint = { git = "https://github.com/mina86/tendermint-rs", rev = "45fbd500d731effb95a98257630feb46f6c41d06" }
+tendermint-light-client = { git = "https://github.com/mina86/tendermint-rs", rev = "45fbd500d731effb95a98257630feb46f6c41d06" }
+tendermint-light-client-verifier = { git = "https://github.com/mina86/tendermint-rs", rev = "45fbd500d731effb95a98257630feb46f6c41d06" }
+tendermint-proto = { git = "https://github.com/mina86/tendermint-rs", rev = "45fbd500d731effb95a98257630feb46f6c41d06" }
+# tendermint                       = { path = "../tendermint-rs-mina/tendermint" }
+# tendermint-light-client          = { path = "../tendermint-rs-mina/light-client" }
+# tendermint-light-client-verifier = { path = "../tendermint-rs-mina/light-client-verifier" }
+# tendermint-proto                 = { path = "../tendermint-rs-mina/proto" }
 
 # Adds support for custom-entrypoint feature
 anchor-syn = { git = "https://github.com/mina86/anchor", branch = "custom-entrypoint" }

--- a/common/cf-guest/Cargo.toml
+++ b/common/cf-guest/Cargo.toml
@@ -12,6 +12,7 @@ ibc-core-client-context.workspace = true
 ibc-core-commitment-types.workspace = true
 ibc-core-host.workspace = true
 ibc-primitives.workspace = true
+ibc-client-tendermint-types.workspace = true
 ibc-proto.workspace = true
 prost = { workspace = true, features = ["prost-derive"] }
 

--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -288,6 +288,15 @@ where
         self.do_update_state(ctx, client_id, header)
     }
 
+    fn update_tm_state(
+        &self,
+        _ctx: &mut E,
+        _client_id: &ibc::ClientId,
+        _header: Option<ibc_client_tendermint_types::Header>,
+    ) -> Result<Vec<ibc::Height>> {
+        unimplemented!("Only tendermint client is supported");
+    }
+
     fn update_state_on_misbehaviour(
         &self,
         ctx: &mut E,
@@ -329,6 +338,15 @@ where
         self.do_verify_client_message(ctx, client_message)
     }
 
+    fn verify_tm_client_message(
+        &self,
+        _ctx: &V,
+        _client_id: &ibc::ClientId,
+        _client_message: Option<ibc_client_tendermint_types::Header>,
+    ) -> Result {
+        unimplemented!("Only tendermint clients are supported");
+    }
+
     fn check_for_misbehaviour(
         &self,
         ctx: &V,
@@ -337,6 +355,15 @@ where
     ) -> Result<bool> {
         let client_message = ClientMessage::<PK>::try_from(client_message)?;
         self.do_check_for_misbehaviour(ctx, client_id, client_message)
+    }
+
+    fn check_for_tm_misbehaviour(
+        &self,
+        ctx: &V,
+        client_id: &ibc::ClientId,
+        client_message: Option<ibc_client_tendermint_types::Header>,
+    ) -> Result<bool> {
+        unimplemented!("only supported for tendermint clients");
     }
 
     fn status(

--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -359,9 +359,9 @@ where
 
     fn check_for_tm_misbehaviour(
         &self,
-        ctx: &V,
-        client_id: &ibc::ClientId,
-        client_message: Option<ibc_client_tendermint_types::Header>,
+        _ctx: &V,
+        _client_id: &ibc::ClientId,
+        _client_message: Option<ibc_client_tendermint_types::Header>,
     ) -> Result<bool> {
         unimplemented!("only supported for tendermint clients");
     }

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -28,6 +28,7 @@ hex-literal.workspace = true
 ibc-proto.workspace = true
 ibc-testkit = { workspace = true, optional = true }
 ibc.workspace = true
+ibc-client-tendermint-types.workspace = true
 linear-map.workspace = true
 primitive-types.workspace = true
 prost.workspace = true
@@ -50,6 +51,7 @@ solana-trie.workspace = true
 stdx.workspace = true
 trie-ids = { workspace = true, features = ["borsh"] }
 wasm = { workspace = true }
+itertools = "0.10.5"
 
 [dev-dependencies]
 anchor-client.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -114,11 +114,38 @@ impl<'a, 'b> ibc::ClientStateValidation<IbcStorage<'a, 'b>> for AnyClientState {
         }
     }
 
+    fn verify_tm_client_message(
+        &self,
+        ctx: &IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        client_message: Option<ibc_client_tendermint_types::Header>,
+    ) -> Result {
+        match self {
+            AnyClientState::Tendermint(cs) => {
+                ibc::tm::client_state::verify_tm_client_message::<
+                    _,
+                    SolanaHostFunctions,
+                >(
+                    cs.inner(), ctx, client_id, client_message, &tm::TmVerifier
+                )
+            }
+            AnyClientState::Wasm(_) => unimplemented!(),
+            #[cfg(any(test, feature = "mocks"))]
+            AnyClientState::Mock(_) => unimplemented!(),
+        }
+    }
+
     delegate!(fn check_for_misbehaviour(
         &self,
         ctx: &IbcStorage<'a, 'b>,
         client_id: &ibc::ClientId,
         client_message: ibc::Any,
+    ) -> Result<bool>);
+    delegate!(fn check_for_tm_misbehaviour(
+        &self,
+        ctx: &IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        client_message: Option<ibc_client_tendermint_types::Header>,
     ) -> Result<bool>);
     delegate!(fn status(
         &self,
@@ -139,6 +166,12 @@ impl<'a, 'b> ibc::ClientStateExecution<IbcStorage<'a, 'b>> for AnyClientState {
         ctx: &mut IbcStorage<'a, 'b>,
         client_id: &ibc::ClientId,
         header: ibc::Any,
+    ) -> Result<Vec<ibc::Height>>);
+    delegate!(fn update_tm_state(
+        &self,
+        ctx: &mut IbcStorage<'a, 'b>,
+        client_id: &ibc::ClientId,
+        header: Option<ibc_client_tendermint_types::Header>,
     ) -> Result<Vec<ibc::Height>>);
     delegate!(fn update_state_on_misbehaviour(
         &self,


### PR DESCRIPTION
Since we have added new methods to the Validation and Execution traits in ibc, we need to implement those. The traits are added to reuse the headers instead of deserializing every time since they consume a lot of units.