### PR TITLE
solana-ibc: make fees configurable by the fee collector

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -30,9 +30,8 @@ pub const METADATA: &[u8] = b"metadata";
 pub const FEE_SEED: &[u8] = b"fee";
 
 pub const FEE_AMOUNT_IN_LAMPORTS: u64 =
-    solana_program::native_token::LAMPORTS_PER_SOL / 100;
-pub const REFUND_FEE_AMOUNT_IN_LAMPORTS: u64 =
-    solana_program::native_token::LAMPORTS_PER_SOL / 100;
+    7 * solana_program::native_token::LAMPORTS_PER_SOL / 100;
+pub const REFUND_FEE_AMOUNT_IN_LAMPORTS: u64 = FEE_AMOUNT_IN_LAMPORTS;
 pub const MINIMUM_FEE_ACCOUNT_BALANCE: u64 =
     solana_program::native_token::LAMPORTS_PER_SOL;
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -29,9 +29,6 @@ pub const METADATA: &[u8] = b"metadata";
 
 pub const FEE_SEED: &[u8] = b"fee";
 
-pub const FEE_AMOUNT_IN_LAMPORTS: u64 =
-    7 * solana_program::native_token::LAMPORTS_PER_SOL / 100;
-pub const REFUND_FEE_AMOUNT_IN_LAMPORTS: u64 = FEE_AMOUNT_IN_LAMPORTS;
 pub const MINIMUM_FEE_ACCOUNT_BALANCE: u64 =
     solana_program::native_token::LAMPORTS_PER_SOL;
 
@@ -203,6 +200,20 @@ pub mod solana_ibc {
         )?;
         chain.maybe_generate_block(&provable)?;
         chain.set_stake((validator).into(), amount)
+    }
+
+    pub fn set_fee_amount<'a, 'info>(
+        ctx: Context<'a, 'a, 'a, 'info, SetFeeAmount<'info>>,
+        new_amount: u64,
+    ) -> Result<()> {
+        let private_storage = &mut ctx.accounts.storage;
+
+        let previous_fees = private_storage.fee_in_lamports;
+        private_storage.fee_in_lamports = new_amount;
+
+        msg!("Fee updated to {} from {}", new_amount, previous_fees);
+
+        Ok(())
     }
 
     /// Sets up new fee collector proposal which wont be changed until the new fee collector
@@ -500,6 +511,8 @@ pub mod solana_ibc {
             return Err(error!(error::Error::InvalidSendTransferParams));
         }
 
+        let fee_amount = ctx.accounts.storage.fee_in_lamports;
+
         let mut store = storage::from_ctx!(ctx, with accounts);
         let mut token_ctx = store.clone();
 
@@ -523,7 +536,7 @@ pub mod solana_ibc {
             &solana_program::system_instruction::transfer(
                 &sender.key(),
                 &fee_collector.key(),
-                FEE_AMOUNT_IN_LAMPORTS,
+                fee_amount,
             ),
             &[sender.clone(), fee_collector.clone(), system_program.clone()],
         )?;
@@ -660,6 +673,16 @@ pub struct ChainWithVerifier<'info> {
     ix_sysvar: AccountInfo<'info>,
 
     system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct SetFeeAmount<'info> {
+    #[account(mut)]
+    fee_collector: Signer<'info>,
+
+    /// The account holding private IBC storage.
+    #[account(mut, seeds = [SOLANA_IBC_STORAGE_SEED], bump, has_one = fee_collector)]
+    storage: Account<'info, storage::PrivateStorage>,
 }
 
 #[derive(Accounts)]

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -310,6 +310,9 @@ pub struct PrivateStorage {
     pub new_fee_collector_proposal: Option<Pubkey>,
 
     pub assets: map::Map<CryptoHash, Asset>,
+
+    // Fee to be charged for each transfer
+    pub fee_in_lamports: u64,
 }
 
 #[derive(Clone, Debug, borsh::BorshSerialize, borsh::BorshDeserialize)]

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -36,6 +36,7 @@ pub const WRITE_ACCOUNT_SEED: &[u8] = b"write";
 pub const TOKEN_NAME: &str = "RETARDIO";
 pub const TOKEN_SYMBOL: &str = "RTRD";
 pub const TOKEN_URI: &str = "https://github.com";
+pub const FEE: u64 = 10000000;
 // const BASE_DENOM: &str = "PICA";
 
 const TRANSFER_AMOUNT: u64 = 1_000_000_000_000_000;
