### PR TITLE
solana-ibc: Unwrap sol when unescrowing wrapped sol.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 test-ledger
 *.so
 .idea
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": "all"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "rust-analyzer.cargo.features": "all"
-}

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -28,6 +28,8 @@ pub const METADATA: &[u8] = b"metadata";
 
 pub const FEE_SEED: &[u8] = b"fee";
 
+pub const WSOL_ADDRESS: &str = "So11111111111111111111111111111111111111112";
+
 pub const MINIMUM_FEE_ACCOUNT_BALANCE: u64 =
     solana_program::native_token::LAMPORTS_PER_SOL;
 
@@ -714,8 +716,8 @@ pub struct Deliver<'info> {
     mint_authority: Option<UncheckedAccount<'info>>,
     #[account(mut)]
     token_mint: Option<Box<Account<'info, Mint>>>,
-    #[account(mut, token::mint = token_mint, token::authority = mint_authority)]
-    escrow_account: Option<Box<Account<'info, TokenAccount>>>,
+    #[account(mut)]
+    escrow_account: Option<UncheckedAccount<'info>>,
     #[account(init_if_needed, payer = sender,
         associated_token::mint = token_mint,
         associated_token::authority = receiver)]

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -15,12 +15,12 @@ use anchor_client::solana_sdk::signature::{
 };
 use anchor_client::solana_sdk::transaction::Transaction;
 use anchor_client::{Client, Cluster};
-use anchor_lang::solana_program::system_instruction::create_account;
 use anchor_lang::AnchorSerialize;
 use anchor_spl::associated_token::get_associated_token_address;
 use anyhow::Result;
 use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
-use spl_token::instruction::initialize_mint2;
+use spl_associated_token_account::instruction::create_associated_token_account;
+use spl_token::solana_program::system_instruction;
 use spl_token::solana_program::sysvar::SysvarId;
 
 use crate::ibc::ClientStateCommon;
@@ -35,10 +35,8 @@ pub const TOKEN_NAME: &str = "RETARDIO";
 pub const TOKEN_SYMBOL: &str = "RTRD";
 pub const TOKEN_URI: &str = "https://github.com";
 pub const FEE: u64 = 10_000_000;
-// const BASE_DENOM: &str = "PICA";
 
-const TRANSFER_AMOUNT: u64 = 1_000_000_000_000_000;
-const MINT_AMOUNT: u64 = 1_000_000_000_000_000_000;
+const TRANSFER_AMOUNT: u64 = 1_000_000_000;
 
 const ORIGINAL_DECIMALS: u8 = 9;
 const EFFECTIVE_DECIMALS: u8 = 6;
@@ -117,9 +115,8 @@ fn anchor_test_deliver() -> Result<()> {
     let fee_collector_pda =
         Pubkey::find_program_address(&[crate::FEE_SEED], &crate::ID).0;
 
-    let mint_keypair = Keypair::new();
-    let native_token_mint_key = mint_keypair.pubkey();
-    let base_denom = native_token_mint_key.to_string();
+    let wrapped_sol_mint = Pubkey::from_str(crate::WSOL_ADDRESS).unwrap();
+    let base_denom = wrapped_sol_mint.to_string();
     let hashed_denom = CryptoHash::digest(base_denom.as_bytes());
 
     let port_id = ibc::PortId::transfer();
@@ -466,53 +463,38 @@ fn anchor_test_deliver() -> Result<()> {
      */
     println!("\nCreating a token mint");
 
-    let create_account_ix = create_account(
-        &authority.pubkey(),
-        &native_token_mint_key,
-        sol_rpc_client.get_minimum_balance_for_rent_exemption(82).unwrap(),
-        82,
-        &anchor_spl::token::ID,
-    );
+    let wrapped_sol_token_account =
+        get_associated_token_address(&authority.pubkey(), &wrapped_sol_mint);
 
-    let create_mint_ix = initialize_mint2(
-        &anchor_spl::token::ID,
-        &native_token_mint_key,
-        &authority.pubkey(),
-        Some(&authority.pubkey()),
-        6,
-    )
-    .expect("invalid mint instruction");
-
-    let create_token_acc_ix = spl_associated_token_account::instruction::create_associated_token_account(&authority.pubkey(), &authority.pubkey(), &native_token_mint_key, &anchor_spl::token::ID);
-    let associated_token_addr = get_associated_token_address(
-        &authority.pubkey(),
-        &native_token_mint_key,
-    );
-    let mint_ix = spl_token::instruction::mint_to(
-        &anchor_spl::token::ID,
-        &native_token_mint_key,
-        &associated_token_addr,
-        &authority.pubkey(),
-        &[&authority.pubkey()],
-        MINT_AMOUNT,
-    )
-    .unwrap();
-
-    let tx = program
+    let sig = program
         .request()
-        .instruction(create_account_ix)
-        .instruction(create_mint_ix)
-        .instruction(create_token_acc_ix)
-        .instruction(mint_ix)
+        .instruction(create_associated_token_account(
+            &authority.pubkey(),
+            &authority.pubkey(),
+            &wrapped_sol_mint,
+            &anchor_spl::token::ID,
+        ))
+        .instruction(system_instruction::transfer(
+            &authority.pubkey(),
+            &wrapped_sol_token_account,
+            1_500_000_000,
+        ))
+        .instruction(
+            spl_token::instruction::sync_native(
+                &anchor_spl::token::ID,
+                &wrapped_sol_token_account,
+            )
+            .unwrap(),
+        )
         .payer(authority.clone())
         .signer(&*authority)
-        .signer(&mint_keypair)
         .send_with_spinner_and_config(RpcSendTransactionConfig {
             skip_preflight: true,
             ..RpcSendTransactionConfig::default()
-        })?;
+        })
+        .unwrap();
 
