### PR TITLE
update the revision of ibc-rs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -112,9 +112,11 @@ jobs:
 
       - name: Install Anchor
         if: steps.cache-anchor.outputs.cache-hit != 'true'
+        # Since the latest avm version doesnt compile with the current rust version, we use the 
+        # old avm version.
         run: |
           set -eux
-          cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
+          cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.0 avm --locked --force
           avm install $ANCHOR_VERSION
           avm use $ANCHOR_VERSION
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "base64 0.21.7",
  "borsh 0.10.4",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2750,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "displaydoc",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2792,7 +2792,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2808,7 +2808,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-client-tendermint-types",
  "ibc-core-client-context",
@@ -2860,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -2948,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "ibc-client-tendermint-types",
  "ibc-core-channel",
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -3030,7 +3030,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -3045,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3088,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "borsh 0.10.4",
  "derive_more",
@@ -3127,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.50.0"
-source = "git+https://github.com/mina86/ibc-rs?rev=e1be8c9292c82c1e7c158067f0014fb292ee652d#e1be8c9292c82c1e7c158067f0014fb292ee652d"
+source = "git+https://github.com/mina86/ibc-rs?rev=87ebc7d20c3ed955d2c70c0845c88dcb3b574a80#87ebc7d20c3ed955d2c70c0845c88dcb3b574a80"
 dependencies = [
  "derive_more",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,17 +56,17 @@ hex-literal = "0.4.1"
 rayon = "1.10.0"
 
 # Use unreleased ibc-rs which supports custom verifier.
-ibc                         = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false, features = ["borsh", "serde"] }
-ibc-client-tendermint-types = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-core-channel-types      = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-core-client-context     = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-core-client-types       = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-core-commitment-types   = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-core-connection-types   = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-core-host               = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-core-host-types         = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-primitives              = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
-ibc-testkit                 = { git = "https://github.com/mina86/ibc-rs", rev = "e1be8c9292c82c1e7c158067f0014fb292ee652d", default-features = false }
+ibc                         = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false, features = ["borsh", "serde"] }
+ibc-client-tendermint-types = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-core-channel-types      = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-core-client-context     = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-core-client-types       = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-core-commitment-types   = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-core-connection-types   = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-core-host               = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-core-host-types         = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-primitives              = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
+ibc-testkit                 = { git = "https://github.com/mina86/ibc-rs", rev = "87ebc7d20c3ed955d2c70c0845c88dcb3b574a80", default-features = false }
 
 ibc-proto = { version = "0.41.0", default-features = false }
 insta = { version = "1.34.0" }


### PR DESCRIPTION
Update the revision of ibc-rs so that the client cannot be expired since there is no way of reviving the client in ibc-rs version of 0.50.0. Once the ibc-rs is updated to the latest version, this wont be required.

rev: https://github.com/mina86/ibc-rs/commit/87ebc7d20c3ed955d2c70c0845c88dcb3b574a80