### PR TITLE
solana-ibc: method to update connection delay of specified connection id

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/error.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/error.rs
@@ -129,6 +129,9 @@ pub enum Error {
     /// blocks would never get finalized until more stake is added and quorum
     /// stake is less than head stake.
     MinQuorumStakeHigherThanTotalStake,
+
+    /// When a connection id which is not yet created is updated
+    InvalidConnectionId,
 }
 
 impl Error {

--- a/solana/solana-ibc/programs/solana-ibc/src/error.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/error.rs
@@ -129,9 +129,6 @@ pub enum Error {
     /// blocks would never get finalized until more stake is added and quorum
     /// stake is less than head stake.
     MinQuorumStakeHigherThanTotalStake,
-
-    /// When a connection id which is not yet created is updated
-    InvalidConnectionId,
 }
 
 impl Error {

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -14,7 +14,6 @@ use anchor_spl::metadata::Metadata;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use borsh::BorshDeserialize;
 use guestchain::config::UpdateConfig;
-
 use lib::hash::CryptoHash;
 use storage::{PrivateStorage, TransferAccounts};
 
@@ -103,9 +102,9 @@ pub mod solana_ibc {
     use anchor_spl::metadata::{
         create_metadata_accounts_v3, CreateMetadataAccountsV3,
     };
-    use crate::ibc::{ExecutionContext, ValidationContext};
 
     use super::*;
+    use crate::ibc::{ExecutionContext, ValidationContext};
 
     /// Initialises the guest blockchain with given configuration and genesis
     /// epoch.
@@ -285,8 +284,8 @@ pub mod solana_ibc {
     ) -> Result<()> {
         let fee_account = &ctx.accounts.fee_account;
         let minimum_balance = Rent::get()?
-            .minimum_balance(fee_account.data_len())
-            + MINIMUM_FEE_ACCOUNT_BALANCE;
+            .minimum_balance(fee_account.data_len()) +
+            MINIMUM_FEE_ACCOUNT_BALANCE;
         let mut available_balance = fee_account.try_borrow_mut_lamports()?;
         if **available_balance > minimum_balance {
             **ctx.accounts.fee_collector.try_borrow_mut_lamports()? +=
@@ -322,13 +321,10 @@ pub mod solana_ibc {
         }
 
         if !private_storage.assets.contains_key(&hashed_full_denom) {
-            private_storage.assets.insert(
-                hashed_full_denom,
-                storage::Asset {
-                    original_decimals,
-                    effective_decimals_on_sol: effective_decimals,
-                },
-            );
+            private_storage.assets.insert(hashed_full_denom, storage::Asset {
+                original_decimals,
+                effective_decimals_on_sol: effective_decimals,
+            });
         } else {
             return Err(error!(error::Error::AssetAlreadyExists));
         }
@@ -455,8 +451,8 @@ pub mod solana_ibc {
         let mut token_ctx = store.clone();
 
         // Check if atleast one of the timeouts is non zero.
-        if !msg.timeout_height_on_b.is_set()
-            && !msg.timeout_timestamp_on_b.is_set()
+        if !msg.timeout_height_on_b.is_set() &&
+            !msg.timeout_timestamp_on_b.is_set()
         {
             return Err(error::Error::InvalidTimeout.into());
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -526,19 +526,26 @@ pub mod solana_ibc {
     /// Can only be called by fee collector.
     pub fn update_connection_delay_period(
         ctx: Context<UpdateConnectionDelay>,
-        connection_id: u64,
+        connection_id_idx: u64,
         delay_period_in_ns: u64,
     ) -> Result<()> {
         let storage = &mut ctx.accounts.storage;
 
+        let connection_id = ConnectionId::new(connection_id_idx);
+
         // Panic if connection_id doenst exist
-        if storage.connections.len() >= connection_id as usize {
-            return Err(error!(error::Error::InvalidConnectionId));
+        if storage.connections.len() >= connection_id_idx as usize {
+            return Err(error!(error::Error::ContextError(
+                crate::ibc::ContextError::ConnectionError(
+                    crate::ibc::ConnectionError::ConnectionNotFound {
+                        connection_id: connection_id.clone()
+                    }
+                )
+            )));
         }
 
         let mut store = crate::storage::from_ctx!(ctx);
 
-        let connection_id = ConnectionId::new(connection_id);
         let connection_end = store.connection_end(&connection_id).unwrap();
 
         let updated_connection = ConnectionEnd::new(

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -14,7 +14,7 @@ use anchor_spl::metadata::Metadata;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use borsh::BorshDeserialize;
 use guestchain::config::UpdateConfig;
-use ibc::{ExecutionContext, ValidationContext};
+
 use lib::hash::CryptoHash;
 use storage::{PrivateStorage, TransferAccounts};
 
@@ -103,6 +103,7 @@ pub mod solana_ibc {
     use anchor_spl::metadata::{
         create_metadata_accounts_v3, CreateMetadataAccountsV3,
     };
+    use crate::ibc::{ExecutionContext, ValidationContext};
 
     use super::*;
 
@@ -284,8 +285,8 @@ pub mod solana_ibc {
     ) -> Result<()> {
         let fee_account = &ctx.accounts.fee_account;
         let minimum_balance = Rent::get()?
-            .minimum_balance(fee_account.data_len()) +
-            MINIMUM_FEE_ACCOUNT_BALANCE;
+            .minimum_balance(fee_account.data_len())
+            + MINIMUM_FEE_ACCOUNT_BALANCE;
         let mut available_balance = fee_account.try_borrow_mut_lamports()?;
         if **available_balance > minimum_balance {
             **ctx.accounts.fee_collector.try_borrow_mut_lamports()? +=
@@ -321,10 +322,13 @@ pub mod solana_ibc {
         }
 
         if !private_storage.assets.contains_key(&hashed_full_denom) {
-            private_storage.assets.insert(hashed_full_denom, storage::Asset {
-                original_decimals,
-                effective_decimals_on_sol: effective_decimals,
-            });
+            private_storage.assets.insert(
+                hashed_full_denom,
+                storage::Asset {
+                    original_decimals,
+                    effective_decimals_on_sol: effective_decimals,
+                },
+            );
         } else {
             return Err(error!(error::Error::AssetAlreadyExists));
         }
@@ -451,8 +455,8 @@ pub mod solana_ibc {
         let mut token_ctx = store.clone();
 
         // Check if atleast one of the timeouts is non zero.
-        if !msg.timeout_height_on_b.is_set() &&
-            !msg.timeout_timestamp_on_b.is_set()
+        if !msg.timeout_height_on_b.is_set()
+            && !msg.timeout_timestamp_on_b.is_set()
         {
             return Err(error::Error::InvalidTimeout.into());
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -533,15 +533,15 @@ pub mod solana_ibc {
         // Panic if connection_id doenst exist
         if storage.connections.len() >= connection_id_idx as usize {
             return Err(error!(error::Error::ContextError(
-                crate::ibc::ContextError::ConnectionError(
-                    crate::ibc::ConnectionError::ConnectionNotFound {
+                ibc::ContextError::ConnectionError(
+                    ibc::ConnectionError::ConnectionNotFound {
                         connection_id: connection_id.clone()
                     }
                 )
             )));
         }
 
-        let mut store = crate::storage::from_ctx!(ctx);
+        let mut store = storage::from_ctx!(ctx);
 
         let connection_end = store.connection_end(&connection_id).unwrap();
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -526,15 +526,15 @@ pub mod solana_ibc {
     /// Can only be called by fee collector.
     pub fn update_connection_delay_period(
         ctx: Context<UpdateConnectionDelay>,
-        connection_id_idx: u64,
+        connection_id_idx: u16,
         delay_period_in_ns: u64,
     ) -> Result<()> {
         let storage = &mut ctx.accounts.storage;
 
-        let connection_id = ibc::ConnectionId::new(connection_id_idx);
+        let connection_id = ibc::ConnectionId::new(connection_id_idx.into());
 
         // Panic if connection_id doenst exist
-        if storage.connections.len() >= connection_id_idx as usize {
+        if storage.connections.len() >= usize::from(connection_id_idx) {
             return Err(error!(error::Error::ContextError(
                 ibc::ContextError::ConnectionError(
                     ibc::ConnectionError::ConnectionNotFound {

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -14,6 +14,7 @@ use anchor_spl::metadata::Metadata;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use borsh::BorshDeserialize;
 use guestchain::config::UpdateConfig;
+use ibc::{ExecutionContext, ValidationContext};
 use lib::hash::CryptoHash;
 use storage::{PrivateStorage, TransferAccounts};
 
@@ -98,10 +99,6 @@ solana_program::custom_panic_default!();
 pub mod solana_ibc {
     use std::time::Duration;
 
-    use ::ibc::core::channel::context::SendPacketValidationContext;
-    use ::ibc::core::connection::types::ConnectionEnd;
-    use ::ibc::core::host::types::identifiers::ConnectionId;
-    use ::ibc::core::host::ExecutionContext;
     use anchor_spl::metadata::mpl_token_metadata::types::DataV2;
     use anchor_spl::metadata::{
         create_metadata_accounts_v3, CreateMetadataAccountsV3,
@@ -531,7 +528,7 @@ pub mod solana_ibc {
     ) -> Result<()> {
         let storage = &mut ctx.accounts.storage;
 
-        let connection_id = ConnectionId::new(connection_id_idx);
+        let connection_id = ibc::ConnectionId::new(connection_id_idx);
 
         // Panic if connection_id doenst exist
         if storage.connections.len() >= connection_id_idx as usize {
@@ -548,7 +545,7 @@ pub mod solana_ibc {
 
         let connection_end = store.connection_end(&connection_id).unwrap();
 
-        let updated_connection = ConnectionEnd::new(
+        let updated_connection = ibc::ConnectionEnd::new(
             connection_end.state,
             connection_end.client_id().clone(),
             connection_end.counterparty().clone(),

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -284,8 +284,8 @@ pub mod solana_ibc {
     ) -> Result<()> {
         let fee_account = &ctx.accounts.fee_account;
         let minimum_balance = Rent::get()?
-            .minimum_balance(fee_account.data_len()) +
-            MINIMUM_FEE_ACCOUNT_BALANCE;
+            .minimum_balance(fee_account.data_len())
+            + MINIMUM_FEE_ACCOUNT_BALANCE;
         let mut available_balance = fee_account.try_borrow_mut_lamports()?;
         if **available_balance > minimum_balance {
             **ctx.accounts.fee_collector.try_borrow_mut_lamports()? +=
@@ -321,10 +321,13 @@ pub mod solana_ibc {
         }
 
         if !private_storage.assets.contains_key(&hashed_full_denom) {
-            private_storage.assets.insert(hashed_full_denom, storage::Asset {
-                original_decimals,
-                effective_decimals_on_sol: effective_decimals,
-            });
+            private_storage.assets.insert(
+                hashed_full_denom,
+                storage::Asset {
+                    original_decimals,
+                    effective_decimals_on_sol: effective_decimals,
+                },
+            );
         } else {
             return Err(error!(error::Error::AssetAlreadyExists));
         }
@@ -451,8 +454,8 @@ pub mod solana_ibc {
         let mut token_ctx = store.clone();
 
         // Check if atleast one of the timeouts is non zero.
-        if !msg.timeout_height_on_b.is_set() &&
-            !msg.timeout_timestamp_on_b.is_set()
+        if !msg.timeout_height_on_b.is_set()
+            && !msg.timeout_timestamp_on_b.is_set()
         {
             return Err(error::Error::InvalidTimeout.into());
         }
@@ -543,7 +546,10 @@ pub mod solana_ibc {
 
         let mut store = storage::from_ctx!(ctx);
 
-        let connection_end = store.connection_end(&connection_id).unwrap();
+        let connection_end = store
+            .connection_end(&connection_id)
+            .map_err(error::Error::ContextError)
+            .map_err(move |err| error!((&err)))?;
 
         let updated_connection = ibc::ConnectionEnd::new(
             connection_end.state,
@@ -552,7 +558,10 @@ pub mod solana_ibc {
             connection_end.versions().to_vec(),
             Duration::from_nanos(delay_period_in_ns),
         )
-        .unwrap();
+        .map_err(|err| {
+            error::Error::ContextError(ibc::ContextError::ConnectionError(err))
+        })
+        .map_err(move |err| error!((&err)))?;
 
         store
             .store_connection(

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -284,8 +284,8 @@ pub mod solana_ibc {
     ) -> Result<()> {
         let fee_account = &ctx.accounts.fee_account;
         let minimum_balance = Rent::get()?
-            .minimum_balance(fee_account.data_len())
-            + MINIMUM_FEE_ACCOUNT_BALANCE;
+            .minimum_balance(fee_account.data_len()) +
+            MINIMUM_FEE_ACCOUNT_BALANCE;
         let mut available_balance = fee_account.try_borrow_mut_lamports()?;
         if **available_balance > minimum_balance {
             **ctx.accounts.fee_collector.try_borrow_mut_lamports()? +=
@@ -321,13 +321,10 @@ pub mod solana_ibc {
         }
 
         if !private_storage.assets.contains_key(&hashed_full_denom) {
-            private_storage.assets.insert(
-                hashed_full_denom,
-                storage::Asset {
-                    original_decimals,
-                    effective_decimals_on_sol: effective_decimals,
-                },
-            );
+            private_storage.assets.insert(hashed_full_denom, storage::Asset {
+                original_decimals,
+                effective_decimals_on_sol: effective_decimals,
+            });
         } else {
             return Err(error!(error::Error::AssetAlreadyExists));
         }
@@ -454,8 +451,8 @@ pub mod solana_ibc {
         let mut token_ctx = store.clone();
 
         // Check if atleast one of the timeouts is non zero.
-        if !msg.timeout_height_on_b.is_set()
-            && !msg.timeout_timestamp_on_b.is_set()
+        if !msg.timeout_height_on_b.is_set() &&
+            !msg.timeout_timestamp_on_b.is_set()
         {
             return Err(error::Error::InvalidTimeout.into());
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -565,7 +565,7 @@ pub mod solana_ibc {
 
         store
             .store_connection(
-                &::ibc::core::host::types::path::ConnectionPath(connection_id),
+                &ibc::path::ConnectionPath(connection_id),
                 updated_connection,
             )
             .map_err(error::Error::ContextError)


### PR DESCRIPTION
Adding a method which would enable us to change the connection delay period of a specified connection end. This method can only be called by `fee_collector` and would fail if a `connection_id` that doesnt exist is passed.