-    println!("  Signature: {}", tx);
+    println!("  Signature: {}", sig);
 
     /*
      * Sending transfer on source chain
@@ -529,7 +511,7 @@ fn anchor_test_deliver() -> Result<()> {
     );
 
     let account_balance_before = sol_rpc_client
-        .get_token_account_balance(&associated_token_addr)
+        .get_token_account_balance(&wrapped_sol_token_account)
         .unwrap();
 
     let sig = program
@@ -545,10 +527,10 @@ fn anchor_test_deliver() -> Result<()> {
             chain,
             system_program: system_program::ID,
             mint_authority: Some(mint_authority_key),
-            token_mint: Some(native_token_mint_key),
+            token_mint: Some(wrapped_sol_mint),
             escrow_account: Some(escrow_account_key),
             fee_collector: Some(fee_collector_pda),
-            receiver_token_account: Some(associated_token_addr),
+            receiver_token_account: Some(wrapped_sol_token_account),
             token_program: Some(anchor_spl::token::ID),
         })
         .args(instruction::SendTransfer {
@@ -564,7 +546,7 @@ fn anchor_test_deliver() -> Result<()> {
     println!("  Signature: {sig}");
 
     let account_balance_after = sol_rpc_client
-        .get_token_account_balance(&associated_token_addr)
+        .get_token_account_balance(&wrapped_sol_token_account)
         .unwrap();
 
     let min_balance_for_rent_exemption =
@@ -575,7 +557,7 @@ fn anchor_test_deliver() -> Result<()> {
     assert_eq!(
         ((account_balance_before.ui_amount.unwrap() -
             account_balance_after.ui_amount.unwrap()) *
-            10_f64.powf(mint_info.decimals.into()))
+            10_f64.powf(9.0))
         .round() as u64,
         TRANSFER_AMOUNT
     );
@@ -743,11 +725,6 @@ fn anchor_test_deliver() -> Result<()> {
      */
     println!("\nRecving on source chain");
 
-    let receiver_native_token_address = get_associated_token_address(
-        &receiver.pubkey(),
-        &native_token_mint_key,
-    );
-
     let packet = construct_packet_from_denom(
         &base_denom,
         port_id.clone(),
@@ -774,11 +751,12 @@ fn anchor_test_deliver() -> Result<()> {
         ibc::MsgEnvelope::Packet,
     );
 
+    let receiver_wrapped_sol_acc =
+        get_associated_token_address(&receiver.pubkey(), &wrapped_sol_mint);
     let escrow_account_balance_before =
-        sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
-    let receiver_account_balance_before = sol_rpc_client
-        .get_token_account_balance(&receiver_native_token_address)
-        .map_or(0f64, |balance| balance.ui_amount.unwrap());
+        sol_rpc_client.get_balance(&mint_authority_key).unwrap();
+    let receiver_balance_before =
+        sol_rpc_client.get_balance(&receiver.pubkey()).unwrap();
 
     let sig = program
         .request()
@@ -793,10 +771,10 @@ fn anchor_test_deliver() -> Result<()> {
             chain,
             system_program: system_program::ID,
             mint_authority: Some(mint_authority_key),
-            token_mint: Some(native_token_mint_key),
+            token_mint: Some(wrapped_sol_mint),
             escrow_account: Some(escrow_account_key),
             fee_collector: Some(fee_collector_pda),
-            receiver_token_account: Some(receiver_native_token_address),
+            receiver_token_account: Some(receiver_wrapped_sol_acc),
             associated_token_program: Some(anchor_spl::associated_token::ID),
             token_program: Some(anchor_spl::token::ID),
         })
