### PR TITLE
fast-bridge: Send required accounts for cross domain transfer

### DIFF
--- a/solana-test.sh
+++ b/solana-test.sh
@@ -1,4 +1,4 @@
-# !/bin/sh
+#!/bin/sh
 set -eux
 solana config set --url http://127.0.0.1:8899
 cd solana/write-account

--- a/solana-test.sh
+++ b/solana-test.sh
@@ -1,15 +1,15 @@
-#!/bin/sh
-# set -eux
-# solana config set --url http://127.0.0.1:8899
-# cd solana/write-account
-# cargo build-sbf
-# cd ../..
-# cd solana/signature-verifier
-# cargo build-sbf
-# cd ../..
-# solana program deploy target/deploy/write.so
-# solana program deploy target/deploy/sigverify.so
-# cargo test  --lib -- --nocapture --include-ignored ::anchor
+# !/bin/sh
+set -eux
+solana config set --url http://127.0.0.1:8899
+cd solana/write-account
+cargo build-sbf
+cd ../..
+cd solana/signature-verifier
+cargo build-sbf
+cd ../..
+solana program deploy target/deploy/write.so
+solana program deploy target/deploy/sigverify.so
+cargo test  --lib -- --nocapture --include-ignored ::anchor
 cargo test --lib -- --nocapture --include-ignored ::escrow
 # find solana/restaking/tests/ -name '*.ts' \
 #      -exec yarn run ts-mocha -p ./tsconfig.json -t 1000000 {} +

