### PR TITLE
solana-ibc: fix condition to check connection id

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -558,7 +558,7 @@ pub mod solana_ibc {
         let connection_id = ibc::ConnectionId::new(connection_id_idx.into());
 
         // Panic if connection_id doenst exist
-        if storage.connections.len() >= usize::from(connection_id_idx) {
+        if storage.connections.len() <= usize::from(connection_id_idx) {
             return Err(error!(error::Error::ContextError(
                 ibc::ContextError::ConnectionError(
                     ibc::ConnectionError::ConnectionNotFound {


### PR DESCRIPTION
Fix the condition to check if the connection id index is more than the number of conditions.