@@ -810,22 +788,15 @@ fn anchor_test_deliver() -> Result<()> {
     println!("  Signature: {sig}");
 
     let escrow_account_balance_after =
-        sol_rpc_client.get_token_account_balance(&escrow_account_key).unwrap();
-    let receiver_account_balance_after = sol_rpc_client
-        .get_token_account_balance(&receiver_native_token_address)
-        .unwrap();
+        sol_rpc_client.get_balance(&mint_authority_key).unwrap();
+    let receiver_balance_after =
+        sol_rpc_client.get_balance(&receiver.pubkey()).unwrap();
     assert_eq!(
-        ((escrow_account_balance_before.ui_amount.unwrap() -
-            escrow_account_balance_after.ui_amount.unwrap()) *
-            10_f64.powf(mint_info.decimals.into()))
-        .round() as u64,
+        receiver_balance_after - receiver_balance_before,
         TRANSFER_AMOUNT
     );
     assert_eq!(
-        ((receiver_account_balance_after.ui_amount.unwrap() -
-            receiver_account_balance_before) *
-            10_f64.powf(mint_info.decimals.into()))
-        .round() as u64,
+        escrow_account_balance_before - escrow_account_balance_after,
         TRANSFER_AMOUNT
     );
 

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -555,9 +555,9 @@ fn anchor_test_deliver() -> Result<()> {
         sol_rpc_client.get_balance(&fee_collector_pda).unwrap();
 
     assert_eq!(
-        ((account_balance_before.ui_amount.unwrap()
-            - account_balance_after.ui_amount.unwrap())
-            * 1_000_000_000f64)
+        ((account_balance_before.ui_amount.unwrap() -
+            account_balance_after.ui_amount.unwrap()) *
+            1_000_000_000f64)
             .round() as u64,
         TRANSFER_AMOUNT
     );
@@ -632,11 +632,11 @@ fn anchor_test_deliver() -> Result<()> {
         .get_token_account_balance(&receiver_token_address)
         .unwrap();
     assert_eq!(
-        ((account_balance_after.ui_amount.unwrap() - account_balance_before)
-            * 10_f64.powf(mint_info.decimals.into()))
+        ((account_balance_after.ui_amount.unwrap() - account_balance_before) *
+            10_f64.powf(mint_info.decimals.into()))
         .round() as u64,
-        TRANSFER_AMOUNT
-            / (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
+        TRANSFER_AMOUNT /
+            (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
     );
 
     /*
@@ -708,12 +708,12 @@ fn anchor_test_deliver() -> Result<()> {
         sol_rpc_client.get_balance(&fee_collector_pda).unwrap();
 
     assert_eq!(
-        ((account_balance_before.ui_amount.unwrap()
-            - account_balance_after.ui_amount.unwrap())
-            * 10_f64.powf(mint_info.decimals.into()))
+        ((account_balance_before.ui_amount.unwrap() -
+            account_balance_after.ui_amount.unwrap()) *
+            10_f64.powf(mint_info.decimals.into()))
         .round() as u64,
-        TRANSFER_AMOUNT
-            / (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
+        TRANSFER_AMOUNT /
+            (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
     );
 
     assert_eq!(fee_account_balance_after - fee_account_balance_before, FEE);

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -555,10 +555,10 @@ fn anchor_test_deliver() -> Result<()> {
         sol_rpc_client.get_balance(&fee_collector_pda).unwrap();
 
     assert_eq!(
-        ((account_balance_before.ui_amount.unwrap() -
-            account_balance_after.ui_amount.unwrap()) *
-            10_f64.powf(9.0))
-        .round() as u64,
+        ((account_balance_before.ui_amount.unwrap()
+            - account_balance_after.ui_amount.unwrap())
+            * 1_000_000_000f64)
+            .round() as u64,
         TRANSFER_AMOUNT
     );
 
@@ -632,11 +632,11 @@ fn anchor_test_deliver() -> Result<()> {
         .get_token_account_balance(&receiver_token_address)
         .unwrap();
     assert_eq!(
-        ((account_balance_after.ui_amount.unwrap() - account_balance_before) *
-            10_f64.powf(mint_info.decimals.into()))
+        ((account_balance_after.ui_amount.unwrap() - account_balance_before)
+            * 10_f64.powf(mint_info.decimals.into()))
         .round() as u64,
-        TRANSFER_AMOUNT /
-            (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
+        TRANSFER_AMOUNT
+            / (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
     );
 
     /*
@@ -708,12 +708,12 @@ fn anchor_test_deliver() -> Result<()> {
         sol_rpc_client.get_balance(&fee_collector_pda).unwrap();
 
     assert_eq!(
-        ((account_balance_before.ui_amount.unwrap() -
-            account_balance_after.ui_amount.unwrap()) *
-            10_f64.powf(mint_info.decimals.into()))
+        ((account_balance_before.ui_amount.unwrap()
+            - account_balance_after.ui_amount.unwrap())
+            * 10_f64.powf(mint_info.decimals.into()))
         .round() as u64,
-        TRANSFER_AMOUNT /
-            (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
+        TRANSFER_AMOUNT
+            / (10_u64.pow((ORIGINAL_DECIMALS - EFFECTIVE_DECIMALS).into()))
     );
 
     assert_eq!(fee_account_balance_after - fee_account_balance_before, FEE);

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use ::ibc::apps::transfer::types::PrefixedDenom;
 use anchor_lang::prelude::{CpiContext, Pubkey};
 use anchor_lang::solana_program::msg;
-use anchor_spl::token::{Burn, MintTo, Transfer};
+use anchor_spl::token::{Burn, CloseAccount, MintTo, Transfer};
 use lib::hash::CryptoHash;
 use primitive_types::U256;
 
@@ -504,6 +504,8 @@ impl IbcStorage<'_, '_> {
             .as_ref()
             .ok_or(TokenTransferError::ParseAccountFailure)?;
 
+        let escrow_account_rent = escrow_account.lamports();
+
         let (sender, receiver, authority) = match op {
             EscrowOp::Escrow => {
                 let auth = accounts
@@ -525,6 +527,25 @@ impl IbcStorage<'_, '_> {
         let seeds = seeds.as_ref();
         let seeds = core::slice::from_ref(&seeds);
 
+        // Close the wsol account so that the receiver gets the amount in native SOL
+        // instead of wrapped SOL which is unusable if the wallet doesnt have any
+        // SOL to pay for the fees.
+        if matches!(op, EscrowOp::Unescrow) &&
+            coin.denom.base_denom.as_str() == crate::WSOL_ADDRESS
+        {
+            let receiver = accounts
+                .receiver
+                .as_ref()
+                .ok_or(TokenTransferError::ParseAccountFailure)?;
+            let mint_authority = accounts
+                .mint_authority
+                .as_ref()
+                .ok_or(TokenTransferError::ParseAccountFailure)?;
+            **mint_authority.try_borrow_mut_lamports().unwrap() -= amount;
+            **receiver.try_borrow_mut_lamports().unwrap() += amount;
+            return Ok(());
+        }
+
         // Below is the actual instruction that we are going to send to the Token program.
         let transfer_instruction = Transfer {
             from: sender.clone(),
@@ -536,8 +557,48 @@ impl IbcStorage<'_, '_> {
             transfer_instruction,
             seeds, //signer PDA
         );
-
         anchor_spl::token::transfer(cpi_ctx, amount).unwrap();
+
+        // Closing the wsol account after transferring the amount to the escrow
+        // so that the escrow account holds the wsol deposits in native SOL which
+        // can be transferred to the receiver instead of sending wrapped sol.
+        if matches!(op, EscrowOp::Escrow) &&
+            coin.denom.base_denom.as_str() == crate::WSOL_ADDRESS
+        {
+            let mint_authority = accounts
+                .mint_authority
+                .as_ref()
+                .ok_or(TokenTransferError::ParseAccountFailure)?;
+            let sender = accounts
+                .sender
+                .as_ref()
+                .ok_or(TokenTransferError::ParseAccountFailure)?;
+            let close_account_ix_accs = CloseAccount {
+                account: receiver.clone(),
+                destination: mint_authority.clone(),
+                authority: mint_authority.clone(),
+            };
+            let cpi_ctx = CpiContext::new_with_signer(
+                token_program.clone(),
+                close_account_ix_accs,
+                seeds,
+            );
+            msg!(
+                "Mint authority {} sender {} and rent {}",
+                mint_authority.key,
+                sender.key,
+                escrow_account_rent
+            );
+            anchor_spl::token::close_account(cpi_ctx).unwrap();
+            // Closing the account transfers all the lamports to the
+            // destination account including the initial rent paid
+            // for creation of the account by the sender. So we need
+            // to transfer the rent back to the sender.
+            **mint_authority.try_borrow_mut_lamports().unwrap() -=
+                escrow_account_rent;
+            **sender.try_borrow_mut_lamports().unwrap() += escrow_account_rent;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
Whenever someone sends SOL to Solana, they get wrapped sol instead of native SOL which is unusable if the wallet didnt have SOL previously. So whenever someone send SOL from solana, the escrow account which holds wsol gets closed and all the lamports are sent to the `mint_authority` account which is the owner of the escrow account. When we unescrow the wrapped sol, we debit it from the `mint_authority` account instead of transferring from the `escrow` account. This will allow users to receive native SOL on solana instead of wrapped sol. Though when users deposit, they need to have wrapped SOL which can be a prior instruction to convert SOL to wSOL.