### PR TITLE
IBC Hooks: add hooks to call bridge escrow program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5724,6 +5724,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-allocator",
+ "solana-program 1.17.31",
  "solana-signature-verifier",
  "solana-trie",
  "solana-write-account",

--- a/solana/solana-ibc/programs/solana-ibc/Cargo.toml
+++ b/solana/solana-ibc/programs/solana-ibc/Cargo.toml
@@ -35,6 +35,11 @@ primitive-types.workspace = true
 prost.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+# We normally access solana_program via anchor_lang but to support
+# pubkey! macro we need to have solana_program as direct dependency.
+# TODO(mina86): Remove this once we upgrade Anchor to version with its
+# own pubkey! macro.
+solana-program.workspace = true
 spl-associated-token-account.workspace = true
 spl-token.workspace = true
 strum.workspace = true

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -35,8 +35,8 @@ pub const WSOL_ADDRESS: &str = "So11111111111111111111111111111111111111112";
 pub const MINIMUM_FEE_ACCOUNT_BALANCE: u64 =
     solana_program::native_token::LAMPORTS_PER_SOL;
 
-pub const BRIDGE_ESCROW_PROGRAM_ID: &str =
-    "AhfoGVmS19tvkEG2hBuZJ1D6qYEjyFmXZ1qPoFD6H4Mj";
+pub const BRIDGE_ESCROW_PROGRAM_ID: Pubkey =
+    solana_program::pubkey!("AhfoGVmS19tvkEG2hBuZJ1D6qYEjyFmXZ1qPoFD6H4Mj");
 pub const HOOK_TOKEN_ADDRESS: &str =
     "0x36dd1bfe89d409f869fabbe72c3cf72ea8b460f6";
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -35,6 +35,11 @@ pub const WSOL_ADDRESS: &str = "So11111111111111111111111111111111111111112";
 pub const MINIMUM_FEE_ACCOUNT_BALANCE: u64 =
     solana_program::native_token::LAMPORTS_PER_SOL;
 
+pub const BRIDGE_ESCROW_PROGRAM_ID: &str =
+    "AhfoGVmS19tvkEG2hBuZJ1D6qYEjyFmXZ1qPoFD6H4Mj";
+pub const HOOK_TOKEN_ADDRESS: &str =
+    "0x36dd1bfe89d409f869fabbe72c3cf72ea8b460f6";
+
 declare_id!("2HLLVco5HvwWriNbUhmVwA2pCetRkpgrqwnjcsZdyTKT");
 
 #[cfg(not(feature = "mocks"))]
