### PR TITLE
solana-ibc: Check atleast one of the timeouts are non zero.

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/error.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/error.rs
@@ -61,6 +61,9 @@ pub enum Error {
 
     // CPI call from an unidentified program
     InvalidCPICall,
+
+    /// If both timeout timestamp and timeout height are zero
+    InvalidTimeout
 }
 
 impl Error {

--- a/solana/solana-ibc/programs/solana-ibc/src/error.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/error.rs
@@ -63,7 +63,7 @@ pub enum Error {
     InvalidCPICall,
 
     /// If both timeout timestamp and timeout height are zero
-    InvalidTimeout
+    InvalidTimeout,
 }
 
 impl Error {

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -279,6 +279,11 @@ pub mod solana_ibc {
     ) -> Result<()> {
         let mut store = storage::from_ctx!(ctx);
 
+        // Check if atleast one of the timeouts is non zero.
+        if !timeout_height.is_set() && !timeout_timestamp.is_set() {
+            return Err(error::Error::InvalidTimeout.into());
+        }
+
         let sequence = store
             .get_next_sequence_send(&ibc::path::SeqSendPath::new(
                 &port_id,
@@ -366,7 +371,7 @@ pub mod solana_ibc {
         let mut store = storage::from_ctx!(ctx, with accounts);
         let mut token_ctx = store.clone();
 
-        // Check if atleast one of the timeouts non zero.
+        // Check if atleast one of the timeouts is non zero.
         if !msg.timeout_height_on_b.is_set() && !msg.timeout_timestamp_on_b.is_set() {
             return Err(error::Error::InvalidTimeout.into());
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -372,7 +372,9 @@ pub mod solana_ibc {
         let mut token_ctx = store.clone();
 
         // Check if atleast one of the timeouts is non zero.
-        if !msg.timeout_height_on_b.is_set() && !msg.timeout_timestamp_on_b.is_set() {
+        if !msg.timeout_height_on_b.is_set() &&
+            !msg.timeout_timestamp_on_b.is_set()
+        {
             return Err(error::Error::InvalidTimeout.into());
         }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -366,6 +366,11 @@ pub mod solana_ibc {
         let mut store = storage::from_ctx!(ctx, with accounts);
         let mut token_ctx = store.clone();
 
+        // Check if atleast one of the timeouts non zero.
+        if !msg.timeout_height_on_b.is_set() && !msg.timeout_timestamp_on_b.is_set() {
+            return Err(error::Error::InvalidTimeout.into());
+        }
+
         let height = store.borrow().chain.head()?.block_height;
         // height just before the data is added to the trie.
         msg!("Current Block height {}", height);

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -835,6 +835,9 @@ fn construct_packet_from_denom(
 
     let serialized_data = serde_json::to_vec(&packet_data).unwrap();
 
+    let never = ibc::TimeoutHeight::At(
+        ibc::Height::new(u64::MAX, u64::MAX).unwrap(),
+    );
     let packet = ibc::Packet {
         seq_on_a: sequence.into(),
         port_id_on_a: port_id.clone(),
@@ -842,7 +845,7 @@ fn construct_packet_from_denom(
         port_id_on_b: port_id,
         chan_id_on_b: channel_id_on_b,
         data: serialized_data.clone(),
-        timeout_height_on_b: ibc::TimeoutHeight::Never,
+        timeout_height_on_b: never,
         timeout_timestamp_on_b: ibc::Timestamp::none(),
     };
 

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -801,6 +801,10 @@ fn anchor_test_deliver() -> Result<()> {
     Ok(())
 }
 
+fn max_timeout_height() -> ibc::TimeoutHeight {
+    ibc::TimeoutHeight::At(ibc::Height::new(u64::MAX, u64::MAX).unwrap())
+}
+
 fn construct_packet_from_denom(
     base_denom: &str,
     port_id: ibc::PortId,
@@ -835,8 +839,6 @@ fn construct_packet_from_denom(
 
     let serialized_data = serde_json::to_vec(&packet_data).unwrap();
 
-    let never =
-        ibc::TimeoutHeight::At(ibc::Height::new(u64::MAX, u64::MAX).unwrap());
     let packet = ibc::Packet {
         seq_on_a: sequence.into(),
         port_id_on_a: port_id.clone(),
@@ -844,7 +846,7 @@ fn construct_packet_from_denom(
         port_id_on_b: port_id,
         chan_id_on_b: channel_id_on_b,
         data: serialized_data.clone(),
-        timeout_height_on_b: never,
+        timeout_height_on_b: max_timeout_height(),
         timeout_timestamp_on_b: ibc::Timestamp::none(),
     };
 
@@ -884,7 +886,7 @@ fn construct_transfer_packet_from_denom(
         port_id_on_a: port_id.clone(),
         chan_id_on_a: channel_id_on_a.clone(),
         packet_data,
-        timeout_height_on_b: ibc::TimeoutHeight::Never,
+        timeout_height_on_b: max_timeout_height(),
         timeout_timestamp_on_b: ibc::Timestamp::none(),
     }
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -835,9 +835,8 @@ fn construct_packet_from_denom(
 
     let serialized_data = serde_json::to_vec(&packet_data).unwrap();
 
-    let never = ibc::TimeoutHeight::At(
-        ibc::Height::new(u64::MAX, u64::MAX).unwrap(),
-    );
+    let never =
+        ibc::TimeoutHeight::At(ibc::Height::new(u64::MAX, u64::MAX).unwrap());
     let packet = ibc::Packet {
         seq_on_a: sequence.into(),
         port_id_on_a: port_id.clone(),


### PR DESCRIPTION
When a packet is being sent, the timeout height and timeout timestamp can both be set to zero which effectively means that the packet can never time out. And there is no explicit check to prevent this. And this packet would never be accepted by cosmos since cosmos has a check that skips the packet if both the timeouts are zero. And since the packet never times out, the funds would be stuck forever.