### PR TITLE
restaking: fetch the stake from candidate instead of validator

### DIFF
--- a/solana/restaking/programs/restaking/src/lib.rs
+++ b/solana/restaking/programs/restaking/src/lib.rs
@@ -113,7 +113,7 @@ pub mod restaking {
             solana_ibc::chain::ChainData::try_deserialize(&mut chain_data)
                 .unwrap();
         let validator = chain
-            .validator(validator_key)
+            .candidate(validator_key)
             .map_err(|_| ErrorCodes::OperationNotAllowed)?;
         let amount = validator.map_or(u128::from(amount), |val| {
             u128::from(val.stake) + u128::from(amount)
@@ -583,7 +583,7 @@ pub mod restaking {
             solana_ibc::chain::ChainData::try_deserialize(&mut chain_data)
                 .unwrap();
         let validator = chain
-            .validator(validator_key)
+            .candidate(validator_key)
             .map_err(|_| ErrorCodes::OperationNotAllowed)?;
         let amount = validator.map_or(u128::from(amount), |val| {
             u128::from(val.stake) + u128::from(amount)


### PR DESCRIPTION
When depositing, the stake is updated by fetching the stake from `validator` and appending the new value. But during withdrawal, the stake is updated by fetching from `candidate` which creates mismatch between the value. So updating the stake using the `candidate` for all the instances.