### PR TITLE
guestchain: remove force argument from ChainManager::generate_next

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/chain.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/chain.rs
@@ -307,7 +307,6 @@ impl ChainInner {
             host_height,
             host_timestamp,
             trie.hash().clone(),
-            false,
         );
         match res {
             Ok(_) => {


### PR DESCRIPTION
Nothing uses force argument of ChainManager::generate_next so to simplify code get rid of it.