### PR TITLE
solana-ibc: get host consensus state based on feature

### DIFF
--- a/solana/restaking/programs/restaking/Cargo.toml
+++ b/solana/restaking/programs/restaking/Cargo.toml
@@ -16,6 +16,7 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
+witness = []
 
 [dependencies]
 anchor-lang = { workspace = true, features = ["init-if-needed"] }

--- a/solana/restaking/programs/restaking/Cargo.toml
+++ b/solana/restaking/programs/restaking/Cargo.toml
@@ -16,7 +16,6 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
-witness = []
 
 [dependencies]
 anchor-lang = { workspace = true, features = ["init-if-needed"] }

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -91,9 +91,7 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
                     .find(|cs| cs.0 == height.revision_height())
                     .map(|(_slot, timestamp, trie_root)| {
                         let state = cf_solana::ConsensusState {
-                            trie_root: ibc::CommitmentRoot::from_bytes(
-                                trie_root.as_slice(),
-                            ),
+                            trie_root: trie_root.to_vec().into(),
                             timestamp_sec: NonZeroU64::new(*timestamp).unwrap(),
                         };
                         AnyConsensusState::Rollup(state)

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -82,22 +82,24 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
     ) -> Result<Self::AnyConsensusState> {
         let store = self.borrow();
         #[cfg(feature = "witness")]
-        let state = (height.revision_number() == 1).then(|| {
-            store
-                .private
-                .local_consensus_state
-                .iter()
-                .find(|cs| cs.0 == height.revision_height())
-                .map(|(_slot, timestamp, trie_root)| {
-                    let state = cf_solana::ConsensusState {
-                        trie_root: ibc::CommitmentRoot::from_bytes(
-                            trie_root.as_slice(),
-                        ),
-                        timestamp_sec: NonZeroU64::new(*timestamp).unwrap(),
-                    };
-                    AnyConsensusState::Rollup(state)
-                })
-        });
+        let state = (height.revision_number() == 1)
+            .then(|| {
+                store
+                    .private
+                    .local_consensus_state
+                    .iter()
+                    .find(|cs| cs.0 == height.revision_height())
+                    .map(|(_slot, timestamp, trie_root)| {
+                        let state = cf_solana::ConsensusState {
+                            trie_root: ibc::CommitmentRoot::from_bytes(
+                                trie_root.as_slice(),
+                            ),
+                            timestamp_sec: NonZeroU64::new(*timestamp).unwrap(),
+                        };
+                        AnyConsensusState::Rollup(state)
+                    })
+            })
+            .flatten();
         #[cfg(not(feature = "witness"))]
         let state = (height.revision_number() == 1)
             .then(|| {

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -287,9 +287,7 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
         }
     }
 
-    fn get_client_validation_context(&self) -> &Self::V {
-        self
-    }
+    fn get_client_validation_context(&self) -> &Self::V { self }
 
     fn get_compatible_versions(&self) -> Vec<ibc::conn::Version> {
         ibc::conn::get_compatible_versions()
@@ -402,7 +400,7 @@ fn calculate_block_delay(
     if max_expected_time_per_block.is_zero() {
         return 0;
     }
-    let delay = delay_period_time.as_secs_f64()
-        / max_expected_time_per_block.as_secs_f64();
+    let delay = delay_period_time.as_secs_f64() /
+        max_expected_time_per_block.as_secs_f64();
     delay.ceil() as u64
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/validation_context.rs
@@ -82,20 +82,22 @@ impl ibc::ValidationContext for IbcStorage<'_, '_> {
     ) -> Result<Self::AnyConsensusState> {
         let store = self.borrow();
         #[cfg(feature = "witness")]
-        let state = store
-            .private
-            .local_consensus_state
-            .iter()
-            .find(|cs| cs.0 == height.revision_height())
-            .map(|(_slot, timestamp, trie_root)| {
-                let state = cf_solana::ConsensusState {
-                    trie_root: ibc::CommitmentRoot::from_bytes(
-                        trie_root.as_slice(),
-                    ),
-                    timestamp_sec: NonZeroU64::new(*timestamp).unwrap(),
-                };
-                AnyConsensusState::Rollup(state)
-            });
+        let state = (height.revision_number() == 1).then(|| {
+            store
+                .private
+                .local_consensus_state
+                .iter()
+                .find(|cs| cs.0 == height.revision_height())
+                .map(|(_slot, timestamp, trie_root)| {
+                    let state = cf_solana::ConsensusState {
+                        trie_root: ibc::CommitmentRoot::from_bytes(
+                            trie_root.as_slice(),
+                        ),
+                        timestamp_sec: NonZeroU64::new(*timestamp).unwrap(),
+                    };
+                    AnyConsensusState::Rollup(state)
+                })
+        });
         #[cfg(not(feature = "witness"))]
         let state = (height.revision_number() == 1)
             .then(|| {


### PR DESCRIPTION
Host consensus state is required for establishing the connection. So the host consensus state should be returned based on whether the `witness` feature is present or not. If the feature is present, then we return the rollup consensus state else we return the guest consensus state. But the issue is if the `witness` feature is not enabled, it could either be guest or wasm ( which is a wrapper version of guest ). Since the connection with cosmos is already established, we would stick to returning the `guest` consensus state for now.