@@ -122,7 +123,6 @@ fn anchor_test_deliver() -> Result<()> {
     let native_token_mint_key = mint_keypair.pubkey();
     let base_denom = native_token_mint_key.to_string();
     let hashed_denom = CryptoHash::digest(base_denom.as_bytes());
-
 
     let port_id = ibc::PortId::transfer();
     let channel_id_on_a = ibc::ChannelId::new(0);
@@ -392,6 +392,26 @@ fn anchor_test_deliver() -> Result<()> {
         })?;
     println!("  Signature: {sig}");
 
+    /*
+        Set up the fees
+    */
+
+    println!("\nSetting up Fees");
+    let sig = program
+        .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            1_000_000u32,
+        ))
+        .accounts(accounts::SetFeeAmount { fee_collector, storage })
+        .args(instruction::SetFeeAmount { new_amount: FEE })
+        .payer(fee_collector_keypair.clone())
+        .signer(&*fee_collector_keypair)
+        .send_with_spinner_and_config(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        })?;
+    println!("  Signature: {sig}");
+
     // Make sure all the accounts needed for transfer are ready ( mint, escrow etc.)
     // Pass the instruction for transfer
 
@@ -399,6 +419,7 @@ fn anchor_test_deliver() -> Result<()> {
      * Setup deliver escrow.
      */
 
+    println!("\nCreating Token mint");
     let token_metadata_pda = Pubkey::find_program_address(
         &[
             "metadata".as_bytes(),
@@ -564,10 +585,7 @@ fn anchor_test_deliver() -> Result<()> {
         TRANSFER_AMOUNT
     );
 
-    assert_eq!(
-        fee_account_balance_after - min_balance_for_rent_exemption,
-        crate::FEE_AMOUNT_IN_LAMPORTS
-    );
+    assert_eq!(fee_account_balance_after - min_balance_for_rent_exemption, FEE);
 
     /*
      * On Destination chain
@@ -721,15 +739,9 @@ fn anchor_test_deliver() -> Result<()> {
             (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
     );
 
-    assert_eq!(
-        fee_account_balance_after - fee_account_balance_before,
-        crate::FEE_AMOUNT_IN_LAMPORTS
-    );
+    assert_eq!(fee_account_balance_after - fee_account_balance_before, FEE);
 
-    assert_eq!(
-        fee_account_balance_after - fee_account_balance_before,
-        crate::FEE_AMOUNT_IN_LAMPORTS
-    );
+    assert_eq!(fee_account_balance_after - fee_account_balance_before, FEE);
 
     /*
      * On Source chain

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -36,7 +36,7 @@ pub const WRITE_ACCOUNT_SEED: &[u8] = b"write";
 pub const TOKEN_NAME: &str = "RETARDIO";
 pub const TOKEN_SYMBOL: &str = "RTRD";
 pub const TOKEN_URI: &str = "https://github.com";
-pub const FEE: u64 = 10000000;
+pub const FEE: u64 = 10_000_000;
 // const BASE_DENOM: &str = "PICA";
 
 const TRANSFER_AMOUNT: u64 = 1_000_000_000_000_000;

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -242,12 +242,13 @@ impl ibc::Module for IbcStorage<'_, '_> {
         if result.1.is_err() {
             let store = self.borrow();
             let accounts = &store.accounts;
+            let private = &store.private;
             let receiver = accounts.receiver.clone().unwrap();
             let fee_collector = accounts.fee_collector.clone().unwrap();
             **fee_collector.try_borrow_mut_lamports().unwrap() -=
-                crate::REFUND_FEE_AMOUNT_IN_LAMPORTS;
+                private.fee_in_lamports;
             **receiver.try_borrow_mut_lamports().unwrap() +=
-                crate::REFUND_FEE_AMOUNT_IN_LAMPORTS;
+                private.fee_in_lamports;
         }
         (
             result.0,
@@ -269,12 +270,13 @@ impl ibc::Module for IbcStorage<'_, '_> {
         if result.1.is_ok() {
             let store = self.borrow();
             let accounts = &store.accounts;
+            let private = &store.private;
             let receiver = accounts.receiver.clone().unwrap();
             let fee_collector = accounts.fee_collector.clone().unwrap();
             **fee_collector.try_borrow_mut_lamports().unwrap() -=
-                crate::REFUND_FEE_AMOUNT_IN_LAMPORTS;
+                private.fee_in_lamports;
             **receiver.try_borrow_mut_lamports().unwrap() +=
-                crate::REFUND_FEE_AMOUNT_IN_LAMPORTS;
+                private.fee_in_lamports;
         }
         (
             result.0,


### PR DESCRIPTION
Make fees configurable by storing them in the private storage account instead of hard-coding them in the source code.