@@ -472,8 +477,8 @@ pub mod solana_ibc {
     /// doesnt exists.
     ///
     /// Would panic if it doesnt match the one that is in the packet
-    pub fn send_transfer(
-        ctx: Context<SendTransfer>,
+    pub fn send_transfer<'a, 'info>(
+        ctx: Context<'a, 'a, 'a, 'info, SendTransfer<'info>>,
         hashed_full_denom: CryptoHash,
         msg: ibc::MsgTransfer,
     ) -> Result<()> {

--- a/solana/solana-ibc/programs/solana-ibc/src/storage.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/storage.rs
@@ -473,6 +473,9 @@ pub struct TransferAccounts<'a> {
     pub mint_authority: Option<AccountInfo<'a>>,
     pub token_program: Option<AccountInfo<'a>>,
     pub fee_collector: Option<AccountInfo<'a>>,
+    /// Contains the list of accounts required for the hooks
+    /// if present
+    pub remaining_accounts: Vec<AccountInfo<'a>>,
 }
 
 #[derive(Debug)]
@@ -544,6 +547,7 @@ macro_rules! from_ctx {
     };
     ($ctx:expr, with accounts) => {{
         let accounts = &$ctx.accounts;
+        let remaining_accounts = &$ctx.remaining_accounts;
         let accounts = TransferAccounts {
             sender: Some(accounts.sender.as_ref().to_account_info()),
             receiver: accounts
@@ -574,6 +578,7 @@ macro_rules! from_ctx {
                 .fee_collector
                 .as_deref()
                 .map(ToAccountInfo::to_account_info),
+            remaining_accounts: remaining_accounts.to_vec()
         };
         $crate::storage::from_ctx!($ctx, accounts = accounts)
     }};

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -389,7 +389,6 @@ impl From<FtPacketData> for FungibleTokenPacketData {
     }
 }
 
-
 /// Calls bridge escrow after receiving packet if necessary.
 ///
 /// If the packet is for a [`HOOK_TOKEN_ADDRESS`] token, parses the transfer
@@ -431,9 +430,13 @@ fn call_bridge_escrow(
     const INSTRUCTION_DISCRIMINANT: [u8; 8] =
         [149, 112, 68, 208, 4, 206, 248, 125];
 
+    // Serialize the intent id and memo with borsh since the destination contract
+    // is written with anchor and expects the data to be in borsh encoded.
     let instruction_data =
-        [&INSTRUCTION_DISCRIMINANT[..], intent_id.as_bytes(), memo.as_bytes()]
-            .concat();
+        [&INSTRUCTION_DISCRIMINANT[..],
+        &intent_id.try_to_vec().unwrap(),
+        &memo.try_to_vec().unwrap()]
+        .concat();
 
     let account_metas = accounts
         .iter()
@@ -457,7 +460,6 @@ fn call_bridge_escrow(
     msg!("Hook: Bridge escrow call successful");
     Ok(())
 }
-
 
 /// Parses memo of a transaction directed at the bridge escrow.
 ///
@@ -503,4 +505,14 @@ fn test_parse_bridge_memo() {
     ] {
         assert!(parse_bridge_memo(data).is_none(), "memo: {data}");
     }
+}
+
+#[test]
+fn test_memo() {
+    let memo = "8,WdFwv2TiGksf6x5CCwC6Svrz6JYzgCw4P1MC4Kcn3UE,7BgBvyjrZX1YKz4oh9mjb8ZScatkkwb8DzFx7LoiVkM3,XSUoLRkKahnVkrVteuJuLcPuhn2uPecFHM3zCcgsAQs,8q4qp8hMSfUZZcetiJrW7jD9n4pWmSA8ua19CcdT6p3H,Sysvar1nstructions1111111111111111111111111,TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA,H77KMAJhXEq82LmCNckaUHmXXU1RTUh5FePLVD9UAHUh,FFFhqkq4DKhdeGeLqsi72u7g8GqdgQyrqu4mdRo9kKDt,100000,false,0x0362110922F923B57b7EfF68eE7A51827b2dF4b4,0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,0xd41fb9e1dA5255dD994b029bC3C7e06ea8105BF3,1000000";
+    let (intent_id, memo) = parse_bridge_memo(memo).unwrap();
+    println!("intent_id: {intent_id}");
+    println!("memo: {memo}");
+    let parts: Vec<&str> = memo.split(',').collect();
+    println!("parts: {:?}", parts.len());
 }

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -415,8 +415,10 @@ fn call_bridge_escrow(
     // The memo is a string and the structure is as follow:
     // "<accounts count>,<AccountKey1> ..... <AccountKeyN>,<intent_id>,<memo>"
     //
-    // The relayer would parse the memo and pass the relevant accounts The
-    // intent_id and memo needs to be stripped
+    // The relayer would parse the memo and pass the relevant accounts.
+    //
+    // The intent_id and memo needs to be stripped so that it can be sent to the
+    // bridge escrow contract.
     let (intent_id, memo) =
         parse_bridge_memo(data.memo.as_ref()).ok_or_else(|| {
             let err = ibc::TokenTransferError::Other("Invalid memo".into());
@@ -425,7 +427,7 @@ fn call_bridge_escrow(
 
     // This is the 8 byte discriminant since the program is written in
     // anchor. it is hash of "<namespace>:<function_name>" which is
-    // "global:on_receive_transfer" respectively.
+    // "global:on_receive_transfer" in our case.
     const INSTRUCTION_DISCRIMINANT: [u8; 8] =
         [149, 112, 68, 208, 4, 206, 248, 125];
 

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -418,7 +418,7 @@ fn call_bridge_escrow(
     // The relayer would parse the memo and pass the relevant accounts The
     // intent_id and memo needs to be stripped
     let (intent_id, memo) =
-        parse_bridge_memo(&data.memo.as_ref()).ok_or_else(|| {
+        parse_bridge_memo(data.memo.as_ref()).ok_or_else(|| {
             let err = ibc::TokenTransferError::Other("Invalid memo".into());
             ibc::AcknowledgementStatus::error(err.into())
         })?;

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -175,8 +175,7 @@ impl ibc::Module for IbcStorage<'_, '_> {
                     return Err(ibc::AcknowledgementStatus::error(
                         ibc::TokenTransferError::PacketDataDeserialization
                             .into(),
-                    )
-                    .into());
+                    ));
                 }
             };
             // The hook would only be called if the transferred token is the one we are interested in
@@ -187,35 +186,33 @@ impl ibc::Module for IbcStorage<'_, '_> {
                 // The relayer would parse the memo and pass the relevant accounts
                 // The intent_id and memo needs to be stripped
                 let memo = data.memo.as_ref();
-                let (accounts_size, rest) = memo.split_once(",").ok_or(
+                let (accounts_size, rest) = memo.split_once(',').ok_or(
                     ibc::AcknowledgementStatus::error(
                         ibc::TokenTransferError::Other(
                             "Invalid memo".to_string(),
                         )
                         .into(),
-                    )
-                    .into(),
+                    ),
                 )?;
                 // This is the 8 byte discriminant since the program is written in
                 // anchor. it is hash of "<namespace>:<function_name>" which is
                 // "global:on_receive_transfer" respectively.
                 let instruction_discriminant: Vec<u8> =
                     vec![149, 112, 68, 208, 4, 206, 248, 125];
-                let values = rest.split(",").collect::<Vec<&str>>();
+                let values = rest.split(',').collect::<Vec<&str>>();
                 let (_passed_accounts, ix_data) =
                     values.split_at(accounts_size.parse::<usize>().unwrap());
-                let intent_id = ix_data.get(0).ok_or(
+                let intent_id = ix_data.first().ok_or(
                     ibc::AcknowledgementStatus::error(
                         ibc::TokenTransferError::Other(
                             "Invalid memo".to_string(),
                         )
                         .into(),
-                    )
-                    .into(),
+                    ),
                 )?;
                 let memo = ix_data[1..].join(",");
                 let mut instruction_data = instruction_discriminant;
-                instruction_data.extend_from_slice(&intent_id.as_bytes());
+                instruction_data.extend_from_slice(intent_id.as_bytes());
                 instruction_data.extend_from_slice(memo.as_bytes());
 
                 let bridge_escrow_program_id =
@@ -236,9 +233,9 @@ impl ibc::Module for IbcStorage<'_, '_> {
                 );
 
                 invoke(&instruction, accounts).map_err(|err| {
-                    return ibc::AcknowledgementStatus::error(
+                    ibc::AcknowledgementStatus::error(
                         ibc::TokenTransferError::Other(err.to_string()).into(),
-                    );
+                    )
                 })?;
                 msg!("Hook: Bridge escrow call successful");
             }

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -149,12 +149,12 @@ impl ibc::Module for IbcStorage<'_, '_> {
                 self,
                 &maybe_ft_packet,
             );
-        let cloned_ack = ack.clone();
-        let ack_status = str::from_utf8(cloned_ack.as_bytes())
+        let ack_status = str::from_utf8(ack.as_bytes())
             .expect("Invalid acknowledgement string");
-        let status = serde_json::from_slice::<ibc::AcknowledgementStatus>(
-            ack.as_bytes(),
-        );
+        msg!("ibc::Packet acknowledgement: {}", ack_status);
+
+        let status =
+            serde_json::from_str::<ibc::AcknowledgementStatus>(ack_status);
         let success = if let Ok(status) = status {
             status.is_successful()
         } else {
@@ -247,7 +247,7 @@ impl ibc::Module for IbcStorage<'_, '_> {
                 ack = status.into();
             }
         }
-        msg!("ibc::Packet acknowledgement: {}", ack_status);
+
         (extras, ack)
     }
 

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -432,11 +432,12 @@ fn call_bridge_escrow(
 
     // Serialize the intent id and memo with borsh since the destination contract
     // is written with anchor and expects the data to be in borsh encoded.
-    let instruction_data =
-        [&INSTRUCTION_DISCRIMINANT[..],
+    let instruction_data = [
+        &INSTRUCTION_DISCRIMINANT[..],
         &intent_id.try_to_vec().unwrap(),
-        &memo.try_to_vec().unwrap()]
-        .concat();
+        &memo.try_to_vec().unwrap(),
+    ]
+    .concat();
 
     let account_metas = accounts
         .iter()
@@ -509,7 +510,17 @@ fn test_parse_bridge_memo() {
 
 #[test]
 fn test_memo() {
-    let memo = "8,WdFwv2TiGksf6x5CCwC6Svrz6JYzgCw4P1MC4Kcn3UE,7BgBvyjrZX1YKz4oh9mjb8ZScatkkwb8DzFx7LoiVkM3,XSUoLRkKahnVkrVteuJuLcPuhn2uPecFHM3zCcgsAQs,8q4qp8hMSfUZZcetiJrW7jD9n4pWmSA8ua19CcdT6p3H,Sysvar1nstructions1111111111111111111111111,TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA,H77KMAJhXEq82LmCNckaUHmXXU1RTUh5FePLVD9UAHUh,FFFhqkq4DKhdeGeLqsi72u7g8GqdgQyrqu4mdRo9kKDt,100000,false,0x0362110922F923B57b7EfF68eE7A51827b2dF4b4,0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,0xd41fb9e1dA5255dD994b029bC3C7e06ea8105BF3,1000000";
+    let memo = "8,WdFwv2TiGksf6x5CCwC6Svrz6JYzgCw4P1MC4Kcn3UE,\
+                7BgBvyjrZX1YKz4oh9mjb8ZScatkkwb8DzFx7LoiVkM3,\
+                XSUoLRkKahnVkrVteuJuLcPuhn2uPecFHM3zCcgsAQs,\
+                8q4qp8hMSfUZZcetiJrW7jD9n4pWmSA8ua19CcdT6p3H,\
+                Sysvar1nstructions1111111111111111111111111,\
+                TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA,\
+                H77KMAJhXEq82LmCNckaUHmXXU1RTUh5FePLVD9UAHUh,\
+                FFFhqkq4DKhdeGeLqsi72u7g8GqdgQyrqu4mdRo9kKDt,100000,false,\
+                0x0362110922F923B57b7EfF68eE7A51827b2dF4b4,\
+                0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,\
+                0xd41fb9e1dA5255dD994b029bC3C7e06ea8105BF3,1000000";
     let (intent_id, memo) = parse_bridge_memo(memo).unwrap();
     println!("intent_id: {intent_id}");
     println!("memo: {memo}");

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -1,5 +1,5 @@
 use std::result::Result;
-use std::str::{self, FromStr};
+use std::str;
 
 use anchor_lang::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -215,9 +215,6 @@ impl ibc::Module for IbcStorage<'_, '_> {
                 instruction_data.extend_from_slice(intent_id.as_bytes());
                 instruction_data.extend_from_slice(memo.as_bytes());
 
-                let bridge_escrow_program_id =
-                    Pubkey::from_str(BRIDGE_ESCROW_PROGRAM_ID).unwrap();
-
                 let account_metas = accounts
                     .iter()
                     .map(|account| AccountMeta {
@@ -227,7 +224,7 @@ impl ibc::Module for IbcStorage<'_, '_> {
                     })
                     .collect::<Vec<AccountMeta>>();
                 let instruction = Instruction::new_with_bytes(
-                    bridge_escrow_program_id,
+                    BRIDGE_ESCROW_PROGRAM_ID,
                     &instruction_data,
                     account_metas,
                 );

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -197,8 +197,8 @@ impl ibc::Module for IbcStorage<'_, '_> {
             // This is the 8 byte discriminant since the program is written in
             // anchor. it is hash of "<namespace>:<function_name>" which is
             // "global:on_receive_transfer" respectively.
-            let instruction_discriminant: Vec<u8> =
-                vec![149, 112, 68, 208, 4, 206, 248, 125];
+            const INSTRUCTION_DISCRIMINANT: [u8; 8] =
+                [149, 112, 68, 208, 4, 206, 248, 125];
             let values = rest.split(',').collect::<Vec<&str>>();
             let (_passed_accounts, ix_data) =
                 values.split_at(accounts_size.parse::<usize>().unwrap());
@@ -208,9 +208,12 @@ impl ibc::Module for IbcStorage<'_, '_> {
                         .into(),
                 ))?;
             let memo = ix_data[1..].join(",");
-            let mut instruction_data = instruction_discriminant;
-            instruction_data.extend_from_slice(intent_id.as_bytes());
-            instruction_data.extend_from_slice(memo.as_bytes());
+            let instruction_data = [
+                &INSTRUCTION_DISCRIMINANT[..],
+                intent_id.as_bytes(),
+                memo.as_bytes(),
+            ]
+            .concat();
 
             let account_metas = accounts
                 .iter()


### PR DESCRIPTION
A message is sent through IBC to unlock the funds of the solver. To achieve this, the solana-ibc program needs to forward the memo to the `bridge-escrow` program so that it can release the funds to the solver. Since anybody can send memo, we execute the hook only if the transferred token is the token owned by the `bridge-escrow` on the counterparty chain (ethereum). This allows us to verify that the message to unlock the funds originated from the right contract and it is not spoofed.