### PR TITLE
cf-guest: add support for proofs without block header

### DIFF
--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -206,7 +206,7 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
         value: Vec<u8>,
     ) -> Result {
         let value = Some(value.as_slice());
-        proof::verify(
+        proof::verify_for_block(
             prefix.as_bytes(),
             proof.as_ref(),
             root.as_bytes(),
@@ -226,7 +226,7 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
     ) -> Result {
-        proof::verify(
+        proof::verify_for_block(
             prefix.as_bytes(),
             proof.as_ref(),
             root.as_bytes(),


### PR DESCRIPTION
Introduce proof::generate_for_trie and proof::verify_for_trie functions which generate and verify proofs where state root is the trie root hash. Those proofs don’t include the guest block header at the front of the proof.  The first user of them is the rollup light client since there is no guest blockchain running on the rollup.

For consistency, rename proof::generate to proof::generate_for_block and proof::verify to proof::verify_for_block.