### PR TITLE
wasm: update wasm consensus state to be compatible with sdk50

### DIFF
--- a/common/wasm/src/consensus_state.rs
+++ b/common/wasm/src/consensus_state.rs
@@ -6,13 +6,10 @@ use crate::proto;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConsensusState {
     pub data: Vec<u8>,
-    pub timestamp_ns: u64,
 }
 
 impl ConsensusState {
-    pub fn new(data: Vec<u8>, timestamp_ns: u64) -> Self {
-        Self { data, timestamp_ns }
-    }
+    pub fn new(data: Vec<u8>) -> Self { Self { data } }
 }
 
 impl ibc_core_client_context::consensus_state::ConsensusState
@@ -23,7 +20,7 @@ impl ibc_core_client_context::consensus_state::ConsensusState
     }
 
     fn timestamp(&self) -> ibc_primitives::Timestamp {
-        ibc_primitives::Timestamp::from_nanoseconds(self.timestamp_ns).unwrap()
+        ibc_primitives::Timestamp::none()
     }
 
     fn encode_vec(self) -> alloc::vec::Vec<u8> {
@@ -34,9 +31,7 @@ impl ibc_core_client_context::consensus_state::ConsensusState
 impl Protobuf<Any> for ConsensusState {}
 
 impl From<ConsensusState> for proto::ConsensusState {
-    fn from(state: ConsensusState) -> Self {
-        Self { data: state.data, timestamp_ns: state.timestamp_ns }
-    }
+    fn from(state: ConsensusState) -> Self { Self { data: state.data } }
 }
 
 impl From<&ConsensusState> for proto::ConsensusState {
@@ -46,17 +41,14 @@ impl From<&ConsensusState> for proto::ConsensusState {
 impl TryFrom<proto::ConsensusState> for ConsensusState {
     type Error = proto::BadMessage;
     fn try_from(msg: proto::ConsensusState) -> Result<Self, Self::Error> {
-        Ok(ConsensusState { data: msg.data, timestamp_ns: msg.timestamp_ns })
+        Ok(ConsensusState { data: msg.data })
     }
 }
 
 impl TryFrom<&proto::ConsensusState> for ConsensusState {
     type Error = proto::BadMessage;
     fn try_from(msg: &proto::ConsensusState) -> Result<Self, Self::Error> {
-        Ok(ConsensusState {
-            data: <Vec<u8> as Clone>::clone(&msg.data),
-            timestamp_ns: msg.timestamp_ns,
-        })
+        Ok(ConsensusState { data: <Vec<u8> as Clone>::clone(&msg.data) })
     }
 }
 

--- a/common/wasm/src/proto.rs
+++ b/common/wasm/src/proto.rs
@@ -6,9 +6,6 @@ pub struct ConsensusState {
     /// protobuf encoded data of consensus state
     #[prost(bytes = "vec", tag = "1")]
     pub data: alloc::vec::Vec<u8>,
-    /// Timestamp in nanoseconds.
-    #[prost(uint64, tag = "2")]
-    pub timestamp_ns: u64,
 }
 
 impl prost::Name for ConsensusState {
@@ -37,6 +34,6 @@ impl prost::Name for ConsensusState {
 proto_utils::define_message! {
     ConsensusState; test_consensus_state {
         let data = lib::hash::CryptoHash::test(42).to_vec();
-        Self { data, timestamp_ns: 1 }
+        Self { data }
     }
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/consensus_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/consensus_state.rs
@@ -125,7 +125,6 @@ impl From<cf_guest::ConsensusState> for AnyConsensusState {
             data: prost::Message::encode_to_vec(&cf_guest::proto::Any::from(
                 &state,
             )),
-            timestamp_ns: state.timestamp_ns.get(),
         })
     }
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -74,7 +74,6 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
         };
         let wasm_consensus_state = wasm::consensus_state::ConsensusState::new(
             guest_consensus_state.encode_vec(),
-            state.1.into(),
         );
         Ok(AnyConsensusState::Wasm(wasm_consensus_state))
         // Ok(Self::AnyConsensusState::from(cf_guest::ConsensusState {


### PR DESCRIPTION
With the new sdk50 upgrade of ibc, the wasm consensus state has been modified. The new wasm consensus state doesnt have `timestamp` field. So modifying the wasm consensus state and the proto file for it. 

This should be added if any new connection is going to be established while using sdk50 version on the counterparty. But as of now, this doesnt cause a breaking change.