### PR TITLE
restaking: add checking for the Instructions sysvar

### DIFF
--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -83,7 +83,7 @@ pub mod restaking {
         let guest_chain_program_id = staking_params.guest_chain_program_id;
 
         vault_params.service =
-            if guest_chain_program_id.is_some() { Some(service) } else { None };
+            guest_chain_program_id.is_some().then_some(service);
         vault_params.stake_timestamp_sec = current_time;
         vault_params.stake_amount = amount;
         vault_params.stake_mint = ctx.accounts.token_mint.key();
@@ -571,7 +571,6 @@ pub mod restaking {
         if vault_params.service.is_some() {
             return Err(error!(ErrorCodes::ServiceAlreadySet));
         }
-
 
         vault_params.service = Some(service);
 

--- a/solana/restaking/programs/restaking/src/validation.rs
+++ b/solana/restaking/programs/restaking/src/validation.rs
@@ -15,7 +15,7 @@ use crate::ErrorCodes;
 /// - guest chain program ID: Should match the expected guest chain program ID
 ///
 /// Note: The accounts should be sent in above order.
-pub fn validate_remaining_accounts(
+pub(crate) fn validate_remaining_accounts(
     accounts: &[AccountInfo<'_>],
     expected_guest_chain_program_id: &Pubkey,
 ) -> Result<()> {
@@ -44,4 +44,16 @@ pub fn validate_remaining_accounts(
     }
 
     Ok(())
+}
+
+/// Verifies that given account is the Instruction sysvars and returns it if it
+/// is.
+pub(crate) fn check_instructions_sysvar<'info>(
+    account: &AccountInfo<'info>,
+) -> Result<AccountInfo<'info>> {
+    if solana_program::sysvar::instructions::check_id(account.key) {
+        Ok(account.clone())
+    } else {
+        Err(error!(ErrorCodes::AccountValidationFailedForCPI))
+    }
 }

--- a/solana/restaking/tests/instructions.ts
+++ b/solana/restaking/tests/instructions.ts
@@ -263,7 +263,6 @@ export const withdrawalRequestInstruction = async (
       metadataProgram: new anchor.web3.PublicKey(
         mpl.MPL_TOKEN_METADATA_PROGRAM_ID
       ),
-      instruction: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
     })
     .transaction();
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -179,7 +179,7 @@ pub mod solana_ibc {
         let caller_program_id =
             solana_program::sysvar::instructions::get_instruction_relative(
                 0,
-                &ctx.accounts.instruction.to_account_info(),
+                &ctx.accounts.instruction,
             )?
             .program_id;
         chain.check_staking_program(&caller_program_id)?;
@@ -448,7 +448,7 @@ pub struct SetStake<'info> {
     #[account(address = solana_program::sysvar::instructions::ID)]
     /// CHECK: Used for getting the caller program id to verify if the right
     /// program is calling the method.
-    instruction: AccountInfo<'info>,
+    instruction: UncheckedAccount<'info>,
 }
 
 #[derive(Accounts)]


### PR DESCRIPTION
The Instructions sysvar isn’t used directly by the restaking contract and instead is passed via CPI to the solana-ibc contract.  As such, it’s safe to not verify the account since solana-ibc will perform the verification.  Nonetheless, to introduce another layer of protection, check that the passed account is what we expect.

Note: In addition, remove instruction account from WithdrawalRequest call since it was never used.