### PR TITLE
solana-ibc: hard code staking program address

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/chain.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/chain.rs
@@ -1,6 +1,7 @@
 use core::num::NonZeroU64;
 
 use anchor_lang::prelude::*;
+use borsh::maybestd::io;
 use guestchain::manager::PendingBlock;
 pub use guestchain::Config;
 use lib::hash::CryptoHash;
@@ -68,7 +69,6 @@ impl ChainData {
         trie: &mut storage::TrieAccount,
         config: Config,
         genesis_epoch: Epoch,
-        staking_program_id: Pubkey,
         sig_verify_program_id: Pubkey,
     ) -> Result {
         let (host_height, host_timestamp) = get_host_head()?;
@@ -89,7 +89,7 @@ impl ChainData {
         let inner = ChainInner {
             last_check_height: host_height,
             manager,
-            staking_program_id: Box::new(staking_program_id),
+            _unused: UnusedPubkey,
             sig_verify_program_id: Box::new(sig_verify_program_id),
         };
         let inner = self.inner.insert(Box::new(inner));
@@ -241,22 +241,6 @@ impl ChainData {
         Ok(inner.manager.genesis().clone())
     }
 
-    /// Checks whether given `program_id` matches expected staking program id.
-    ///
-    /// The staking program id is stored within the chain account.  Various
-    /// CPI calls which affect stake and rewards can only be made from that
-    /// program.  This method checks whether program id given as argument
-    /// matches the one we expect.  If it doesn’t, returns `InvalidCPICall`.
-    pub fn check_staking_program(
-        &self,
-        program_id: &Pubkey,
-    ) -> Result<(), Error> {
-        match program_id == &*self.get()?.staking_program_id {
-            false => Err(Error::InvalidCPICall),
-            true => Ok(()),
-        }
-    }
-
     pub fn sig_verify_program_id(&self) -> Result<Pubkey, Error> {
         Ok(*self.get()?.sig_verify_program_id)
     }
@@ -284,8 +268,7 @@ struct ChainInner {
     /// The guest blockchain manager handling generation of new guest blocks.
     manager: Manager,
 
-    /// Staking Contract program ID. The program which would make CPI calls to set the stake
-    staking_program_id: Box<Pubkey>,
+    _unused: UnusedPubkey,
 
     /// Signature verification program ID. The program which responsible for chunking and storing signatures in the account
     sig_verify_program_id: Box<Pubkey>,
@@ -339,6 +322,21 @@ impl ChainInner {
             Err(err) if force => Err(into_error(err)),
             Err(_) => Ok(()),
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct UnusedPubkey;
+
+impl borsh::BorshSerialize for UnusedPubkey {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        Pubkey::default().serialize(writer)
+    }
+}
+
+impl borsh::BorshDeserialize for UnusedPubkey {
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        Pubkey::deserialize_reader(reader).map(|_| Self)
     }
 }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -30,8 +30,6 @@ use crate::{
 };
 
 const IBC_TRIE_PREFIX: &[u8] = b"ibc/";
-pub const STAKING_PROGRAM_ID: &str =
-    "8n3FHwYxFgQCQc2FNFkwDUf9mcqupxXcCvgfHbApMLv3";
 pub const WRITE_ACCOUNT_SEED: &[u8] = b"write";
 pub const TOKEN_NAME: &str = "RETARDIO";
 pub const TOKEN_SYMBOL: &str = "RTRD";
@@ -174,7 +172,6 @@ fn anchor_test_deliver() -> Result<()> {
                 max_block_age_ns: 3600 * 1_000_000_000,
                 min_epoch_length: 200_000.into(),
             },
-            staking_program_id: Pubkey::from_str(STAKING_PROGRAM_ID).unwrap(),
             sig_verify_program_id,
             genesis_epoch: chain::Epoch::new(
                 vec![chain::Validator::new(


### PR DESCRIPTION
To be honest, I’d rather the staking program address was configurable at run time but in interest of time and code simplicity, hard code it in the source of solana-ibc.