### PR TITLE
cf-guest: delete only one consensus state at a time

### DIFF
--- a/common/cf-guest/src/client/tests.rs
+++ b/common/cf-guest/src/client/tests.rs
@@ -390,13 +390,14 @@ impl CommonContext<MockPubKey> for TestContext {
         Ok(())
     }
 
-    fn sorted_consensus_state_heights(
+    fn earliest_consensus_state(
         &self,
         client_id: &ibc::ClientId,
-    ) -> Result<Vec<ibc::Height>> {
+    ) -> Result<Option<(ibc::Height, Self::AnyConsensusState)>> {
         self.check_client_id(client_id);
-        let min = ibc::Height::min(0);
-        let max = ibc::Height::new(u64::MAX, u64::MAX).unwrap();
-        Ok(self.states.range(min..=max).map(|(key, _)| key.clone()).collect())
+        Ok(self
+            .states
+            .first_key_value()
+            .map(|(key, value)| (*key, value.clone())))
     }
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -297,20 +297,18 @@ impl cf_guest::CommonContext<sigverify::ed25519::PubKey>
         self.delete_consensus_state_impl(client_id, height)
     }
 
-    fn sorted_consensus_state_heights(
+    fn earliest_consensus_state(
         &self,
         client_id: &ibc::ClientId,
-    ) -> Result<Vec<ibc::Height>> {
-        let mut heights: Vec<_> = self
-            .borrow()
+    ) -> Result<Option<(ibc::Height, Self::AnyConsensusState)>> {
+        self.borrow()
             .private
             .client(client_id)?
             .consensus_states
-            .keys()
-            .copied()
-            .collect();
-        heights.sort();
-        Ok(heights)
+            .iter()
+            .min_by(|(ref a, _), (ref b, _)| a.cmp(b))
+            .map(|(height, state)| state.state().map(|state| (*height, state)))
+            .transpose()
     }
 }
 


### PR DESCRIPTION
Pruning all expired consensus states may take quite a while to the point when the solana-ibc contract runs out of compute units. Instead, change the code so only the earliest consensus state is checked and pruned.