### PR TITLE
Update borsh dependency to address RUSTSEC-2023-0033 vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e2e5be518ec6053d90a2a7f26843dbee607583c779e6c8395951b9739bdfbe"
 dependencies = [
  "anchor-syn 0.29.0",
- "borsh-derive-internal 0.10.3",
+ "borsh-derive-internal 0.10.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -360,7 +360,7 @@ dependencies = [
  "arrayref",
  "base64 0.13.1",
  "bincode",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "solana-program 2.0.0",
  "thiserror",
@@ -384,7 +384,7 @@ dependencies = [
  "arrayref",
  "base64 0.13.1",
  "bincode",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "getrandom 0.2.11",
  "solana-program 1.17.31",
@@ -916,12 +916,12 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
- "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "borsh-derive 0.10.4",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -949,12 +949,12 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
 dependencies = [
- "borsh-derive-internal 0.10.3",
- "borsh-schema-derive-internal 0.10.3",
+ "borsh-derive-internal 0.10.4",
+ "borsh-schema-derive-internal 0.10.4",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
+checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
+checksum = "276691d96f063427be83e6692b86148e488ebba9f48f77788724ca027ba3b6d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1162,7 +1162,7 @@ dependencies = [
 name = "cf-guest"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "derive_more",
  "guestchain",
@@ -2244,7 +2244,7 @@ dependencies = [
 name = "guestchain"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "derive_more",
  "ibc-core-client-context",
@@ -2682,7 +2682,7 @@ version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "http 1.0.0",
@@ -2711,7 +2711,7 @@ name = "ibc-app-transfer-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-core",
@@ -2752,7 +2752,7 @@ name = "ibc-client-tendermint-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -2825,7 +2825,7 @@ name = "ibc-core-channel-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -2879,7 +2879,7 @@ name = "ibc-core-client-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-core-commitment-types",
@@ -2899,7 +2899,7 @@ name = "ibc-core-commitment-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -2929,7 +2929,7 @@ name = "ibc-core-connection-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -2966,7 +2966,7 @@ name = "ibc-core-handler-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-core-channel-types",
@@ -3008,7 +3008,7 @@ name = "ibc-core-host-cosmos"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-app-transfer-types",
@@ -3032,7 +3032,7 @@ name = "ibc-core-host-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -3061,7 +3061,7 @@ name = "ibc-core-router-types"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-core-host-types",
@@ -3090,7 +3090,7 @@ name = "ibc-primitives"
 version = "0.50.0"
 source = "git+https://github.com/mina86/ibc-rs?rev=f07276383091f75b7ee8bff6fd434f8214ac5054#f07276383091f75b7ee8bff6fd434f8214ac5054"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "derive_more",
  "displaydoc",
  "ibc-proto",
@@ -3110,7 +3110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4ee32b22d3b06f31529b956f4928e5c9a068d71e46cf6abfa19c31ca550553"
 dependencies = [
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytes",
  "flex-error",
  "ics23",
@@ -3432,7 +3432,7 @@ name = "lib"
 version = "0.0.0"
 dependencies = [
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bs58 0.5.1",
  "bytemuck",
  "derive_more",
@@ -3704,7 +3704,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba8ee05284d79b367ae8966d558e1a305a781fc80c9df51f37775169117ba64f"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.9.3",
  "num-derive 0.3.3",
  "num-traits",
  "solana-program 1.17.31",
@@ -5059,7 +5059,7 @@ version = "0.0.0"
 dependencies = [
  "ascii 1.1.0",
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "derive_more",
  "hex-literal",
@@ -5890,7 +5890,7 @@ dependencies = [
  "bincode",
  "bitflags 2.6.0",
  "blake3",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "borsh 0.9.3",
  "bs58 0.4.0",
  "bv",
@@ -5943,7 +5943,7 @@ dependencies = [
  "bincode",
  "bitflags 2.6.0",
  "blake3",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "borsh 0.9.3",
  "borsh 1.5.1",
  "bs58 0.4.0",
@@ -5998,7 +5998,7 @@ dependencies = [
  "bincode",
  "bitflags 2.6.0",
  "blake3",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "borsh 1.5.1",
  "bs58 0.5.1",
  "bv",
@@ -6246,7 +6246,7 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "bitflags 2.6.0",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bs58 0.4.0",
  "bytemuck",
  "byteorder",
@@ -6394,7 +6394,7 @@ name = "solana-signature-verifier"
 version = "0.0.3"
 dependencies = [
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "derive_more",
  "ed25519-dalek",
@@ -6534,7 +6534,7 @@ dependencies = [
  "Inflector",
  "base64 0.21.7",
  "bincode",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bs58 0.4.0",
  "lazy_static",
  "log",
@@ -6799,7 +6799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "992d9c64c2564cc8f63a4b508bf3ebcdf2254b0429b13cd1d31adb6162432a5f"
 dependencies = [
  "assert_matches",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "num-derive 0.4.1",
  "num-traits",
  "solana-program 1.17.31",
@@ -6858,7 +6858,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "solana-program 1.17.31",
  "solana-zk-token-sdk 1.17.31",
@@ -6998,7 +6998,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "solana-program 1.17.31",
  "spl-discriminator",
  "spl-pod",
@@ -7642,7 +7642,7 @@ version = "0.0.0"
 dependencies = [
  "ascii 1.1.0",
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "derive_more",
  "hex-literal",
@@ -7848,7 +7848,7 @@ dependencies = [
  "anchor-lang 0.29.0",
  "anchor-spl",
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bs58 0.5.1",
  "clap 4.4.18",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ arrayvec = "0.7.4"
 ascii = "1.1.0"
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 blake3 = { version = "1.3.3", default-features = false }
-borsh = { version = "0.10.3", default-features = false }
+borsh = { version = "0.10.4", default-features = false }
 bs58 = { version = "0.5.0", default-features = false }
 bytemuck = { version = "1.14", default-features = false }
 chrono = { version = "0.4", default-features = false }

--- a/solana/trie-geyser-plugin/Cargo.lock
+++ b/solana/trie-geyser-plugin/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
  "arrayref",
  "base64 0.13.1",
  "bincode",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "solana-program 2.0.0",
  "thiserror",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.3",
  "hashbrown 0.13.2",
@@ -833,7 +833,7 @@ dependencies = [
 name = "cf-guest"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "derive_more",
  "guestchain",
@@ -1620,7 +1620,7 @@ dependencies = [
 name = "guestchain"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "derive_more",
  "ibc-core-client-context",
@@ -2292,7 +2292,7 @@ name = "lib"
 version = "0.0.0"
 dependencies = [
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bs58 0.5.1",
  "bytemuck",
  "derive_more",
@@ -3347,7 +3347,7 @@ version = "0.0.0"
 dependencies = [
  "ascii 1.1.0",
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "bytemuck",
  "derive_more",
  "lib",
@@ -3836,7 +3836,7 @@ dependencies = [
  "bincode",
  "bitflags 2.6.0",
  "blake3",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "borsh 0.9.3",
  "borsh 1.5.1",
  "bs58 0.4.0",
@@ -3890,7 +3890,7 @@ dependencies = [
  "bincode",
  "bitflags 2.6.0",
  "blake3",
- "borsh 0.10.3",
+ "borsh 0.10.4",
  "borsh 0.9.3",
  "borsh 1.5.1",
  "bs58 0.4.0",


### PR DESCRIPTION
borsh 0.10.3 is vulnerable to RUSTSEC-2023-0033.  While this doesn’t directly affect us, update the dependency so we’re not even subject to this theoretical issue.