### PR TITLE
solana-ibc: Reallocating Anchor accounts

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -396,7 +396,10 @@ pub mod solana_ibc {
     /// given in this call’s context before the body of the method is
     /// executed.
     #[allow(unused_variables)]
-    pub fn realloc_accounts(ctx: Context<ReallocAccounts>, new_length: u64) -> Result<()> {
+    pub fn realloc_accounts(
+        ctx: Context<ReallocAccounts>,
+        new_length: u64,
+    ) -> Result<()> {
         Ok(())
     }
 }
@@ -661,7 +664,6 @@ pub struct ReallocAccounts<'info> {
     chain: Box<Account<'info, chain::ChainData>>,
 
     system_program: Program<'info, System>,
-
 }
 
 impl ibc::Router for storage::IbcStorage<'_, '_> {

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -795,6 +795,7 @@ fn anchor_test_deliver() -> Result<()> {
         })?;
     println!("  Signature {sig}");
 
+
     Ok(())
 }
 


### PR DESCRIPTION
Method that reallocates the anchor accounts based on the length provided.