### PR TITLE
guestchain: Box ChainManager::candidates field

### DIFF
--- a/common/guestchain/src/manager.rs
+++ b/common/guestchain/src/manager.rs
@@ -1,6 +1,7 @@
+use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeSet as Set;
-use alloc::{boxed::Box, collections::VecDeque};
+use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::num::{NonZeroU128, NonZeroU64};
 #[cfg(feature = "std")]


### PR DESCRIPTION
Without this change, solana-ibc contract fails running out of stack. It’s not entirely clear how this helps and a proper investigation and fix would be better but for the time being we’re going with thiss to make things working.