### PR TITLE
Various minor clippy fixes

### DIFF
--- a/common/memory/src/lib.rs
+++ b/common/memory/src/lib.rs
@@ -409,8 +409,8 @@ mod test_write_log {
     fn test_free_commit() {
         let (mut alloc, ptrs) = make_allocator();
         let mut wlog = WriteLog::new(&mut alloc);
-        for num in 5..10 {
-            wlog.free(ptrs[num]);
+        for ptr in &ptrs[5..10] {
+            wlog.free(*ptr);
         }
         assert_nodes(10, wlog.allocator(), &ptrs, 0);
         wlog.commit();
@@ -421,8 +421,8 @@ mod test_write_log {
     fn test_free_rollback() {
         let (mut alloc, ptrs) = make_allocator();
         let mut wlog = WriteLog::new(&mut alloc);
-        for num in 5..10 {
-            wlog.free(ptrs[num]);
+        for ptr in &ptrs[5..10] {
+            wlog.free(*ptr);
         }
         assert_nodes(10, wlog.allocator(), &ptrs, 0);
         core::mem::drop(wlog);

--- a/common/sealable-trie/src/bits.rs
+++ b/common/sealable-trie/src/bits.rs
@@ -1005,6 +1005,7 @@ mod test_pop {
     }
 
     #[test]
+    #[allow(clippy::just_underscores_and_digits)]
     fn test_pop_back_slice() {
         let bytes = [
             7, 182, 182, 167, 177, 247, 171, 255, 255, 255, 0, 0, 0, 0, 0, 0,

--- a/common/sealable-trie/src/bits/ext_key.rs
+++ b/common/sealable-trie/src/bits/ext_key.rs
@@ -266,7 +266,6 @@ fn test_decode() {
 
     #[track_caller]
     fn test(length: u16, offset: U3, bad: &[u8], good: &[u8]) {
-        let offset = U3::try_from(offset).unwrap();
         let num = length * 8 + u16::from(offset);
         let bad = [&num.to_be_bytes()[..], bad].concat();
         assert_eq!(None, ExtKey::decode(&bad, 0));

--- a/common/sealable-trie/src/trie/tests.rs
+++ b/common/sealable-trie/src/trie/tests.rs
@@ -385,7 +385,7 @@ fn stress_test_iter() {
     }
 }
 
-#[derive(Clone, Eq, Ord)]
+#[derive(Clone, Eq)]
 struct Key {
     len: u8,
     buf: [u8; 35],
@@ -425,9 +425,15 @@ impl core::cmp::PartialEq for Key {
     fn eq(&self, other: &Self) -> bool { self.as_bytes() == other.as_bytes() }
 }
 
+impl core::cmp::Ord for Key {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.as_bytes().cmp(other.as_bytes())
+    }
+}
+
 impl core::cmp::PartialOrd for Key {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.as_bytes().partial_cmp(other.as_bytes())
+        Some(self.cmp(other))
     }
 }
 

--- a/common/trie-geyser/src/api.rs
+++ b/common/trie-geyser/src/api.rs
@@ -52,18 +52,18 @@ fn test_slot_data_serialisation() {
 
     let mut proof = proof::MerkleProof::default();
     let level = [
-        CryptoHash::test(10).into(),
-        CryptoHash::test(11).into(),
-        CryptoHash::test(12).into(),
+        CryptoHash::test(10),
+        CryptoHash::test(11),
+        CryptoHash::test(12),
     ];
     proof.push_level(&level, 1);
 
     let data = SlotData {
         delta_hash_proof: proof::DeltaHashProof {
-            parent_blockhash: CryptoHash::test(101).into(),
-            accounts_delta_hash: CryptoHash::test(102).into(),
+            parent_blockhash: CryptoHash::test(101),
+            accounts_delta_hash: CryptoHash::test(102),
             num_sigs: 103,
-            blockhash: CryptoHash::test(104).into(),
+            blockhash: CryptoHash::test(104),
             epoch_accounts_hash: None,
         },
         witness_proof: proof::AccountProof { account_hash_data, proof },

--- a/common/trie-geyser/src/api.rs
+++ b/common/trie-geyser/src/api.rs
@@ -51,11 +51,8 @@ fn test_slot_data_serialisation() {
     );
 
     let mut proof = proof::MerkleProof::default();
-    let level = [
-        CryptoHash::test(10),
-        CryptoHash::test(11),
-        CryptoHash::test(12),
-    ];
+    let level =
+        [CryptoHash::test(10), CryptoHash::test(11), CryptoHash::test(12)];
     proof.push_level(&level, 1);
 
     let data = SlotData {

--- a/solana/signature-verifier/src/api.rs
+++ b/solana/signature-verifier/src/api.rs
@@ -121,7 +121,8 @@ impl<'a, 'info> SignaturesAccount<'a, 'info> {
     #[cfg(any(test, not(feature = "library")))]
     pub(crate) fn write_count_and_sort(&self, count: u32) -> Result {
         let mut data = self.0.try_borrow_mut_data()?;
-        let (head, tail) = stdx::split_at_mut::<4, _>(&mut *data)
+        #[allow(clippy::explicit_auto_deref)]
+        let (head, tail) = stdx::split_at_mut::<4, _>(*data)
             .ok_or(ProgramError::AccountDataTooSmall)?;
         let entries = stdx::as_chunks_mut::<{ SignatureHash::SIZE }, _>(tail)
             .0

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state.rs
@@ -1,5 +1,7 @@
 use anchor_lang::prelude::borsh;
 use anchor_lang::prelude::borsh::maybestd::io;
+use anchor_lang::solana_program::sysvar::clock::Clock;
+use anchor_lang::solana_program::sysvar::Sysvar;
 
 use crate::consensus_state::AnyConsensusState;
 use crate::ibc;
@@ -236,35 +238,21 @@ impl cf_guest::CommonContext<sigverify::ed25519::PubKey>
     type AnyConsensusState = AnyConsensusState;
 
     fn host_metadata(&self) -> Result<(ibc::Timestamp, ibc::Height)> {
-        #[cfg(feature = "witness")]
-        {
-            let clock =
-                anchor_lang::solana_program::sysvar::clock::Clock::get()
-                    .map_err(|e| ibc::ClientError::ClientSpecific {
-                        description: e.to_string(),
-                    })?;
-
-            let slot = clock.slot;
-            let timestamp_sec = clock.unix_timestamp as u64;
-
-            let timestamp =
-                ibc::Timestamp::from_nanoseconds(timestamp_sec * 10u64.pow(9))
-                    .map_err(|e| ibc::ClientError::ClientSpecific {
-                        description: e.to_string(),
-                    })?;
-            let height = ibc::Height::new(1, slot)?;
-            return Ok((timestamp, height));
-        }
-        let timestamp = self.borrow().chain.head()?.timestamp_ns.get();
-        let timestamp =
-            ibc::Timestamp::from_nanoseconds(timestamp).map_err(|err| {
-                ibc::ClientError::Other { description: err.to_string() }
+        let (timestamp_ns, height) = if cfg!(feature = "witness") {
+            let clock = Clock::get().map_err(|e| {
+                ibc::ClientError::ClientSpecific { description: e.to_string() }
             })?;
-
-        let height = u64::from(self.borrow().chain.head()?.block_height);
-        let height = ibc::Height::new(1, height)?;
-
-        Ok((timestamp, height))
+            (clock.unix_timestamp as u64 * 10u64.pow(9), clock.slot)
+        } else {
+            self.borrow().chain.head().map(|head| {
+                (head.timestamp_ns.get(), head.block_height.into())
+            })?
+        };
+        let timestamp = ibc::Timestamp::from_nanoseconds(timestamp_ns)
+            .map_err(|e| ibc::ClientError::ClientSpecific {
+                description: e.to_string(),
+            })?;
+        Ok((timestamp, ibc::Height::new(1, height)?))
     }
 
     fn set_client_state(

--- a/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/client_state/impls.rs
@@ -394,7 +394,7 @@ fn test_merkle_hash() {
         assert_eq!(theirs.leaf_hash(input), ours.leaf_hash(input));
     }
 
-    let foo = Sha256::digest(b"foo");
-    let bar = Sha256::digest(b"bar");
-    assert_eq!(theirs.inner_hash(foo, bar), ours.inner_hash(foo, bar));
+    let one = Sha256::digest(b"foo");
+    let two = Sha256::digest(b"bar");
+    assert_eq!(theirs.inner_hash(one, two), ours.inner_hash(one, two));
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -410,7 +410,7 @@ pub mod solana_ibc {
 
         #[cfg(feature = "witness")]
         {
-            let root = store.borrow().provable.hash().clone();
+            let root = *store.borrow().provable.hash();
             if previous_root != root {
                 msg!("Writing local consensus state");
                 let clock = Clock::get()?;

--- a/solana/solana-ibc/programs/solana-ibc/src/tests.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/tests.rs
@@ -903,6 +903,7 @@ fn max_timeout_height() -> ibc::TimeoutHeight {
     ibc::TimeoutHeight::At(ibc::Height::new(u64::MAX, u64::MAX).unwrap())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn construct_packet_from_denom(
     base_denom: &str,
     port_id: ibc::PortId,


### PR DESCRIPTION
Mostly address `cargo clippy --fix` with some other minor
modifications.  The biggest refactoring is `host_metadata` method in
`client_state.rs` (but of course no behaviour changes).
