### PR TITLE
cf-guest: fix commitment membership proofs verification

### DIFF
--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -245,7 +245,7 @@ impl From<proof::VerifyError> for ibc::ClientError {
 
         Self::InvalidCommitmentProof(match err {
             ProofDecodingFailure(msg) => EncodingFailure(msg),
-            WrongSequenceNumber(err) => EncodingFailure(err.to_string()),
+            BadSequenceNumber(err) => EncodingFailure(err.to_string()),
             _ => ibc::CommitmentError::InvalidMerkleProof,
         })
     }


### PR DESCRIPTION
Packet commitments, receipts and acks are stored in the trie as is rather than being hashed.  This is because they are already 32-byte hashes and there is no need to hash that again.

However, the membership proof verification didn’t take that into account and hashed the commitments checking if the hash exists in the trie.

Fix the implementation so that the commitment value is taken raw and checked that it exists in the trie.