### PR TITLE
solana-ibc: add guest client and consensus states

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -331,11 +331,18 @@ impl cf_guest::CommonContext<sigverify::ed25519::PubKey>
 impl guestchain::Verifier<sigverify::ed25519::PubKey> for IbcStorage<'_, '_> {
     fn verify(
         &self,
-        _message: &[u8],
-        _pubkey: &sigverify::ed25519::PubKey,
-        _signature: &sigverify::ed25519::Signature,
+        message: &[u8],
+        pubkey: &sigverify::ed25519::PubKey,
+        signature: &sigverify::ed25519::Signature,
     ) -> bool {
-        unimplemented!()
+        let pubkey = pubkey.as_ref();
+        let sig = signature.as_ref();
+        if let Some(verifier) = crate::global().verifier() {
+            if verifier.verify(message, pubkey, sig).unwrap_or(false) {
+                return true;
+            }
+        }
+        false
     }
 }
 
@@ -345,6 +352,25 @@ impl cf_solana::CommonContext for IbcStorage<'_, '_> {
     type AnyConsensusState = AnyConsensusState;
 
     fn host_metadata(&self) -> Result<(ibc::Timestamp, ibc::Height)> {
+        #[cfg(feature = "witness")]
+        {
+            let clock =
+                anchor_lang::solana_program::sysvar::clock::Clock::get()
+                    .map_err(|e| ibc::ClientError::ClientSpecific {
+                        description: e.to_string(),
+                    })?;
+
+            let slot = clock.slot;
+            let timestamp_sec = clock.unix_timestamp as u64;
+
+            let timestamp =
+                ibc::Timestamp::from_nanoseconds(timestamp_sec * 10u64.pow(9))
+                    .map_err(|e| ibc::ClientError::ClientSpecific {
+                        description: e.to_string(),
+                    })?;
+            let height = ibc::Height::new(1, slot)?;
+            return Ok((timestamp, height));
+        } 
         let timestamp = self.borrow().chain.head()?.timestamp_ns.get();
         let timestamp =
             ibc::Timestamp::from_nanoseconds(timestamp).map_err(|err| {

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -19,6 +19,7 @@ macro_rules! delegate {
                 AnyClientState::Tendermint(cs) => cs.$name($($arg),*),
                 AnyClientState::Wasm(_) => unimplemented!(),
                 AnyClientState::Rollup(cs) => cs.$name($($arg),*),
+                AnyClientState::Guest(cs) => cs.$name($($arg),*),
                 #[cfg(any(test, feature = "mocks"))]
                 AnyClientState::Mock(cs) => cs.$name($($arg),*),
             }
@@ -55,6 +56,7 @@ impl ibc::ClientStateCommon for AnyClientState {
             }
             AnyClientState::Wasm(_) => unimplemented!(),
             AnyClientState::Rollup(_) => unimplemented!(),
+            AnyClientState::Guest(_) => unimplemented!(),
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(cs) => cs.verify_upgrade_client(
                 upgraded_client_state,
@@ -89,6 +91,9 @@ impl ibc::ClientStateCommon for AnyClientState {
             AnyClientState::Rollup(cs) => {
                 cs.verify_membership(prefix, proof, root, path, value)
             }
+            AnyClientState::Guest(cs) => {
+                cs.verify_membership(prefix, proof, root, path, value)
+            }
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(cs) => {
                 cs.verify_membership(prefix, proof, root, path, value)
@@ -113,6 +118,9 @@ impl ibc::ClientStateCommon for AnyClientState {
             }
             AnyClientState::Wasm(_) => unimplemented!(),
             AnyClientState::Rollup(cs) => {
+                cs.verify_non_membership(prefix, proof, root, path)
+            }
+            AnyClientState::Guest(cs) => {
                 cs.verify_non_membership(prefix, proof, root, path)
             }
             #[cfg(any(test, feature = "mocks"))]
@@ -143,6 +151,9 @@ impl<'a, 'b> ibc::ClientStateValidation<IbcStorage<'a, 'b>> for AnyClientState {
             AnyClientState::Rollup(cs) => {
                 cs.verify_client_message(ctx, client_id, client_message)
             }
+            AnyClientState::Guest(cs) => {
+                cs.verify_client_message(ctx, client_id, client_message)
+            }
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(cs) => {
                 cs.verify_client_message(ctx, client_id, client_message)
@@ -167,6 +178,7 @@ impl<'a, 'b> ibc::ClientStateValidation<IbcStorage<'a, 'b>> for AnyClientState {
             }
             AnyClientState::Wasm(_) => unimplemented!(),
             AnyClientState::Rollup(_) => unimplemented!(),
+            AnyClientState::Guest(_) => unimplemented!(),
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(_) => unimplemented!(),
         }


### PR DESCRIPTION
Adding guest client and consensus states so that the solana-ibc on the rollup can store them. The guest client and consensus state was previous removed since we used to store the wasm wrapped guest states. It was removed here https://github.com/ComposableFi/emulated-light-client/pull/255 and now its added again.