--- a/solana/bridge-escrow/programs/bridge-escrow/src/lib.rs
+++ b/solana/bridge-escrow/programs/bridge-escrow/src/lib.rs
@@ -85,7 +85,10 @@ pub mod bridge_escrow {
 
         let current_timestamp = Clock::get()?.unix_timestamp as u64;
 
-        require!(current_timestamp < new_intent.timeout_timestamp_in_sec, ErrorCode::InvalidTimeout);
+        require!(
+            current_timestamp < new_intent.timeout_timestamp_in_sec,
+            ErrorCode::InvalidTimeout
+        );
 
         intent.intent_id = new_intent.intent_id;
         intent.user = new_intent.user_in;
@@ -386,7 +389,7 @@ pub mod bridge_escrow {
 
     /// If the intent has not been solved, then the funds can withdrawn by the user
     /// after the timeout period has passed.
-    /// 
+    ///
     /// TODO: The funds should only be withdrawn if the message is sent through IBC that
     /// the request got timed out.
     pub fn on_timeout(

--- a/solana/bridge-escrow/programs/bridge-escrow/src/lib.rs
+++ b/solana/bridge-escrow/programs/bridge-escrow/src/lib.rs
@@ -8,8 +8,6 @@ use anchor_spl::token::{Mint, Token, TokenAccount, Transfer as SplTransfer};
 use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
 use ibc::apps::transfer::types::packet::PacketData;
 use ibc::apps::transfer::types::{PrefixedCoin, PrefixedDenom};
-use ibc::core::channel::types::timeout::TimeoutHeight::At;
-use ibc::core::client::types::Height;
 use ibc::core::host::types::identifiers::{ChannelId, PortId};
 use ibc::core::primitives::Timestamp;
 use ibc::primitives::Signer as IbcSigner;
@@ -37,6 +35,7 @@ declare_id!("64K4AFty7UK9VJC6qykEVwFA93VoyND2uGyQgYa98ui9");
 #[program]
 pub mod bridge_escrow {
     use anchor_spl::token::{CloseAccount, MintTo};
+    use ibc::core::channel::types::timeout::TimeoutHeight;
 
     use super::*;
 
@@ -359,13 +358,9 @@ pub mod bridge_escrow {
                     receiver: String::from("pfm").into(),
                     memo: memo.into(),
                 },
-                timeout_height_on_b: At(
-                    Height::new(2018502000, 29340670).unwrap()
-                ),
-                timeout_timestamp_on_b: Timestamp::from_nanoseconds(
-                    1000000000000000000,
-                )
-                .unwrap(),
+                timeout_height_on_b: TimeoutHeight::Never,
+                timeout_timestamp_on_b: Timestamp::from_nanoseconds(u64::MAX)
+                    .unwrap(),
             };
 
             send_transfer(transfer_ctx, hashed_full_denom, msg)?;

--- a/solana/bridge-escrow/programs/bridge-escrow/src/lib.rs
+++ b/solana/bridge-escrow/programs/bridge-escrow/src/lib.rs
@@ -85,6 +85,8 @@ pub mod bridge_escrow {
 
         let current_timestamp = Clock::get()?.unix_timestamp as u64;
 
+        require!(current_timestamp < new_intent.timeout_timestamp_in_sec, ErrorCode::InvalidTimeout);
+
         intent.intent_id = new_intent.intent_id;
         intent.user = new_intent.user_in;
         intent.token_in = new_intent.token_in;
@@ -384,6 +386,9 @@ pub mod bridge_escrow {
 
     /// If the intent has not been solved, then the funds can withdrawn by the user
     /// after the timeout period has passed.
+    /// 
+    /// TODO: The funds should only be withdrawn if the message is sent through IBC that
+    /// the request got timed out.
     pub fn on_timeout(
         ctx: Context<OnTimeout>,
         _intent_id: String,

--- a/solana/bridge-escrow/programs/bridge-escrow/src/tests.rs
+++ b/solana/bridge-escrow/programs/bridge-escrow/src/tests.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anchor_client::solana_client::rpc_client::RpcClient;
 use anchor_client::solana_client::rpc_config::RpcSendTransactionConfig;
@@ -278,6 +278,11 @@ fn escrow_bridge_program() -> Result<()> {
     )
     .0;
 
+    let current_timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
     let new_intent = IntentPayload {
         intent_id: intent_id.clone(),
         user_in: user.pubkey(),
@@ -285,7 +290,7 @@ fn escrow_bridge_program() -> Result<()> {
         amount_in: TRANSFER_AMOUNT,
         token_out: token_out.to_string(),
         amount_out: amount_out.to_string(),
-        timeout_timestamp_in_sec: 10000,
+        timeout_timestamp_in_sec: current_timestamp + 10000,
         winner_solver: solver.pubkey(),
         single_domain: true,
     };
@@ -405,7 +410,7 @@ fn escrow_bridge_program() -> Result<()> {
         amount_in: TRANSFER_AMOUNT,
         token_out: token_out.to_string(),
         amount_out: amount_out.to_string(),
-        timeout_timestamp_in_sec: 10000,
+        timeout_timestamp_in_sec: current_timestamp + 10000,
         winner_solver: solver.pubkey(),
         single_domain: false,
     };

--- a/solana/bridge-escrow/programs/bridge-escrow/src/tests.rs
+++ b/solana/bridge-escrow/programs/bridge-escrow/src/tests.rs
@@ -278,10 +278,8 @@ fn escrow_bridge_program() -> Result<()> {
     )
     .0;
 
-    let current_timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let current_timestamp =
+        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
 
     let new_intent = IntentPayload {
         intent_id: intent_id.clone(),


### PR DESCRIPTION
For cross domain transfers, an acknowledgement is sent from destination to source in form of a token transfer. The packet contains the memo that has the information about unlocking the funds. The source would then parse the memo and unlock the funds to the solver mentioned in the memo. Since we only have token transfers enabled and no cross chain messages, a token needs to be transferred. For this, we create a dummy token owned by the program which mints a token everytime and sends a transfer. The timeout of the transfer is set to infinite so that it always reaches the counterparty chain.

Also the `on_receive_transfer` method accepts a memo which unlocks the funds to the solver. Right now it is being called by the auctioneer but once the hooks are enabled on `solana-ibc` program, this method would then be called by the `solana-ibc` program.