### PR TITLE
ts-sdk: perform proper serialization of amount to u256

### DIFF
--- a/solana/solana-ibc/tests/solana-ibc.ts
+++ b/solana/solana-ibc/tests/solana-ibc.ts
@@ -11,7 +11,7 @@ import {
   sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import { solanaIbcProgramId, rpcUrl, depositor } from "./constants";
-import { getInt64Bytes, hexToBytes, getGuestChainAccounts } from "./utils";
+import { hexToBytes, getGuestChainAccounts, numberTo32ByteBuffer } from "./utils";
 import { instructionSchema } from "./schema";
 
 describe("solana-ibc", () => {
@@ -19,7 +19,7 @@ describe("solana-ibc", () => {
     // Parameters
     const sender = depositor.publicKey; // solana account address
     const receiver = "centauri1c8jhgqsdzw5su4yeel93nrp9xmhlpapyd9k0ue"; // cosmos address
-    const amount = 10000000000000000; // amount to send
+    const amount = 10000000000000000n; // amount to send
     const channelIdOfSolana = "channel-0"; // example channel id
     const portId = "transfer"; // always the same
     const memo = "";
@@ -69,7 +69,7 @@ describe("solana-ibc", () => {
 const sendTransfer = async (
   sender: anchor.web3.PublicKey,
   receiver: string,
-  amount: number,
+  amount: bigint,
   channelIdOfSolana: string,
   portId: string,
   memo: string,
@@ -80,12 +80,7 @@ const sendTransfer = async (
 ) => {
   const senderPublicKey = new anchor.web3.PublicKey(sender);
 
-  const emptyArray = [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  ];
-
-  const convertedAmount = getInt64Bytes(amount);
-  const finalAmount = convertedAmount.concat(emptyArray);
+  const convertedAmount = numberTo32ByteBuffer(amount);
 
   let tokenMint: anchor.web3.PublicKey;
 
@@ -116,7 +111,7 @@ const sendTransfer = async (
           trace_path: trace_path,
           base_denom: baseDenom,
         },
-        amount: finalAmount,
+        amount: convertedAmount,
       },
       sender: sender.toString(),
       receiver,

--- a/solana/solana-ibc/tests/utils.ts
+++ b/solana/solana-ibc/tests/utils.ts
@@ -14,11 +14,15 @@ import {
 import bs58 from "bs58";
 import { solanaIbcProgramId } from "./constants";
 
-export function getInt64Bytes(x: number) {
-  let y = Math.floor(x / 2 ** 32);
-  return [y, y << 8, y << 16, y << 24, x, x << 8, x << 16, x << 24].map(
-    (z) => z >>> 24
-  );
+export function numberTo32ByteBuffer(num: bigint): Uint8Array {
+  const buffer = Buffer.alloc(32);
+  let numberHex = num.toString(16);
+  if (numberHex.length % 2 !== 0) {
+    numberHex = "0" + numberHex;
+  }
+  const numberBytes = Buffer.from(numberHex, "hex");
+  numberBytes.reverse().copy(buffer, 0);
+  return new Uint8Array(buffer);
 }
 
 export function hexToBytes(hex: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     }
   },
   "compilerOptions": {
+    "target": "ES2020",
     "declaration": true,
     "moduleResolution": "node",
     "module": "es2015"


### PR DESCRIPTION
Use LE format to convert the bigint to 32 byte array instead of 8 byte done previously.