### PR TITLE
cf-solana: add bank hash handling plus some refactoring

### DIFF
--- a/common/cf-solana/src/proof/tests.rs
+++ b/common/cf-solana/src/proof/tests.rs
@@ -179,28 +179,46 @@ mod hash_account {
         assert_eq!(WANT, got.0);
     }
 
-    /// Tests that AccountProof::hash_account calculates has correctly.
-    ///
-    /// Specifically we compare it to result of `hash_account` function (which is
-    /// tested separately in `test_hash_account`).
+    /// Tests AccountHashData getters.
     #[test]
-    fn test_account_proof_hash() {
+    fn test_account_hash_data_getters() {
         let pubkey: Pubkey = PUBKEY.parse().unwrap();
         let owner: Pubkey = OWNER.parse().unwrap();
-
-        let mut accounts = [(PubKey::from(pubkey.clone()), Hash(WANT))];
-        let (_, proof) = AccountProof::generate(
-            &mut accounts,
+        let data = AccountHashData::new(
             LAMPORTS,
             (&owner).into(),
             EXECUTABLE,
             RENT_EPOCH,
             &DATA,
             (&pubkey).into(),
-        )
-        .unwrap();
+        );
 
-        assert_eq!(WANT, proof.hash_account().0);
+        assert_eq!(LAMPORTS, data.lamports());
+        assert_eq!(&owner, <&Pubkey>::from(data.owner()));
+        assert_eq!(EXECUTABLE, data.executable());
+        assert_eq!(RENT_EPOCH, data.rent_epoch());
+        assert_eq!(&DATA, data.data());
+        assert_eq!(&pubkey, <&Pubkey>::from(data.key()));
+    }
+
+    /// Tests that AccountHashData::calculate_hash calculates has correctly.
+    ///
+    /// Specifically compares result to value returned by `hash_account`
+    /// function (which is tested separately in `test_hash_account`).
+    #[test]
+    fn test_account_hash_data_hash() {
+        let pubkey: Pubkey = PUBKEY.parse().unwrap();
+        let owner: Pubkey = OWNER.parse().unwrap();
+        let data = AccountHashData::new(
+            LAMPORTS,
+            (&owner).into(),
+            EXECUTABLE,
+            RENT_EPOCH,
+            &DATA,
+            (&pubkey).into(),
+        );
+
+        assert_eq!(WANT, data.calculate_hash().0);
     }
 
     /// Test account proof verification.

--- a/common/cf-solana/src/types.rs
+++ b/common/cf-solana/src/types.rs
@@ -205,5 +205,5 @@ macro_rules! impl_sol_conversions {
 
 #[cfg(feature = "solana-program")]
 impl_sol_conversions!(solana_program);
-#[cfg(any(test, feature = "solana-program2"))]
+#[cfg(any(test, feature = "solana-program-2"))]
 impl_sol_conversions!(solana_program_2);

--- a/common/cf-solana/src/utils.rs
+++ b/common/cf-solana/src/utils.rs
@@ -46,14 +46,14 @@ pub(super) mod blake3 {
 
     /// Calculates Blake3 hash of given byte slice.
     ///
-    /// When `solana` or `solana2` feature is enabled and building a solana
-    /// program, this is using Solana’s `sol_blake3` syscall.  Otherwise, the
-    /// calculation is done by `blake3` crate.
+    /// When `solana-program` or `solana-program-2` feature is enabled and
+    /// building a solana program, this is using Solana’s `sol_blake3` syscall.
+    /// Otherwise, the calculation is done by `blake3` crate.
     #[allow(dead_code)]
     pub fn hash(bytes: &[u8]) -> Hash {
         if cfg!(target_os = "solana-program") &&
             (cfg!(feature = "solana-program") ||
-                cfg!(feature = "solana-program2"))
+                cfg!(feature = "solana-program-2"))
         {
             hashv(&[bytes])
         } else {
@@ -70,13 +70,13 @@ pub(super) mod blake3 {
     pub fn hashv(slices: &[&[u8]]) -> Hash {
         #[cfg(all(
             target_os = "solana-program",
-            feature = "solana-program2"
+            feature = "solana-program-2"
         ))]
         return Hash(solana_program_2::blake3::hashv(slices).0);
         #[cfg(all(
             target_os = "solana-program",
             feature = "solana-program",
-            not(feature = "solana-program2")
+            not(feature = "solana-program-2")
         ))]
         return Hash(solana_program::blake3::hashv(slices).0);
 


### PR DESCRIPTION
Firstly, add DeltaHashProof type which contains all the information that are needed to calculate delta hash.  One piece of information in it is the accounts delta hash.  As such, this struct together with a trusted bank hash acts as a proof for the accounts delta hash.

Secondly, create AccountHashData wrapper for the account_hash_data field of the AccountProof struct.  This improves type safety and better encapsulates the account information used in hash calculation.

Lastly, fix a few instances where solana-program2 Cargo feature name was used instead of proper solana-program-2.