### PR TITLE
convert to events and add event for consensus

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -237,7 +237,7 @@ impl cf_guest::CommonContext<sigverify::ed25519::PubKey>
         client_id: &ibc::ClientId,
         state: Self::AnyClientState,
     ) -> Result<()> {
-        Self::set_client_state(self, client_id, state)
+        self.store_client_state_impl(client_id, state)
     }
 
     fn consensus_state(

--- a/solana/solana-ibc/programs/solana-ibc/src/events.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/events.rs
@@ -127,10 +127,7 @@ pub struct ClientStateUpdate<'a> {
     /// Client identifier which got updated.
     pub client_id: CowClientId<'a>,
 
-    /// Client state serialised as a protocol buffer.
-    ///
-    /// This is the value whose commitment (mixed with client id) is stored in
-    /// the trie.
+    /// Borsh-serialised [`crate::client_state::AnyClientState`].
     pub state: alloc::borrow::Cow<'a, [u8]>,
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/events.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/events.rs
@@ -23,7 +23,6 @@ pub enum Event<'a> {
     BlockSigned(BlockSigned),
     BlockFinalised(BlockFinalised),
     ClientStateUpdate(ClientStateUpdate<'a>),
-    ConsensusStateUpdate(ConsensusStateUpdate<'a>),
 }
 
 /// Event emitted once blockchain is implemented.
@@ -132,29 +131,6 @@ pub struct ClientStateUpdate<'a> {
     ///
     /// This is the value whose commitment (mixed with client id) is stored in
     /// the trie.
-    pub state: alloc::borrow::Cow<'a, [u8]>,
-}
-
-/// Event emitted each time IBC consensus state is updated.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-    derive_more::From,
-)]
-pub struct ConsensusStateUpdate<'a> {
-    /// Client identifier the state belongs to.
-    pub client_id: CowClientId<'a>,
-
-    /// Height of the consensus state.
-    pub height: ibc::Height,
-
-    /// Consensus state serialised as a protocol buffer.
-    ///
-    /// This is the value whose commitment is stored in the trie.
     pub state: alloc::borrow::Cow<'a, [u8]>,
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/execution_context.rs
@@ -101,14 +101,7 @@ impl IbcStorage<'_, '_> {
 
         let trie_key =
             trie_ids::TrieKey::for_consensus_state(client.index, height);
-        store.provable.set(&trie_key, &hash).map_err(client_error)?;
-
-        events::emit(events::ConsensusStateUpdate {
-            client_id: events::client_id(client_id),
-            height,
-            state: events::bytes(encoded_state.as_slice()),
-        })
-        .map_err(client_error)
+        store.provable.set(&trie_key, &hash).map_err(client_error)
     }
 
     pub(crate) fn delete_consensus_state_impl(


### PR DESCRIPTION
As per comment, perhaps it’s better to use proper event? This PR does three things:
- Converts the behaviour from logging to emitting an event.
- Adds an event for consensus state.  I honestly don’t know how useful that is? If we don’t need it it might be better to skip it.
- Changes to output proto encoding rather then borsh. This is because proto is what is being hashed and stored in the trie, so perhaps that’s more convenient than outputting borsh?
Thoughts?