### PR TITLE
solana-ibc: validation for token mint and fix tests

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -22,6 +22,8 @@ pub const PACKET_SEED: &[u8] = b"packet";
 pub const SOLANA_IBC_STORAGE_SEED: &[u8] = b"private";
 pub const TRIE_SEED: &[u8] = b"trie";
 pub const MINT_ESCROW_SEED: &[u8] = b"mint_escrow";
+pub const MINT: &[u8] = b"mint";
+pub const ESCROW: &[u8] = b"escrow";
 
 declare_id!("9fd7GDygnAmHhXDVWgzsfR6kSRvwkxVnsY8SaSpSH4SX");
 
@@ -484,7 +486,7 @@ pub struct InitMint<'info> {
               bump, space = 100)]
     mint_authority: UncheckedAccount<'info>,
 
-    #[account(init_if_needed, payer = sender, seeds = [hashed_base_denom.as_ref()],
+    #[account(init_if_needed, payer = sender, seeds = [MINT, port_id.as_bytes(), channel_id_on_b.as_bytes(), hashed_base_denom.as_ref()],
               bump, mint::decimals = 6, mint::authority = mint_authority)]
     token_mint: Account<'info, Mint>,
 
@@ -608,7 +610,7 @@ pub struct SendTransfer<'info> {
     #[account(mut)]
     token_mint: Option<Box<Account<'info, Mint>>>,
     #[account(init_if_needed, payer = sender, seeds = [
