### PR TITLE
light-clients: update revision number for cf-guest and cf-solana to 1

### DIFF
--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -270,7 +270,7 @@ where
         ctx.store_consensus_state(
             ibc::path::ClientConsensusStatePath::new(
                 client_id.clone(),
-                0,
+                1,
                 u64::from(self.latest_height),
             ),
             consensus_state.into(),

--- a/common/cf-solana/src/client/impls.rs
+++ b/common/cf-solana/src/client/impls.rs
@@ -188,7 +188,7 @@ where
         ctx.store_consensus_state(
             ibc::path::ClientConsensusStatePath::new(
                 client_id.clone(),
-                0,
+                1,
                 self.latest_slot.get(),
             ),
             consensus_state.into(),


### PR DESCRIPTION
This is to increase compatibility with other libraries which fail to
properly decode proto3 message with missing revision number field
(missing fields should be decoded as zero in proto3).
