### PR TITLE
guestchain: clear candidates changed flag only if new epoch to start

### DIFF
--- a/common/cf-solana/src/proof.rs
+++ b/common/cf-solana/src/proof.rs
@@ -4,6 +4,7 @@ pub use cf_guest::proof::{
     generate_for_trie, verify_for_trie, GenerateError, IbcProof, VerifyError,
 };
 use lib::hash::CryptoHash;
+#[allow(unused_imports)]
 use lib::par::prelude::*;
 
 #[cfg(test)]


### PR DESCRIPTION
The Candidates struct has a changed flag indicating whether the set of candidates has changed (in such a way that it would affect the validators set).  This is used to determine whether a new epoch should be started or not.  Once next epoch is scheduled in the block, the flag should be cleared.

Alas, the code clears the flag each time block is generated even if a new epoch isn’t about to start.  As a consequence, if set of candidates changes in the middle of an epoch, the change will not be reflected once the new epoch is ready to start.

Fix this by clearing the flag only if next_epoch is populated in produced block.