### PR TITLE
solana-ibc: get rent from account data size

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/impls.rs
@@ -7,6 +7,8 @@ use anchor_lang::solana_program::msg;
 use anchor_spl::token::{Burn, CloseAccount, MintTo, Transfer};
 use lib::hash::CryptoHash;
 use primitive_types::U256;
+use spl_token::solana_program::rent::Rent;
+use spl_token::solana_program::sysvar::Sysvar;
 
 use crate::ibc::apps::transfer::context::{
     TokenTransferExecutionContext, TokenTransferValidationContext,
@@ -504,7 +506,9 @@ impl IbcStorage<'_, '_> {
             .as_ref()
             .ok_or(TokenTransferError::ParseAccountFailure)?;
 
-        let escrow_account_rent = escrow_account.lamports();
+        let rent = Rent::get().unwrap();
+        let escrow_account_rent =
+            rent.minimum_balance(escrow_account.data_len());
 
         let (sender, receiver, authority) = match op {
             EscrowOp::Escrow => {


### PR DESCRIPTION
the rent for the wrapped sol escrow token account which is closed should be calculated from rent object based on the lenght of account data.