### PR TITLE
Pin serde to 1.0.203 to avoid build failure with newer version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,9 +4574,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.194"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -4601,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.194"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,9 @@ prost = { version = "0.12.3", default-features = false }
 prost-build = { version = "0.12.3", default-features = false }
 rand = { version = "0.8.5" }
 reqwest = "0.12.3"
-serde = "1"
+# TODO(mina86): Change to "1" once we update the toolchain.  Building
+# with serde 1.0.204 breaks due to the use of ‘diagnostic’ attribute.
+serde = "=1.0.203"
 serde_json = "1"
 serde_bytes = "0.11.14"
 sha2 = { version = "0.10.7", default-features = false }


### PR DESCRIPTION
We are stuck at using Rust version that Anchor CLI is using (which is not the latest release).  Sadly, serde 1.0.204 requires a new version which stabilises `diagnostic` attribute name space.  Pin serde to last supported version so that code builds with Rust we’re using.