### PR TITLE
witness: store local consensus state during initialization for witness feature

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -123,7 +123,7 @@ pub mod solana_ibc {
             let storage = &mut ctx.accounts.storage;
             let clock = Clock::get()?;
             let slot = clock.slot;
-            let timestamp = clock?.unix_timestamp as u64;
+            let timestamp = clock.unix_timestamp as u64;
             storage
                 .add_local_consensus_state(slot, timestamp, *provable.hash())
                 .unwrap();

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -127,7 +127,7 @@ pub mod solana_ibc {
                 .add_local_consensus_state(
                     slot,
                     timestamp,
-                    provable.hash().clone(),
+                    *provable.hash(),
                 )
                 .unwrap();
         }

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -118,6 +118,19 @@ pub mod solana_ibc {
             &ctx.accounts.trie,
             &ctx.accounts.sender,
         )?;
+        #[cfg(feature = "witness")]
+        {
+            let storage = &mut ctx.accounts.storage;
+            let slot = Clock::get()?.slot;
+            let timestamp = Clock::get()?.unix_timestamp as u64;
+            storage
+                .add_local_consensus_state(
+                    slot,
+                    timestamp,
+                    provable.hash().clone(),
+                )
+                .unwrap();
+        }
         ctx.accounts.chain.initialise(
             &mut provable,
             config,

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -125,11 +125,7 @@ pub mod solana_ibc {
             let slot = clock.slot;
             let timestamp = clock?.unix_timestamp as u64;
             storage
-                .add_local_consensus_state(
-                    slot,
-                    timestamp,
-                    *provable.hash(),
-                )
+                .add_local_consensus_state(slot, timestamp, *provable.hash())
                 .unwrap();
         }
         ctx.accounts.chain.initialise(

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -121,8 +121,9 @@ pub mod solana_ibc {
         #[cfg(feature = "witness")]
         {
             let storage = &mut ctx.accounts.storage;
-            let slot = Clock::get()?.slot;
-            let timestamp = Clock::get()?.unix_timestamp as u64;
+            let clock = Clock::get()?;
+            let slot = clock.slot;
+            let timestamp = clock?.unix_timestamp as u64;
             storage
                 .add_local_consensus_state(
                     slot,


### PR DESCRIPTION
When establishing the connection, we need to store the consensus state on chain before the client is stored since the consensus state would be required during `OpenTry` or `OpenAck` based on order of how the connection is established. So storing the consensus state during `initialize` method so that when the client is created, it can use the stored consensus state.