### PR TITLE
solana-ibc: Update block time

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -234,8 +234,8 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
 
     fn max_expected_time_per_block(&self) -> Duration {
         // The blocks are only produced when the state root
-        // changes or if the block age is more than the one 
-        // in the config. And then it also depends on how 
+        // changes or if the block age is more than the one
+        // in the config. And then it also depends on how
         // fast the validators sign.
         Duration::from_secs(3600)
     }

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -233,10 +233,11 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
     }
 
     fn max_expected_time_per_block(&self) -> Duration {
-        // In Solana protocol, the block time is 400ms second.
-        // Considering factors such as network latency, as a precaution,
-        // we set the duration to 1 seconds.
-        Duration::from_secs(1)
+        // The blocks are only produced when the state root
+        // changes or if the block age is more than the one 
+        // in the config. And then it also depends on how 
+        // fast the validators sign.
+        Duration::from_secs(3600)
     }
 
     fn validate_message_signer(&self, signer: &ibc::Signer) -> Result {


### PR DESCRIPTION
Update block time from 1 second to 3600 second which is used to estimate the delay from the timestamp. It refers to the maximum block time and not the average block time.