### PR TITLE
light-clients: make prefix empty for both cf-solana and cf-guest

### DIFF
--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -199,7 +199,7 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
     /// See [`proof::verify`] for documentation of the proof format.
     fn verify_membership(
         &self,
-        prefix: &ibc::CommitmentPrefix,
+        _prefix: &ibc::CommitmentPrefix,
         proof: &ibc::CommitmentProofBytes,
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
@@ -207,7 +207,7 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
     ) -> Result {
         let value = Some(value.as_slice());
         proof::verify_for_block(
-            prefix.as_bytes(),
+            &[],
             proof.as_ref(),
             root.as_bytes(),
             path,
@@ -221,13 +221,13 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
     /// See [`proof::verify`] for documentation of the proof format.
     fn verify_non_membership(
         &self,
-        prefix: &ibc::CommitmentPrefix,
+        _prefix: &ibc::CommitmentPrefix,
         proof: &ibc::CommitmentProofBytes,
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
     ) -> Result {
         proof::verify_for_block(
-            prefix.as_bytes(),
+            &[],
             proof.as_ref(),
             root.as_bytes(),
             path,

--- a/common/cf-guest/src/client/impls.rs
+++ b/common/cf-guest/src/client/impls.rs
@@ -206,6 +206,8 @@ impl<PK: PubKey> ibc::ClientStateCommon for ClientState<PK> {
         value: Vec<u8>,
     ) -> Result {
         let value = Some(value.as_slice());
+        // TODO: Once IBC is updated everywhere to version which supports empty
+        // prefixes, change `&[]` with `prefix.as_bytes()`.
         proof::verify_for_block(
             &[],
             proof.as_ref(),

--- a/common/cf-solana/src/client/impls.rs
+++ b/common/cf-solana/src/client/impls.rs
@@ -130,7 +130,7 @@ impl ibc::ClientStateCommon for ClientState {
     /// See [`proof::verify`] for documentation of the proof format.
     fn verify_membership(
         &self,
-        prefix: &ibc::CommitmentPrefix,
+        _prefix: &ibc::CommitmentPrefix,
         proof: &ibc::CommitmentProofBytes,
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
@@ -138,7 +138,7 @@ impl ibc::ClientStateCommon for ClientState {
     ) -> Result {
         let value = Some(value.as_slice());
         proof::verify_for_trie(
-            prefix.as_bytes(),
+            &[],
             proof.as_ref(),
             root.as_bytes(),
             path,
@@ -152,13 +152,13 @@ impl ibc::ClientStateCommon for ClientState {
     /// See [`proof::verify`] for documentation of the proof format.
     fn verify_non_membership(
         &self,
-        prefix: &ibc::CommitmentPrefix,
+        _prefix: &ibc::CommitmentPrefix,
         proof: &ibc::CommitmentProofBytes,
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
     ) -> Result {
         proof::verify_for_trie(
-            prefix.as_bytes(),
+            &[],
             proof.as_ref(),
             root.as_bytes(),
             path,

--- a/common/cf-solana/src/client/impls.rs
+++ b/common/cf-solana/src/client/impls.rs
@@ -157,14 +157,8 @@ impl ibc::ClientStateCommon for ClientState {
         root: &ibc::CommitmentRoot,
         path: ibc::path::Path,
     ) -> Result {
-        proof::verify_for_trie(
-            &[],
-            proof.as_ref(),
-            root.as_bytes(),
-            path,
-            None,
-        )
-        .map_err(Into::into)
+        proof::verify_for_trie(&[], proof.as_ref(), root.as_bytes(), path, None)
+            .map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
Since prefix is expected to be empty, send empty prefixes when verifying proofs.