### PR TITLE
validator: use timestamp in ns while checking if block can be generated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6680,7 +6680,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "validator"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator"
-version = "0.0.6"
+version = "0.0.7"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -105,9 +105,7 @@ pub fn run_validator(config: Config) {
                 .unwrap();
             let trie_data =
                 solana_trie::TrieAccount::new(trie_account.data).unwrap();
-            let timestamp_in_ns = u64::try_from(host_timestamp)
-                .ok()
-                .and_then(|timestamp| timestamp.checked_mul(1_000_000_000))
+            let timestamp_in_ns = host_timestamp.checked_mul(1_000_000_000)
                 .and_then(NonZeroU64::new)
                 .unwrap();
             let result = chain_account.check_generate_block(

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -105,7 +105,8 @@ pub fn run_validator(config: Config) {
                 .unwrap();
             let trie_data =
                 solana_trie::TrieAccount::new(trie_account.data).unwrap();
-            let timestamp_in_ns = host_timestamp.checked_mul(1_000_000_000)
+            let timestamp_in_ns = host_timestamp
+                .checked_mul(1_000_000_000)
                 .and_then(NonZeroU64::new)
                 .unwrap();
             let result = chain_account.check_generate_block(

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -105,9 +105,14 @@ pub fn run_validator(config: Config) {
                 .unwrap();
             let trie_data =
                 solana_trie::TrieAccount::new(trie_account.data).unwrap();
+            let timestamp_in_ns = u64::try_from(host_timestamp)
+                .ok()
+                .and_then(|timestamp| timestamp.checked_mul(1_000_000_000))
+                .and_then(NonZeroU64::new)
+                .unwrap();
             let result = chain_account.check_generate_block(
                 host_height.into(),
-                NonZeroU64::new(host_timestamp).unwrap(),
+                timestamp_in_ns,
                 trie_data.hash(),
             );
             if result.is_ok() {


### PR DESCRIPTION
When checking if block can be generated, it looks for whether the block age is more than minimum or if there is change in the state. But the timestamp used to check the age is in nanoseconds and hence the timestamp should be provided in nanoseconds.