### PR TITLE
hooks: fix hook structure by deserializing json instead of string

### DIFF
--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -477,7 +477,7 @@ fn call_bridge_escrow(
 /// validation on accounts is performed.
 fn parse_bridge_memo(memo: &str) -> Option<(String, String)> {
     let parsed = serde_json::from_str::<serde_json::Value>(memo).ok()?;
-    let memo_str = parsed.get("memo")?.as_str()?.to_string();
+    let memo_str = parsed.get("memo")?.as_str()?;
     let (count, rest) = memo_str.split_once(',')?;
     let mut current = rest;
     // Skip accounts


### PR DESCRIPTION
Since PFM only support passing of the memo for the next transfer as json, strings can be passed. So we have to deserialize the memo with json and get the string from it. Also log the acknowledgement after the hooks is performed since the ack can change based on the result of hooks.