### PR TITLE
ibc-hook: Add validation for hooks

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -112,9 +112,11 @@ jobs:
 
       - name: Install Anchor
         if: steps.cache-anchor.outputs.cache-hit != 'true'
+        # Since the latest avm version doesnt compile with the current rust version, we use the 
+        # old avm version.
         run: |
           set -eux
-          cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
+          cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.0 avm --locked --force
           avm install $ANCHOR_VERSION
           avm use $ANCHOR_VERSION
 

--- a/solana/solana-ibc/programs/solana-ibc/src/lib.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/lib.rs
@@ -37,8 +37,7 @@ pub const MINIMUM_FEE_ACCOUNT_BALANCE: u64 =
 
 pub const BRIDGE_ESCROW_PROGRAM_ID: Pubkey =
     solana_program::pubkey!("AhfoGVmS19tvkEG2hBuZJ1D6qYEjyFmXZ1qPoFD6H4Mj");
-pub const HOOK_TOKEN_ADDRESS: &str =
-    "0x36dd1bfe89d409f869fabbe72c3cf72ea8b460f6";
+
 
 declare_id!("2HLLVco5HvwWriNbUhmVwA2pCetRkpgrqwnjcsZdyTKT");
 

--- a/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
+++ b/solana/solana-ibc/programs/solana-ibc/src/transfer/mod.rs
@@ -9,7 +9,7 @@ use spl_token::solana_program::program::invoke;
 use crate::ibc::apps::transfer::types::packet::PacketData;
 use crate::ibc::apps::transfer::types::proto::transfer::v2::FungibleTokenPacketData;
 use crate::storage::IbcStorage;
-use crate::{ibc, BRIDGE_ESCROW_PROGRAM_ID, HOOK_TOKEN_ADDRESS};
+use crate::{ibc, BRIDGE_ESCROW_PROGRAM_ID};
 
 pub(crate) mod impls;
 
@@ -413,7 +413,7 @@ fn call_bridge_escrow(
 
     // The hook would only be called if the transferred token is the one we are
     // interested in
-    if data.token.denom.base_denom.as_str() != HOOK_TOKEN_ADDRESS {
+    if !check_denom_is_hook_address(data.token.denom.base_denom.as_str()) {
         return Ok(());
     }
 
@@ -489,6 +489,21 @@ fn parse_bridge_memo(memo: &str) -> Option<(String, String)> {
     Some((intent.to_string(), memo.to_string()))
 }
 
+/// Checks whether the base denom matches the expected hook address.
+///
+/// The hooks are only performed if the base denom matches any of the
+/// whitelisted hook address.
+fn check_denom_is_hook_address(base_denom: &str) -> bool {
+    // solana_program::pubkey! doesn’t work so we’re using hex instead.  See
+    // https://github.com/coral-xyz/anchor/pull/3021 for more context.
+    // TODO(mina86): Use pubkey macro once we upgrade to anchor lang with it.
+    let expected_hook_addresses = [
+        "0x36dd1bfe89d409f869fabbe72c3cf72ea8b460f6",
+        "3zT4Uzktt7Hyx6qitv2Fa1eqYyFtc3v7h3F9EHgDmVDR",
+    ];
+    expected_hook_addresses.contains(&base_denom)
+}
+
 #[test]
 fn test_parse_bridge_memo() {
     for (intent, memo, data) in [
@@ -544,4 +559,14 @@ fn test_memo() {
     println!("memo: {memo}");
     let parts: Vec<&str> = memo.split(',').collect();
     println!("parts: {:?}", parts.len());
+}
+
+#[test]
+fn test_denom_is_hook_address() {
+    const GOOD_ONE: &str = "0x36dd1bfe89d409f869fabbe72c3cf72ea8b460f6";
+    const GOOD_TWO: &str = "3zT4Uzktt7Hyx6qitv2Fa1eqYyFtc3v7h3F9EHgDmVDR";
+    const BAD: &str = "0x36dd1bfe89d409";
+    assert_eq!(check_denom_is_hook_address(&GOOD_ONE), true);
+    assert_eq!(check_denom_is_hook_address(&GOOD_TWO), true);
+    assert_eq!(check_denom_is_hook_address(&BAD), false);
 }


### PR DESCRIPTION
Check if the accounts passing to the program through the hook is initialized. If any of them is not initialized, then the hook program would not be called and a failed acknowledgement would be sent back.