### PR TITLE
Update tendermint dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6092,8 +6092,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.34.1"
-source = "git+https://github.com/mina86/tendermint-rs?rev=7cad235b651728dbfe6d2bfbd9110c329f0d6e7e#7cad235b651728dbfe6d2bfbd9110c329f0d6e7e"
+version = "0.34.36"
+source = "git+https://github.com/mina86/tendermint-rs?rev=7b674c3693076de393069ab80bc1f703f639949a#7b674c3693076de393069ab80bc1f703f639949a"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -6120,8 +6120,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.34.1"
-source = "git+https://github.com/mina86/tendermint-rs?rev=7cad235b651728dbfe6d2bfbd9110c329f0d6e7e#7cad235b651728dbfe6d2bfbd9110c329f0d6e7e"
+version = "0.34.36"
+source = "git+https://github.com/mina86/tendermint-rs?rev=7b674c3693076de393069ab80bc1f703f639949a#7b674c3693076de393069ab80bc1f703f639949a"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -6132,8 +6132,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.34.1"
-source = "git+https://github.com/mina86/tendermint-rs?rev=7cad235b651728dbfe6d2bfbd9110c329f0d6e7e#7cad235b651728dbfe6d2bfbd9110c329f0d6e7e"
+version = "0.34.36"
+source = "git+https://github.com/mina86/tendermint-rs?rev=7b674c3693076de393069ab80bc1f703f639949a#7b674c3693076de393069ab80bc1f703f639949a"
 dependencies = [
  "bytes",
  "flex-error",
@@ -7253,5 +7253,5 @@ dependencies = [
 
 [[patch.unused]]
 name = "tendermint-light-client"
-version = "0.34.1"
-source = "git+https://github.com/mina86/tendermint-rs?rev=7cad235b651728dbfe6d2bfbd9110c329f0d6e7e#7cad235b651728dbfe6d2bfbd9110c329f0d6e7e"
+version = "0.34.36"
+source = "git+https://github.com/mina86/tendermint-rs?rev=7b674c3693076de393069ab80bc1f703f639949a#7b674c3693076de393069ab80bc1f703f639949a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6093,7 +6093,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.34.36"
-source = "git+https://github.com/mina86/tendermint-rs?rev=7b674c3693076de393069ab80bc1f703f639949a#7b674c3693076de393069ab80bc1f703f639949a"
+source = "git+https://github.com/mina86/tendermint-rs?rev=9f157c06f9053940bd182f4b3e8e958e5731d0c7#7b674c3693076de393069ab80bc1f703f639949a"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.34.36"
-source = "git+https://github.com/mina86/tendermint-rs?rev=7b674c3693076de393069ab80bc1f703f639949a#7b674c3693076de393069ab80bc1f703f639949a"
+source = "git+https://github.com/mina86/tendermint-rs?rev=9f157c06f9053940bd182f4b3e8e958e5731d0c7#7b674c3693076de393069ab80bc1f703f639949a"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -6133,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.34.36"
-source = "git+https://github.com/mina86/tendermint-rs?rev=7b674c3693076de393069ab80bc1f703f639949a#7b674c3693076de393069ab80bc1f703f639949a"
+source = "git+https://github.com/mina86/tendermint-rs?rev=9f157c06f9053940bd182f4b3e8e958e5731d0c7#7b674c3693076de393069ab80bc1f703f639949a"
 dependencies = [
  "bytes",
  "flex-error",
@@ -7254,4 +7254,4 @@ dependencies = [
 [[patch.unused]]
 name = "tendermint-light-client"
 version = "0.34.36"
-source = "git+https://github.com/mina86/tendermint-rs?rev=7b674c3693076de393069ab80bc1f703f639949a#7b674c3693076de393069ab80bc1f703f639949a"
+source = "git+https://github.com/mina86/tendermint-rs?rev=9f157c06f9053940bd182f4b3e8e958e5731d0c7#7b674c3693076de393069ab80bc1f703f639949a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,10 +120,10 @@ aes-gcm-siv = { git = "https://github.com/RustCrypto/AEADs", rev = "6105d7a5591a
 curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "8274d5cbb6fc3f38cdc742b4798173895cd2a290" }
 
 # Uses solana sys call as default hashing
-tendermint                       = { git = "https://github.com/mina86/tendermint-rs", rev = "7cad235b651728dbfe6d2bfbd9110c329f0d6e7e" }
-tendermint-light-client          = { git = "https://github.com/mina86/tendermint-rs", rev = "7cad235b651728dbfe6d2bfbd9110c329f0d6e7e" }
-tendermint-light-client-verifier = { git = "https://github.com/mina86/tendermint-rs", rev = "7cad235b651728dbfe6d2bfbd9110c329f0d6e7e" }
-tendermint-proto                 = { git = "https://github.com/mina86/tendermint-rs", rev = "7cad235b651728dbfe6d2bfbd9110c329f0d6e7e" }
+tendermint                       = { git = "https://github.com/mina86/tendermint-rs", rev = "7b674c3693076de393069ab80bc1f703f639949a" }
+tendermint-light-client          = { git = "https://github.com/mina86/tendermint-rs", rev = "7b674c3693076de393069ab80bc1f703f639949a" }
+tendermint-light-client-verifier = { git = "https://github.com/mina86/tendermint-rs", rev = "7b674c3693076de393069ab80bc1f703f639949a" }
+tendermint-proto                 = { git = "https://github.com/mina86/tendermint-rs", rev = "7b674c3693076de393069ab80bc1f703f639949a" }
 
 # Adds support for custom-entrypoint feature
 anchor-syn = { git = "https://github.com/mina86/anchor", branch = "custom-entrypoint" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,10 +120,10 @@ aes-gcm-siv = { git = "https://github.com/RustCrypto/AEADs", rev = "6105d7a5591a
 curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "8274d5cbb6fc3f38cdc742b4798173895cd2a290" }
 
 # Uses solana sys call as default hashing
-tendermint                       = { git = "https://github.com/mina86/tendermint-rs", rev = "7b674c3693076de393069ab80bc1f703f639949a" }
-tendermint-light-client          = { git = "https://github.com/mina86/tendermint-rs", rev = "7b674c3693076de393069ab80bc1f703f639949a" }
-tendermint-light-client-verifier = { git = "https://github.com/mina86/tendermint-rs", rev = "7b674c3693076de393069ab80bc1f703f639949a" }
-tendermint-proto                 = { git = "https://github.com/mina86/tendermint-rs", rev = "7b674c3693076de393069ab80bc1f703f639949a" }
+tendermint                       = { git = "https://github.com/mina86/tendermint-rs", rev = "9f157c06f9053940bd182f4b3e8e958e5731d0c7" }
+tendermint-light-client          = { git = "https://github.com/mina86/tendermint-rs", rev = "9f157c06f9053940bd182f4b3e8e958e5731d0c7" }
+tendermint-light-client-verifier = { git = "https://github.com/mina86/tendermint-rs", rev = "9f157c06f9053940bd182f4b3e8e958e5731d0c7" }
+tendermint-proto                 = { git = "https://github.com/mina86/tendermint-rs", rev = "9f157c06f9053940bd182f4b3e8e958e5731d0c7" }
 
 # Adds support for custom-entrypoint feature
 anchor-syn = { git = "https://github.com/mina86/anchor", branch = "custom-entrypoint" }


### PR DESCRIPTION
Update tendermint dependency to include our sign bytes reuse code.
The fork is mostly Tendermint 0.36.0 with just the sign bytes encoding
optimisation.