-        port_id.as_bytes(), channel_id.as_bytes(), hashed_base_denom.as_ref()
+        ESCROW, port_id.as_bytes(), channel_id.as_bytes(), hashed_base_denom.as_ref()
     ], bump, token::mint = token_mint, token::authority = mint_authority)]
     escrow_account: Option<Box<Account<'info, TokenAccount>>>,
     #[account(mut)]

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -88,10 +88,6 @@ fn anchor_test_deliver() -> Result<()> {
             .unwrap()
             .pubkey();
 
-    let sol_rpc_client = program.rpc();
-    let _airdrop_signature =
-        airdrop(&sol_rpc_client, authority.pubkey(), lamports);
-
     // Build, sign, and send program instruction
     let storage = Pubkey::find_program_address(
         &[crate::SOLANA_IBC_STORAGE_SEED],
@@ -106,6 +102,43 @@ fn anchor_test_deliver() -> Result<()> {
     let native_token_mint_key = mint_keypair.pubkey();
     let base_denom = native_token_mint_key.to_string();
     let hashed_denom = CryptoHash::digest(base_denom.as_bytes());
+
+    let port_id = ibc::PortId::transfer();
+    let channel_id_on_a = ibc::ChannelId::new(0);
+    let channel_id_on_b = ibc::ChannelId::new(1);
+
+    let seeds = [
+        crate::ESCROW,
+        port_id.as_bytes(),
+        channel_id_on_a.as_bytes(),
+        hashed_denom.as_ref(),
+    ];
+    let (escrow_account_key, _bump) =
+        Pubkey::find_program_address(&seeds, &crate::ID);
+    let (token_mint_key, _bump) = Pubkey::find_program_address(
+        &[
+            crate::MINT,
+            port_id.as_bytes(),
+            channel_id_on_a.as_bytes(),
+            hashed_denom.as_ref(),
+        ],
+        &crate::ID,
+    );
+    let (mint_authority_key, _bump) =
+        Pubkey::find_program_address(&[MINT_ESCROW_SEED], &crate::ID);
+
+    let receiver = Rc::new(Keypair::new());
+
+    let sender_token_address =
+        get_associated_token_address(&authority.pubkey(), &token_mint_key);
+    let receiver_token_address =
+        get_associated_token_address(&receiver.pubkey(), &token_mint_key);
+
+    let sol_rpc_client = program.rpc();
+    let _airdrop_signature =
+        airdrop(&sol_rpc_client, authority.pubkey(), lamports);
+    let _airdrop_signature =
+        airdrop(&sol_rpc_client, receiver.pubkey(), lamports);
 
     /*
      * Initialise chain
@@ -286,19 +319,6 @@ fn anchor_test_deliver() -> Result<()> {
         })?;
     println!("  Signature: {sig}");
 
-    let port_id = ibc::PortId::transfer();
-    let channel_id_on_a = ibc::ChannelId::new(0);
-    let channel_id_on_b = ibc::ChannelId::new(1);
-
-    let seeds =
-        [port_id.as_bytes(), channel_id_on_a.as_bytes(), hashed_denom.as_ref()];
-    let (escrow_account_key, _bump) =
-        Pubkey::find_program_address(&seeds, &crate::ID);
-    let (token_mint_key, _bump) =
-        Pubkey::find_program_address(&[hashed_denom.as_ref()], &crate::ID);
-    let (mint_authority_key, _bump) =
-        Pubkey::find_program_address(&[MINT_ESCROW_SEED], &crate::ID);
-
     /*
      * Setup mock connection and channel
      *
@@ -307,12 +327,6 @@ fn anchor_test_deliver() -> Result<()> {
      *  - Get token account for receiver and sender
      */
     println!("\nSetting up mock connection and channel");
-    let receiver = Keypair::new();
-
-    let sender_token_address =
-        get_associated_token_address(&authority.pubkey(), &token_mint_key);
-    let receiver_token_address =
-        get_associated_token_address(&receiver.pubkey(), &token_mint_key);
 
     let sig = program
         .request()
@@ -437,7 +451,7 @@ fn anchor_test_deliver() -> Result<()> {
     let msg_transfer = construct_transfer_packet_from_denom(
         &base_denom,
         port_id.clone(),
-        channel_id_on_b.clone(),
+        true,
         channel_id_on_a.clone(),
         associated_token_addr,
         receiver_token_address,
@@ -503,9 +517,9 @@ fn anchor_test_deliver() -> Result<()> {
     let packet = construct_packet_from_denom(
         &base_denom,
         port_id.clone(),
+        false,
         channel_id_on_b.clone(),
         channel_id_on_a.clone(),
-        channel_id_on_b.clone(),
         2,
         sender_token_address,
         receiver_token_address,
@@ -573,14 +587,14 @@ fn anchor_test_deliver() -> Result<()> {
     let msg_transfer = construct_transfer_packet_from_denom(
         &base_denom,
         port_id.clone(),
+        false,
         channel_id_on_a.clone(),
-        channel_id_on_a.clone(),
-        associated_token_addr,
         receiver_token_address,
+        sender_token_address,
     );
 
     let account_balance_before = sol_rpc_client
-        .get_token_account_balance(&associated_token_addr)
+        .get_token_account_balance(&receiver_token_address)
         .unwrap();
 
     let sig = program
@@ -589,16 +603,16 @@ fn anchor_test_deliver() -> Result<()> {
             1_000_000u32,
         ))
         .accounts(accounts::SendTransfer {
-            sender: authority.pubkey(),
-            receiver: Some(receiver.pubkey()),
+            sender: receiver.pubkey(),
+            receiver: Some(authority.pubkey()),
             storage,
             trie,
             chain,
             system_program: system_program::ID,
             mint_authority: Some(mint_authority_key),
-            token_mint: Some(native_token_mint_key),
-            escrow_account: Some(escrow_account_key),
-            receiver_token_account: Some(associated_token_addr),
+            token_mint: Some(token_mint_key),
+            escrow_account: None,
+            receiver_token_account: Some(receiver_token_address),
             associated_token_program: Some(anchor_spl::associated_token::ID),
             token_program: Some(anchor_spl::token::ID),
         })
@@ -608,8 +622,8 @@ fn anchor_test_deliver() -> Result<()> {
             hashed_base_denom: hashed_denom,
             msg: msg_transfer,
         })
-        .payer(authority.clone())
-        .signer(&*authority)
+        .payer(receiver.clone())
+        .signer(&*receiver)
         .send_with_spinner_and_config(RpcSendTransactionConfig {
             skip_preflight: true,
             ..RpcSendTransactionConfig::default()
@@ -617,7 +631,7 @@ fn anchor_test_deliver() -> Result<()> {
     println!("  Signature: {sig}");
 
     let account_balance_after = sol_rpc_client
-        .get_token_account_balance(&associated_token_addr)
+        .get_token_account_balance(&receiver_token_address)
         .unwrap();
 
     assert_eq!(
@@ -641,7 +655,7 @@ fn anchor_test_deliver() -> Result<()> {
     let packet = construct_packet_from_denom(
         &base_denom,
         port_id.clone(),
-        channel_id_on_b.clone(),
+        true,
         channel_id_on_b.clone(),
         channel_id_on_a.clone(),
         3,
@@ -730,7 +744,7 @@ fn anchor_test_deliver() -> Result<()> {
     let packet = construct_packet_from_denom(
         &base_denom,
         port_id.clone(),
-        channel_id_on_a.clone(),
+        true,
         channel_id_on_a.clone(),
         channel_id_on_b.clone(),
         1,
@@ -763,7 +777,6 @@ fn anchor_test_deliver() -> Result<()> {
         })?;
     println!("  Signature: {sig}");
 
-
     /*
      * Free Write account
      */
@@ -793,7 +806,7 @@ fn construct_packet_from_denom(
     port_id: ibc::PortId,
     // Channel id used to define if its source chain or destination chain (in
     // denom).
-    denom_channel_id: ibc::ChannelId,
+    is_destination: bool,
     channel_id_on_a: ibc::ChannelId,
     channel_id_on_b: ibc::ChannelId,
     sequence: u64,
@@ -801,7 +814,11 @@ fn construct_packet_from_denom(
     receiver_token_address: Pubkey,
     memo: String,
 ) -> ibc::Packet {
-    let denom = format!("{port_id}/{denom_channel_id}/{base_denom}");
+    let denom = if is_destination {
+        format!("{port_id}/{channel_id_on_a}/{base_denom}")
+    } else {
+        base_denom.to_string()
+    };
     let denom =
         ibc::apps::transfer::types::PrefixedDenom::from_str(&denom).unwrap();
     let token = ibc::apps::transfer::types::Coin {
@@ -835,20 +852,24 @@ fn construct_packet_from_denom(
 fn construct_transfer_packet_from_denom(
     base_denom: &str,
     port_id: ibc::PortId,
-    // Channel id used to define if its source chain or destination chain (in
-    // denom).
-    denom_channel_id: ibc::ChannelId,
+    is_source: bool,
     channel_id_on_a: ibc::ChannelId,
     sender_address: Pubkey,
     receiver_address: Pubkey,
 ) -> MsgTransfer {
-    let denom = format!("{port_id}/{denom_channel_id}/{base_denom}");
+    let denom = if !is_source {
+        format!("{port_id}/{channel_id_on_a}/{base_denom}")
+    } else {
+        base_denom.to_string()
+    };
     let denom =
         ibc::apps::transfer::types::PrefixedDenom::from_str(&denom).unwrap();
     let token = ibc::apps::transfer::types::Coin {
         denom,
         amount: TRANSFER_AMOUNT.into(),
     };
+
+    println!("This is token {:?}", token);
 
     let packet_data = ibc::apps::transfer::types::packet::PacketData {
         token: token.into(),


### PR DESCRIPTION
The token mint on destination chain is a PDA with seeds as portId, channelId and hashed denom. But during mint and burn, the account was not validated if it really was a PDA with the above seeds which could have enabled users to pass a different token mint.

Fixed tests to reflect the above changes.