### PR TITLE
solana-trie: make witness generic type

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -390,10 +390,8 @@ impl PrivateStorage {
 }
 
 /// Provable storage, i.e. the trie, held in an account.
-pub type TrieAccount<'a, 'b> = solana_trie::WitnessedTrieAccount<
-    'a,
-    solana_trie::ResizableAccount<'a, 'b>,
->;
+pub type TrieAccount<'a, 'b> =
+    solana_trie::TrieAccount<solana_trie::ResizableAccount<'a, 'b>>;
 
 /// Checks contents of given unchecked account and returns a trie if it’s valid.
 ///

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -390,8 +390,10 @@ impl PrivateStorage {
 }
 
 /// Provable storage, i.e. the trie, held in an account.
-pub type TrieAccount<'a, 'b> =
-    solana_trie::TrieAccount<'a, solana_trie::ResizableAccount<'a, 'b>>;
+pub type TrieAccount<'a, 'b> = solana_trie::WitnessedTrieAccount<
+    'a,
+    solana_trie::ResizableAccount<'a, 'b>,
+>;
 
 /// Checks contents of given unchecked account and returns a trie if it’s valid.
 ///

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -104,7 +104,8 @@ pub fn run_validator(config: Config) {
                 .value
                 .unwrap();
             let trie_data =
-                solana_trie::TrieAccount::new(trie_account.data).unwrap();
+                solana_trie::TrieAccount::<_, ()>::new(trie_account.data)
+                    .unwrap();
             let timestamp_in_ns = host_timestamp
                 .checked_mul(1_000_000_000)
                 .and_then(NonZeroU64::new)


### PR DESCRIPTION
Allow customising TrieAccount through a generic witness type.  The main use case is making it TrieAccount Send and Sync by removing support for the witness.  This is needed by, for example, relayer.