### PR TITLE
solana-ibc: write local consensus state when witness feature is enabled

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -402,10 +402,25 @@ pub mod solana_ibc {
         let height = store.borrow().chain.head()?.block_height;
         // height just before the data is added to the trie.
         msg!("Current Block height {}", height);
+        let previous_root = store.borrow().provable.hash().clone();
 
         ::ibc::core::entrypoint::dispatch(&mut store, &mut router, message)
             .map_err(error::Error::ContextError)
             .map_err(move |err| error!((&err)))?;
+
+        #[cfg(feature = "witness")]
+        {
+            let root = store.borrow().provable.hash().clone();
+            if previous_root != root {
+                msg!("Writing local consensus state");
+                let slot = Clock::get()?.slot;
+                let timestamp = Clock::get()?.unix_timestamp as u64;
+                let storage = &mut store.borrow_mut().private;
+                storage
+                    .add_local_consensus_state(slot, timestamp, root)
+                    .unwrap();
+            }
+        }
 
         Ok(())
     }

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -1,6 +1,8 @@
 use alloc::rc::Rc;
 use core::cell::RefCell;
 use core::num::NonZeroU64;
+#[cfg(feature = "witness")]
+use std::collections::VecDeque;
 
 use anchor_lang::prelude::*;
 use borsh::maybestd::io;
@@ -313,6 +315,9 @@ pub struct PrivateStorage {
 
     // Fee to be charged for each transfer
     pub fee_in_lamports: u64,
+
+    #[cfg(feature = "witness")]
+    pub local_consensus_state: VecDeque<(u64, u64, CryptoHash)>,
 }
 
 #[derive(Clone, Debug, borsh::BorshSerialize, borsh::BorshDeserialize)]
@@ -386,6 +391,20 @@ impl PrivateStorage {
             .ok_or_else(|| ibc::ClientError::ClientStateNotFound {
                 client_id: client_id.clone(),
             })
+    }
+
+    #[cfg(feature = "witness")]
+    pub fn add_local_consensus_state(
+        &mut self,
+        slot: u64,
+        timestamp: u64,
+        trie_root: CryptoHash,
+    ) -> Result<(), ibc::ClientError> {
+        if self.local_consensus_state.len() == MAX_CONSENSUS_STATES {
+            self.local_consensus_state.pop_front();
+        }
+        self.local_consensus_state.push_back((slot, timestamp, trie_root));
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Local consensus state is required for establishing connections. It is required only to establish connection after which it wont be required. So we store the consensus state every time trie changes for a maximum of 64 states.