### PR TITLE
validator: remove jito mev client for staking

### DIFF
--- a/validator/src/stake.rs
+++ b/validator/src/stake.rs
@@ -7,16 +7,13 @@ use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::compute_budget::ComputeBudgetInstruction;
 use anchor_client::solana_sdk::signature::Keypair;
 use anchor_client::solana_sdk::signer::Signer;
-use anchor_client::solana_sdk::transaction::Transaction;
-use anchor_client::{Client, Cluster};
+use anchor_client::{Client, ClientError, Cluster};
 use anchor_lang::solana_program::instruction::AccountMeta;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::solana_program::sysvar::SysvarId;
 use restaking::{accounts, Service};
 
 use crate::command::Config;
-use crate::skip_fail;
-use crate::utils::{BundleStatusResponse, Payload, Response};
 
 pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
     let validator = Rc::new(Keypair::from(config.keypair));
@@ -90,116 +87,68 @@ pub fn stake(config: Config, amount: u64, token_mint: Pubkey) {
             &validator.pubkey(),
             &receipt_token_key,
         );
-
-    let jito_address =
-        Pubkey::from_str("96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5")
-            .unwrap();
-    let ix = program
-        .request()
-        .instruction(anchor_lang::solana_program::system_instruction::transfer(
-            &validator.pubkey(),
-            &jito_address,
-            config.priority_fees,
-        ))
-        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            500_000u32,
-        ))
-        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-            config.priority_fees,
-        ))
-        .accounts(accounts::Deposit {
-            depositor: validator.pubkey(),
-            vault_params,
-            staking_params,
-            token_mint,
-            depositor_token_account,
-            vault_token_account,
-            receipt_token_mint: receipt_token_key,
-            receipt_token_account,
-            metadata_program: anchor_spl::metadata::ID,
-            token_program: anchor_spl::token::ID,
-            associated_token_program: anchor_spl::associated_token::ID,
-            system_program: anchor_lang::solana_program::system_program::ID,
-            rent: anchor_lang::solana_program::rent::Rent::id(),
-            instruction: anchor_lang::solana_program::sysvar::instructions::ID,
-            master_edition_account,
-            nft_metadata,
-        })
-        .accounts(vec![
-            AccountMeta { pubkey: chain, is_signer: false, is_writable: true },
-            AccountMeta { pubkey: trie, is_signer: false, is_writable: true },
-            AccountMeta {
-                pubkey: solana_ibc_program_id,
-                is_signer: false,
-                is_writable: true,
-            },
-        ])
-        .args(restaking::instruction::Deposit {
-            service: Service::GuestChain { validator: validator.pubkey() },
-            amount,
-        })
-        .payer(validator.clone())
-        .signer(&*validator)
-        .signer(&receipt_token_keypair)
-        .instructions()
-        .unwrap();
-    // Retrying it for 5 times.
-    for _ in 0..5 {
-        let rpc_client = program.rpc();
-        let latest_blockhash = rpc_client.get_latest_blockhash().unwrap();
-        let new_tx = Transaction::new_signed_with_payer(
-            ix.as_slice(),
-            Some(&validator.pubkey()),
-            &[&*validator, &receipt_token_keypair],
-            latest_blockhash,
-        );
-        let serialized_tx = bincode::serialize(&new_tx).unwrap();
-        // encode in base 58
-        let encoded_tx = bs58::encode(serialized_tx).into_string();
-        let client = reqwest::blocking::Client::new();
-        let send_payload = Payload {
-            jsonrpc: "2.0".to_string(),
-            id: 1,
-            method: "sendBundle".to_string(),
-            params: vec![vec![encoded_tx]],
-        };
-        let response = client
-            .post("https://mainnet.block-engine.jito.wtf/api/v1/bundles")
-            .json(&send_payload)
+    log::info!("This is priority fee {:?}", config.priority_fees);
+    for tries in 1..6 {
+        let tx = program
+            .request()
+            .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+                500_000u32,
+            ))
+            .instruction(ComputeBudgetInstruction::set_compute_unit_price(
+                config.priority_fees,
+            ))
+            .accounts(accounts::Deposit {
+                depositor: validator.pubkey(),
+                vault_params,
+                staking_params,
+                token_mint,
+                depositor_token_account,
+                vault_token_account,
+                receipt_token_mint: receipt_token_key,
+                receipt_token_account,
+                metadata_program: anchor_spl::metadata::ID,
+                token_program: anchor_spl::token::ID,
+                associated_token_program: anchor_spl::associated_token::ID,
+                system_program: anchor_lang::solana_program::system_program::ID,
+                rent: anchor_lang::solana_program::rent::Rent::id(),
+                instruction:
+                    anchor_lang::solana_program::sysvar::instructions::ID,
+                master_edition_account,
+                nft_metadata,
+            })
+            .accounts(vec![
+                AccountMeta {
+                    pubkey: chain,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: trie,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: solana_ibc_program_id,
+                    is_signer: false,
+                    is_writable: true,
+                },
+            ])
+            .args(restaking::instruction::Deposit {
+                service: Service::GuestChain { validator: validator.pubkey() },
+                amount,
+            })
+            .payer(validator.clone())
+            .signer(&*validator)
+            .signer(&receipt_token_keypair)
             .send();
-        let response = skip_fail!(response);
-        let response: Result<Response, reqwest::Error> = response.json();
-        let response = skip_fail!(response);
-        let bundle_id = response.result;
-        // log::info!("This is bundle id {:?}", bundle_id);
-        let response_payload = Payload {
-            jsonrpc: "2.0".to_string(),
-            id: 1,
-            method: "getBundleStatuses".to_string(),
-            params: vec![vec![bundle_id]],
-        };
-        for _ in 0..5 {
-            sleep(Duration::from_secs(1));
-            let response = client
-                .post("https://mainnet.block-engine.jito.wtf/api/v1/bundles")
-                .json(&response_payload)
-                .send();
-            let response = skip_fail!(response);
-            let response: Result<BundleStatusResponse, reqwest::Error> =
-                response.json();
-            let response = skip_fail!(response);
-            // log::info!("This is text for bundle status {:?}", x);
-            // log::info!("This is response {:?}", response);
-            if !response.result.value.is_empty() {
-                log::info!(
-                    "This is staking signature:\n  {}",
-                    response.result.value[0].clone().transactions[0]
-                );
-                return;
-            }
+        if let Err(err @ ClientError::SolanaClientError(_)) = tx {
+            log::error!("Couldnt not send the transaction: {:?}", err);
+        } else if let Ok(tx) = tx {
+            println!("This is staking signature:\n  {}", tx);
+            return;
         }
-        log::info!("Retrying to send the transaction");
-        sleep(Duration::from_secs(1));
+        sleep(Duration::from_millis(500));
+        log::info!("Retrying to send the transaction: Attempt {}", tries);
     }
     panic!("Could not send the transaction, please try again");
 }


### PR DESCRIPTION
We were sending transaction for staking through jito which is a bit immature since it doesnt return an error when it fails. So switching it back to send it through rpc.